### PR TITLE
Exporting MISP confidence tags

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -116,10 +116,6 @@ class MISPtoSTIX1Parser(MISPtoSTIXParser):
     def _handle_attribute_indicator(self, attribute: dict, observable: Observable) -> Indicator:
         indicator = self._create_indicator_from_attribute(attribute)
         indicator.add_observable(observable)
-        related_indicator = RelatedIndicator(
-            indicator,
-            relationship=attribute['category']
-        )
         return indicator
 
     def _handle_attribute_tags_and_galaxies(self, attribute: dict, indicator: Indicator) -> tuple:

--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -1050,10 +1050,11 @@ class MISPtoSTIX1Parser(MISPtoSTIXParser):
             tlp_marking = TLPMarkingStructure()
             tlp_marking.color = self._set_color(self._fetch_colors(sorted_tags['tlp_tags']))
             marking_specification.marking_structures.append(tlp_marking)
-        for tag in sorted_tags['simple_tags']:
-            simple_marking = SimpleMarkingStructure()
-            simple_marking.statement = tag
-            marking_specification.marking_structures.append(simple_marking)
+        if 'simple_tags' in sorted_tags:
+            for tag in sorted_tags['simple_tags']:
+                simple_marking = SimpleMarkingStructure()
+                simple_marking.statement = tag
+                marking_specification.marking_structures.append(simple_marking)
         handling.add_marking(marking_specification)
         return handling
 

--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -239,7 +239,7 @@ class MISPtoSTIX1Parser(MISPtoSTIXParser):
                 sorted_tags[feature].append(tag)
             if confidence_tags:
                 campaign.confidence = Confidence(
-                    value = confidence_tags.pop(min(confidence_tags))['confidence'],
+                    value = confidence_tags[min(confidence_tags)]['confidence'],
                     timestamp = timestamp
                 )
                 for confidence_tag in confidence_tags.values():

--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -6,7 +6,6 @@ import os
 import re
 from .exportparser import MISPtoSTIXParser
 from collections import defaultdict
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from stix2.properties import ListProperty, StringProperty
@@ -288,27 +287,6 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser):
 
     def _get_object_ids(self, name: str, object_type: str) -> Generator[None, None, str]:
         return (stix_object['id'] for stix_object in self._galaxies_catalog[name][object_type])
-
-    def _handle_markings(self, object_args: dict, markings: tuple):
-        marking_ids = []
-        for marking in markings:
-            if marking in self._markings:
-                marking_ids.append(self._markings[marking]['marking'].id)
-                continue
-            if self._is_tlp_tag(marking):
-                marking_definition = deepcopy(self._mapping.tlp_markings[marking])
-                marking_id = marking_definition.id
-                if marking_id not in self.unique_ids:
-                    self._markings[marking] = {
-                        'marking': marking_definition,
-                        'used': False
-                    }
-                    self.__ids[marking_id] = marking_id
-                marking_ids.append(marking_id)
-                continue
-            object_args['labels'].append(marking)
-        if marking_ids:
-            object_args['object_marking_refs'] = marking_ids
 
     def _handle_relationships(self):
         for relationship in self.__relationships:

--- a/misp_stix_converter/misp2stix/misp_to_stix20.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix20.py
@@ -4,6 +4,7 @@
 from .misp_to_stix2 import MISPtoSTIX2Parser
 from .stix20_mapping import Stix20Mapping
 from collections import defaultdict
+from copy import deepcopy
 from datetime import datetime
 from stix2.properties import (DictionaryProperty, IDProperty, ListProperty,
                               ReferenceProperty, StringProperty, TimestampProperty)
@@ -121,6 +122,27 @@ class MISPtoSTIX20Parser(MISPtoSTIX2Parser):
             'interoperability': True
         }
         self._append_SDO(CustomNote(**custom_args))
+
+    def _handle_markings(self, object_args: dict, markings: tuple):
+        marking_ids = []
+        for marking in markings:
+            if marking in self._markings:
+                marking_ids.append(self._markings[marking]['marking'].id)
+                continue
+            if self._is_tlp_tag(marking):
+                marking_definition = deepcopy(self._mapping.tlp_markings[marking])
+                marking_id = marking_definition.id
+                if marking_id not in self.unique_ids:
+                    self._markings[marking] = {
+                        'marking': marking_definition,
+                        'used': False
+                    }
+                    self.__ids[marking_id] = marking_id
+                marking_ids.append(marking_id)
+                continue
+            object_args['labels'].append(marking)
+        if marking_ids:
+            object_args['object_marking_refs'] = marking_ids
 
     def _handle_opinion_object(self, sighting: dict, reference_id: str):
         opinion_args = {

--- a/misp_stix_converter/misp2stix/misp_to_stix20.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix20.py
@@ -137,7 +137,7 @@ class MISPtoSTIX20Parser(MISPtoSTIX2Parser):
                         'marking': marking_definition,
                         'used': False
                     }
-                    self.__ids[marking_id] = marking_id
+                    self.unique_ids[marking_id] = marking_id
                 marking_ids.append(marking_id)
                 continue
             object_args['labels'].append(marking)

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -140,9 +140,10 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
 
     def _handle_markings(self, object_args: dict, markings: tuple):
         marking_ids = []
+        confidence_tags = {}
         for marking in markings:
             if marking in self._mapping.confidence_tags:
-                object_args['confidence'] = self._mapping.confidence_tags[marking]
+                confidence_tags[self._mapping.confidence_tags[marking]] = marking
                 continue
             if marking in self._markings:
                 marking_ids.append(self._markings[marking]['marking'].id)
@@ -159,6 +160,9 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
                 marking_ids.append(marking_id)
                 continue
             object_args['labels'].append(marking)
+        if confidence_tags:
+            object_args['confidence'] = min(confidence_tags)
+            object_args['labels'].extend(confidence_tags.values())
         if marking_ids:
             object_args['object_marking_refs'] = marking_ids
 

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -155,7 +155,7 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
                         'marking': marking_definition,
                         'used': False
                     }
-                    self.__ids[marking_id] = marking_id
+                    self.unique_ids[marking_id] = marking_id
                 marking_ids.append(marking_id)
                 continue
             object_args['labels'].append(marking)

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -140,11 +140,8 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
 
     def _handle_markings(self, object_args: dict, markings: tuple):
         marking_ids = []
-        confidence_tags = {}
+        confidence_score = []
         for marking in markings:
-            if marking in self._mapping.confidence_tags:
-                confidence_tags[self._mapping.confidence_tags[marking]] = marking
-                continue
             if marking in self._markings:
                 marking_ids.append(self._markings[marking]['marking'].id)
                 continue
@@ -159,10 +156,11 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
                     self.unique_ids[marking_id] = marking_id
                 marking_ids.append(marking_id)
                 continue
+            if marking in self._mapping.confidence_tags:
+                confidence_score.append(self._mapping.confidence_tags[marking])
             object_args['labels'].append(marking)
-        if confidence_tags:
-            object_args['confidence'] = min(confidence_tags)
-            object_args['labels'].extend(confidence_tags.values())
+        if confidence_score:
+            object_args['confidence'] = min(confidence_score)
         if marking_ids:
             object_args['object_marking_refs'] = marking_ids
 

--- a/misp_stix_converter/misp2stix/stix1_mapping.py
+++ b/misp_stix_converter/misp2stix/stix1_mapping.py
@@ -115,6 +115,32 @@ SCHEMALOC_DICT = Mapping(
 
 class Stix1Mapping:
     def __init__(self):
+        self.__confidence_mapping = {
+            'misp:confidence-level="completely-confident"': {
+                'score': 100,
+                'stix_value': 'High'
+            },
+            'misp:confidence-level="usually-confident"': {
+                'score': 75,
+                'stix_value': 'High'
+            },
+            'misp:confidence-level="fairly-confident"': {
+                'score': 50,
+                'stix_value': 'Medium'
+            },
+            'misp:confidence-level="rarely-confident"': {
+                'score': 25,
+                'stix_value': 'Low'
+            },
+            'misp:confidence-level="unconfident"': {
+                'score': 0,
+                'stix_value': 'None'
+            },
+            'misp:confidence-level="confidence-cannot-be-evaluated"': {
+                'score': 200,
+                'stix_value': 'Unknown'
+            }
+        }
         self.__confidence_description = "Derived from MISP's IDS flag. If an attribute is marked for IDS exports, the confidence will be high, otherwise none"
         self.__confidence_value = "High"
         _hash_type_attributes = {
@@ -749,6 +775,10 @@ class Stix1Mapping:
     @property
     def attribute_types_mapping(self) -> dict:
         return self.__attribute_types_mapping
+
+    @property
+    def confidence_mapping(self) -> dict:
+        return self.__confidence_mapping
 
     @property
     def confidence_description(self) -> str:

--- a/misp_stix_converter/misp2stix/stix21_mapping.py
+++ b/misp_stix_converter/misp2stix/stix21_mapping.py
@@ -23,6 +23,13 @@ class Stix21Mapping(Stix2Mapping):
             )
         )
         self._declare_attributes_mapping(updates=v21_specific_attributes)
+        self.__confidence_tags = {
+            'misp:confidence-level="completely-confident"': 100,
+            'misp:confidence-level="usually-confident"': 75,
+            'misp:confidence-level="fairly-confident"': 50,
+            'misp:confidence-level="rarely-confident"': 25,
+            'misp:confidence-level="unconfident"': 0
+        }
         artifact_values = {
             "mime_type": "application/zip",
             "encryption_algorithm": "mime-type-indicated",
@@ -251,6 +258,10 @@ class Stix21Mapping(Stix2Mapping):
     @property
     def annotation_single_fields(self) -> tuple:
         return self.__annotation_single_fields
+
+    @property
+    def confidence_tags(self) -> dict:
+        return self.__confidence_tags
 
     @property
     def credential_object_mapping(self) -> dict:

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,7 +8,7 @@ python-versions = "*"
 
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "dev"
 optional = false
@@ -123,7 +123,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "importlib-resources"
-version = "5.8.0"
+version = "5.9.0"
 description = "Read resources from Python packages"
 category = "main"
 optional = false
@@ -133,8 +133,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -146,7 +146,7 @@ python-versions = "*"
 
 [[package]]
 name = "jsonschema"
-version = "4.6.2"
+version = "4.7.2"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -469,11 +469,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
@@ -498,15 +498,15 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "zipp"
-version = "3.8.0"
+version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
@@ -518,8 +518,7 @@ antlr4-python3-runtime = [
     {file = "antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b"},
 ]
 atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
@@ -558,16 +557,16 @@ importlib-metadata = [
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
-    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
+    {file = "importlib_resources-5.9.0-py3-none-any.whl", hash = "sha256:f78a8df21a79bcc30cfd400bdc38f314333de7c0fb619763f6b9dabab8268bb7"},
+    {file = "importlib_resources-5.9.0.tar.gz", hash = "sha256:5481e97fb45af8dcf2f798952625591c58fe599d0735d86b10f54de086a61681"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.6.2-py3-none-any.whl", hash = "sha256:e331e32e29743014fa59fa77895b5d8669382a4904c8ef23144f7f078ec031c7"},
-    {file = "jsonschema-4.6.2.tar.gz", hash = "sha256:b19f62322b0f06927e8ae6215c01654e1885857cdcaf58ae1772b1aa97f1faf2"},
+    {file = "jsonschema-4.7.2-py3-none-any.whl", hash = "sha256:c7448a421b25e424fccfceea86b4e3a8672b4436e1988ccbde92c80828d4f085"},
+    {file = "jsonschema-4.7.2.tar.gz", hash = "sha256:73764f461d61eb97a057c929368610a134d1d1fffd858acfe88864ee94f1f1d3"},
 ]
 lxml = [
     {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
@@ -809,8 +808,8 @@ typing-extensions = [
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
+    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
 ]
 weakrefmethod = [
     {file = "weakrefmethod-1.0.3.tar.gz", hash = "sha256:37bc1fbb5575acf82172d4eb7b6fc4412d77d5a1d70dff2c1f8a4574301cda66"},
@@ -882,6 +881,6 @@ wrapt = [
     {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
 ]
 zipp = [
-    {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},
-    {file = "zipp-3.8.0.tar.gz", hash = "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad"},
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
 ]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2704,6 +2704,42 @@ _TEST_X509_OBJECT = {
     ]
 }
 
+_CAMPAIGN_NAME_ATTRIBUTE = {
+    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+    "type": "campaign-name",
+    "category": "Attribution",
+    "value": "MartyMcFly",
+    "timestamp": "1603642920",
+    "to_ids": False
+}
+
+_INDICATOR_ATTRIBUTE = {
+    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+    "type": "domain",
+    "category": "Network activity",
+    "value": "circl.lu",
+    "timestamp": "1603642920",
+    "comment": "Domain test attribute",
+    "to_ids": True
+}
+
+_NON_INDICATOR_ATTRIBUTE = {
+    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+    "type": "vulnerability",
+    "category": "External analysis",
+    "value": "CVE-2017-11774",
+    "timestamp": "1603642920",
+    "comment": "Vulnerability test attribute"
+}
+
+_OBSERVABLE_ATTRIBUTE = {
+    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+    "type": "AS",
+    "category": "Network activity",
+    "timestamp": "1603642920",
+    "value": "AS174"
+}
+
 ################################################################################
 #                               BASE EVENT TESTS                               #
 ################################################################################
@@ -2712,13 +2748,24 @@ def get_base_event():
     return deepcopy(_BASE_EVENT)
 
 
-def get_published_event():
-    base_event = deepcopy(_BASE_EVENT)
-    base_event['Event']['date'] = '2020-10-25'
-    base_event['Event']['timestamp'] = '1603642920'
-    base_event['Event']['published'] = True
-    base_event['Event']['publish_timestamp'] = "1603642920"
-    return base_event
+def get_event_with_attribute_confidence_tags():
+    tags = [
+        {'name': 'tlp:white'},
+        {"name": 'misp:confidence-level="completely-confident"'},
+        {"name": 'misp:confidence-level="fairly-confident"'}
+    ]
+    event = deepcopy(_BASE_EVENT)
+    event['Event']['Tag'] = deepcopy(tags)
+    attributes = [
+        deepcopy(_INDICATOR_ATTRIBUTE),
+        deepcopy(_CAMPAIGN_NAME_ATTRIBUTE),
+        deepcopy(_NON_INDICATOR_ATTRIBUTE),
+        deepcopy(_OBSERVABLE_ATTRIBUTE)
+    ]
+    for attribute in attributes:
+        attribute['Tag'] = deepcopy(tags)
+    event['Event']['Attribute'] = attributes
+    return event
 
 
 def get_event_with_escaped_values_v20():
@@ -2745,6 +2792,28 @@ def get_event_with_escaped_values_v21():
     return event
 
 
+def get_event_with_object_confidence_tags():
+    tags = [
+        {'name': 'tlp:white'},
+        {'name': 'misp:confidence-level="confidence-cannot-be-evaluated"'},
+        {'name': 'misp:confidence-level="usually-confident"'}
+    ]
+    event = deepcopy(_BASE_EVENT)
+    event['Event']['Tag'] = deepcopy(tags)
+    ip_port_object = deepcopy(_TEST_IP_PORT_OBJECT)
+    ip_port_object['Attribute'][0]['to_ids'] = True
+    misp_objects = [
+        ip_port_object,
+        deepcopy(_TEST_COURSE_OF_ACTION_OBJECT),
+        deepcopy(_TEST_ASN_OBJECT)
+    ]
+    for misp_object in misp_objects:
+        for attribute, tag in zip(misp_object['Attribute'][:3], tags):
+            attribute['Tag'] = [tag]
+    event['Event']['Object'] = misp_objects
+    return event
+
+
 def get_event_with_tags():
     event = deepcopy(_BASE_EVENT)
     event['Event']['Tag'] = [
@@ -2757,6 +2826,15 @@ def get_event_with_tags():
         deepcopy(_TEST_ATTACK_PATTERN_GALAXY)
     ]
     return event
+
+
+def get_published_event():
+    base_event = deepcopy(_BASE_EVENT)
+    base_event['Event']['date'] = '2020-10-25'
+    base_event['Event']['timestamp'] = '1603642920'
+    base_event['Event']['published'] = True
+    base_event['Event']['publish_timestamp'] = "1603642920"
+    return base_event
 
 
 ################################################################################
@@ -2904,33 +2982,6 @@ _IBAN_ATTRIBUTE = {
     "to_ids": True
 }
 
-_INDICATOR_ATTRIBUTE = {
-    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
-    "type": "domain",
-    "category": "Network activity",
-    "value": "circl.lu",
-    "timestamp": "1603642920",
-    "comment": "Domain test attribute",
-    "to_ids": True
-}
-
-_NON_INDICATOR_ATTRIBUTE = {
-    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
-    "type": "vulnerability",
-    "category": "External analysis",
-    "value": "CVE-2017-11774",
-    "timestamp": "1603642920",
-    "comment": "Vulnerability test attribute"
-}
-
-_OBSERVABLE_ATTRIBUTE = {
-    "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
-    "type": "AS",
-    "category": "Network activity",
-    "timestamp": "1603642920",
-    "value": "AS174"
-}
-
 _PORT_ATTRIBUTE = {
     "uuid": "1af096a0-efa1-4331-9300-a6b5eb4df2e6",
     "type": "port",
@@ -3033,14 +3084,7 @@ def get_event_with_attachment_attribute():
 def get_event_with_campaign_name_attribute():
     event = deepcopy(_BASE_EVENT)
     event['Event']['Attribute'] = [
-        {
-            "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
-            "type": "campaign-name",
-            "category": "Attribution",
-            "value": "MartyMcFly",
-            "timestamp": "1603642920",
-            "to_ids": False
-        }
+        deepcopy(_CAMPAIGN_NAME_ATTRIBUTE)
     ]
     return event
 

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -56,8 +56,8 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
             self.parser._mapping.confidence_tags[misp_object['Attribute'][2]['Tag'][0]['name']]
         )
         self.assertEqual(
-            stix_object.labels[-2:],
-            [attribute['Tag'][0]['name'] for attribute in misp_object['Attribute'][1:3]]
+            set(stix_object.labels[-2:]),
+            set(attribute['Tag'][0]['name'] for attribute in misp_object['Attribute'][1:3])
         )
 
     def _check_opinion_features(self, opinion, sighting, object_id):

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -37,11 +37,28 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
     #                              UTILITY FUNCTIONS.                              #
     ################################################################################
 
+    def _check_attribute_confidence_tags(self, stix_object, attribute):
+        self.assertEqual(
+            stix_object.confidence,
+            self.parser._mapping.confidence_tags[attribute['Tag'][-1]['name']]
+        )
+        self.assertEqual(stix_object.labels[-2:], [tag['name'] for tag in attribute['Tag'][1:]])
+
     def _check_bundle_features(self, length):
         bundle = self.parser.bundle
         self.assertEqual(bundle.type, 'bundle')
         self.assertEqual(len(bundle.objects), length)
         return bundle.objects
+
+    def _check_object_confidence_tags(self, stix_object, misp_object):
+        self.assertEqual(
+            stix_object.confidence,
+            self.parser._mapping.confidence_tags[misp_object['Attribute'][2]['Tag'][0]['name']]
+        )
+        self.assertEqual(
+            stix_object.labels[-2:],
+            [attribute['Tag'][0]['name'] for attribute in misp_object['Attribute'][1:3]]
+        )
 
     def _check_opinion_features(self, opinion, sighting, object_id):
         self.assertEqual(opinion.type, 'opinion')
@@ -400,20 +417,35 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
         )
         self.assertEqual(note.object_refs, [grouping.id])
 
-    def test_published_event(self):
-        event = get_published_event()
-        orgc = event['Event']['Orgc']
+    def test_event_with_attribute_confidence_tags(self):
+        event = get_event_with_attribute_confidence_tags()
+        tlp_tag, *confidence_tags = event['Event']['Tag']
+        domain, campaign_name, vulnerability_attribute, AS = event['Event']['Attribute']
         self.parser.parse_misp_event(event)
-        stix_objects = self._check_bundle_features(3)
+        stix_objects = self._check_bundle_features(8)
         self._check_spec_versions(stix_objects)
-        identity, report, _ = stix_objects
-        timestamp = self._datetime_from_timestamp(event['Event']['timestamp'])
-        identity_id = self._check_identity_features(identity, orgc, timestamp)
-        self._check_report_features(report, event['Event'], identity_id, timestamp)
+        _, grouping, indicator, campaign, vulnerability, observed_data, _, marking = stix_objects
         self.assertEqual(
-            report.published,
-            self._datetime_from_timestamp(event['Event']['publish_timestamp'])
+            grouping.confidence,
+            self.parser._mapping.confidence_tags[confidence_tags[1]['name']]
         )
+        self.assertEqual(grouping.labels[-2:], [tag['name'] for tag in confidence_tags])
+        self._assert_multiple_equal(
+            [marking.id],
+            grouping.object_marking_refs,
+            indicator.object_marking_refs,
+            campaign.object_marking_refs,
+            vulnerability.object_marking_refs,
+            observed_data.object_marking_refs
+        )
+        self.assertEqual(
+            f'{marking.definition_type}:{marking.definition[marking.definition_type]}',
+            tlp_tag['name']
+        )
+        self._check_attribute_confidence_tags(indicator, domain)
+        self._check_attribute_confidence_tags(campaign, campaign_name)
+        self._check_attribute_confidence_tags(vulnerability, vulnerability_attribute)
+        self._check_attribute_confidence_tags(observed_data, AS)
 
     def test_event_with_escaped_characters(self):
         event = get_event_with_escaped_values_v21()
@@ -460,6 +492,34 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
         object_ids = {ip_src.id, observed_data.id, domain_ip.id}
         self.assertEqual(set(object_refs), object_ids)
 
+    def test_event_with_object_confidence_tags(self):
+        event = get_event_with_object_confidence_tags()
+        tlp_tag, *confidence_tags = event['Event']['Tag']
+        ip_port, course_of_action, asn = event['Event']['Object']
+        self.parser.parse_misp_event(event)
+        stix_objects = self._check_bundle_features(7)
+        self._check_spec_versions(stix_objects)
+        _, grouping, indicator, coa, observed_data, _, marking = stix_objects
+        self._assert_multiple_equal(
+            grouping.confidence,
+            self.parser._mapping.confidence_tags[confidence_tags[1]['name']]
+        )
+        self.assertEqual(grouping.labels[-2:], [tag['name'] for tag in confidence_tags])
+        self._assert_multiple_equal(
+            [marking.id],
+            grouping.object_marking_refs,
+            indicator.object_marking_refs,
+            coa.object_marking_refs,
+            observed_data.object_marking_refs
+        )
+        self.assertEqual(
+            f'{marking.definition_type}:{marking.definition[marking.definition_type]}',
+            tlp_tag['name']
+        )
+        self._check_object_confidence_tags(indicator, ip_port)
+        self._check_object_confidence_tags(coa, course_of_action)
+        self._check_object_confidence_tags(observed_data, asn)
+
     def test_event_with_sightings(self):
         event = get_event_with_sightings()
         orgc = event['Event']['Orgc']
@@ -498,7 +558,6 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
             observed_data.id,
             identity2.id
         )
-        print(self.parser.bundle.serialize(indent=4))
         self._check_opinion_features(
             opinion1,
             sightings1[2],
@@ -540,6 +599,21 @@ class TestSTIX21Export(TestSTIX2Export, TestSTIX21):
         _, _, _, marking = stix_objects
         self.assertEqual(marking.definition_type, 'tlp')
         self.assertEqual(marking.definition['tlp'], 'white')
+
+    def test_published_event(self):
+        event = get_published_event()
+        orgc = event['Event']['Orgc']
+        self.parser.parse_misp_event(event)
+        stix_objects = self._check_bundle_features(3)
+        self._check_spec_versions(stix_objects)
+        identity, report, _ = stix_objects
+        timestamp = self._datetime_from_timestamp(event['Event']['timestamp'])
+        identity_id = self._check_identity_features(identity, orgc, timestamp)
+        self._check_report_features(report, event['Event'], identity_id, timestamp)
+        self.assertEqual(
+            report.published,
+            self._datetime_from_timestamp(event['Event']['publish_timestamp'])
+        )
 
     ################################################################################
     #                        SINGLE ATTRIBUTES EXPORT TESTS                        #


### PR DESCRIPTION
This is the first step of a missing feature to handle properly confidence levels as mentioned in #6 
Now we handle properly confidence levels while converting MISP to STIX, and we'll then add the feature to handle confidence levels while importing STIX content into MISP