### PR TITLE
fix: `type` access for dict type Observables

### DIFF
--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -501,9 +501,10 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser):
 
         :param observed_data: The Observed Data object
         """
-        observable_types = set(
-            observable.type for observable in observed_data.objects.values()
-        )
+        observable_types = set()
+        for observable in observed_data.objects.values():
+            observable_types.add(observable.get('type') if type(observable) is dict else observable.type)
+
         mapping = self._handle_observables_mapping(observable_types)
         feature = f'_parse_{mapping}_observable_objects'
         try:


### PR DESCRIPTION
Under ObservedData we have objects. These objects are either `ObservableProperty` type or can be `dictionaries`. If the object type is a custom object then we get a dictionary and when we try to access the `type` using the '.' notation it throws a runtime error. 

This fix is to make it work for custom objects so the existing error handling can gracefully handle the situation.