### PR TITLE
Add minimum supported python version is 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     description='Python scripts to convert MISP into STIX or STIX into MISP',
     long_description=long_description,
     long_description_content_type='text/markdown',
+    python_requires='>=3.6',
     packages=['misp_stix_converter'],
     classifiers=[
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
See `python_requires` on https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires 