### PR TITLE
Fix naive timestamp

### DIFF
--- a/misp_stix_converter/misp2stix/exportparser.py
+++ b/misp_stix_converter/misp2stix/exportparser.py
@@ -6,7 +6,7 @@ from .stix1_mapping import MISPtoSTIX1Mapping
 from .stix20_mapping import MISPtoSTIX20Mapping
 from .stix21_mapping import MISPtoSTIX21Mapping
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pymisp import MISPAttribute, MISPObject
 from typing import Optional, Union
 
@@ -160,7 +160,7 @@ class MISPtoSTIXParser:
     def _datetime_from_timestamp(timestamp: Union[datetime, str]) -> datetime:
         if isinstance(timestamp, datetime):
             return timestamp
-        return datetime.utcfromtimestamp(int(timestamp))
+        return datetime.fromtimestamp(int(timestamp), timezone.utc)
 
     @staticmethod
     def _fetch_ids_flag(attributes: list) -> bool:


### PR DESCRIPTION
This PR solves the following issue:

**Snippet**
```
parser = MISPtoSTIX21Parser()
parser.parse_misp_event(event)

store = stix2.MemoryStore()
store.add(parser.stix_objects)

properties = {"x_custom_stuff": True}

for indicator in store.query(stix2.Filter('type', '=', 'indicator')):
    indicator = indicator.new_version(custom_properties=properties)
```

**Error**
```
TypeError: can't compare offset-naive and offset-aware datetimes
```
https://github.com/oasis-open/cti-python-stix2/blob/2860699f19ad64a8bb7e04b449763fdee1925a62/stix2/versioning.py#L48

**Note/Request:** would be awesome if after this merge, you guys could make available the new version of this package in pypi.

:rocket: Thank you for this library! :rocket: