### PR TITLE
Use MISP event UUID for bundle ID

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix20.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix20.py
@@ -1104,7 +1104,7 @@ class MISPtoSTIX20Parser(MISPtoSTIX2Parser):
         return AttackPattern(**attack_pattern_args)
 
     def _create_bundle(self) -> Bundle:
-        return Bundle(self.stix_objects, allow_custom=True)
+        return Bundle(self.stix_objects, allow_custom=True, id="bundle--" + self._misp_event.get('uuid'))
 
     @staticmethod
     def _create_campaign(campaign_args: dict) -> Campaign:

--- a/misp_stix_converter/misp2stix/misp_to_stix20.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix20.py
@@ -1104,7 +1104,7 @@ class MISPtoSTIX20Parser(MISPtoSTIX2Parser):
         return AttackPattern(**attack_pattern_args)
 
     def _create_bundle(self) -> Bundle:
-        return Bundle(self.stix_objects, allow_custom=True, id="bundle--" + self._misp_event.get('uuid'))
+        return Bundle(self.stix_objects, allow_custom=True, id=f"bundle--{self._misp_event.get('uuid')}" if hasattr(self, "_misp_event") else None )
 
     @staticmethod
     def _create_campaign(campaign_args: dict) -> Campaign:

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -1450,7 +1450,7 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
         return AttackPattern(**attack_pattern_args)
 
     def _create_bundle(self) -> Bundle:
-        return Bundle(self.stix_objects, allow_custom=True, id="bundle--" + self._misp_event.get('uuid'))
+        return Bundle(self.stix_objects, allow_custom=True, id=f"bundle--{self._misp_event.get('uuid')}" if hasattr(self, "_misp_event") else None )
 
     @staticmethod
     def _create_campaign(campaign_args: dict) -> Campaign:

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -1450,7 +1450,7 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
         return AttackPattern(**attack_pattern_args)
 
     def _create_bundle(self) -> Bundle:
-        return Bundle(self.stix_objects, allow_custom=True)
+        return Bundle(self.stix_objects, allow_custom=True, id="bundle--" + self._misp_event.get('uuid'))
 
     @staticmethod
     def _create_campaign(campaign_args: dict) -> Campaign:


### PR DESCRIPTION
Currently, when creating a new STIX2 bundle, the bundle ID creates a new random UUID. 

Since we already have an ID for the event, which is analog to the bundle, we can use the same UUID. This also means, running multiple times on the same event will generate the same bundle id. 
