### PR TITLE
Removing Galaxies generic descriptions from the STIX 2.x objects description field

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -2418,11 +2418,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             attack_pattern_id = f"attack-pattern--{cluster['uuid']}"
             attack_pattern_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                attack_pattern_id,
-                timestamp
+                cluster, galaxy['name'], attack_pattern_id, timestamp
             )
             if cluster.get('meta'):
                 attack_pattern_args.update(
@@ -2458,11 +2454,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             course_of_action_id = f"course-of-action--{cluster['uuid']}"
             course_of_action_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                course_of_action_id,
-                timestamp
+                cluster, galaxy['name'], course_of_action_id, timestamp
             )
             if cluster.get('meta'):
                 course_of_action_args.update(
@@ -2519,11 +2511,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             intrusion_set_id = f"intrusion-set--{cluster['uuid']}"
             intrusion_set_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                intrusion_set_id,
-                timestamp
+                cluster, galaxy['name'], intrusion_set_id, timestamp
             )
             if cluster.get('meta'):
                 intrusion_set_args.update(
@@ -2564,11 +2552,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             malware_id = f"malware--{cluster['uuid']}"
             malware_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                malware_id,
-                timestamp
+                cluster, galaxy['name'], malware_id, timestamp
             )
             if cluster.get('meta'):
                 meta_args = self._parse_meta_fields(cluster['meta'], 'malware')
@@ -2689,11 +2673,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             threat_actor_id = f"threat-actor--{cluster['uuid']}"
             threat_actor_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                threat_actor_id,
-                timestamp
+                cluster, galaxy['name'], threat_actor_id, timestamp
             )
             if cluster.get('meta'):
                 meta_args = self._parse_meta_fields(
@@ -2734,11 +2714,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             tool_id = f"tool--{cluster['uuid']}"
             tool_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                tool_id,
-                timestamp
+                cluster, galaxy['name'], tool_id, timestamp
             )
             if cluster.get('meta'):
                 meta_args = self._parse_meta_fields(cluster['meta'], 'tool')
@@ -2794,11 +2770,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 continue
             vulnerability_id = f"vulnerability--{cluster['uuid']}"
             vulnerability_args = self._create_galaxy_args(
-                cluster,
-                galaxy['description'],
-                galaxy['name'],
-                vulnerability_id,
-                timestamp
+                cluster, galaxy['name'], vulnerability_id, timestamp
             )
             if cluster.get('meta'):
                 vulnerability_args.update(
@@ -2857,9 +2829,9 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
         )
         return custom_args
 
-    def _create_galaxy_args(self, cluster: Union[MISPGalaxyCluster, dict],
-                            description: str, name: str, object_id: str,
-                            timestamp: Optional[datetime] = None) -> dict:
+    def _create_galaxy_args(
+            self, cluster: Union[MISPGalaxyCluster, dict], name: str,
+            object_id: str, timestamp: Optional[datetime] = None) -> dict:
         object_type = object_id.split('--')[0]
 
         value = cluster['value']
@@ -2870,10 +2842,11 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
             'id': object_id,
             'type': object_type,
             'name': value,
-            'description': f"{description} | {cluster['description']}",
             'labels': self._create_galaxy_labels(name, cluster),
             'interoperability': True
         }
+        if cluster.get('description') is not None:
+            galaxy_args['description'] = cluster['description']
         if timestamp is None:
             if not cluster.get('timestamp'):
                 return galaxy_args

--- a/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
@@ -251,11 +251,10 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         else:
             custom_galaxy = self._get_stix_object(custom_ref)
             galaxy_type = custom_galaxy.x_misp_type
-            galaxy_description, cluster_description = custom_galaxy.x_misp_description.split(' | ')
             cluster_args = {
                 'type': galaxy_type,
                 'value': custom_galaxy.x_misp_value,
-                'description': cluster_description
+                'description': custom_galaxy.x_misp_description
             }
             if hasattr(custom_galaxy, 'x_misp_meta'):
                 cluster_args['meta'] = custom_galaxy.x_misp_meta
@@ -265,7 +264,7 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
             }
             if galaxy_type not in self._galaxies:
                 self._create_galaxy_args(
-                    galaxy_description, galaxy_type, custom_galaxy.x_misp_name
+                    galaxy_type, custom_galaxy.x_misp_name
                 )
 
     def _parse_custom_object(self, custom_ref: str):
@@ -422,16 +421,17 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
     #                 STIX Domain Objects (SDOs) PARSING FUNCTIONS                 #
     ################################################################################
 
-    def _create_galaxy_args(self, description: str, galaxy_type: str,
-                            galaxy_name: str) -> MISPGalaxy:
+    def _create_galaxy_args(self, galaxy_type: str, galaxy_name: str) -> MISPGalaxy:
         misp_galaxy = MISPGalaxy()
-        misp_galaxy.from_dict(
-            **{
-                'type': galaxy_type,
-                'name': galaxy_name,
-                'description': description
-            }
-        )
+        if galaxy_type in self.galaxy_definitions:
+            misp_galaxy.from_dict(**self.galaxy_definitions[galaxy_type])
+        else:
+            misp_galaxy.from_dict(
+                **{
+                    'type': galaxy_type,
+                    'name': galaxy_name
+                }
+            )
         self._galaxies[galaxy_type] = misp_galaxy
 
     def _parse_course_of_action_object(
@@ -479,13 +479,11 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         galaxy_type, galaxy_name = self._extract_galaxy_labels(
             stix_object.labels
         )
-        cluster, galaxy_description = self._parse_galaxy_cluster(
+        cluster = self._parse_galaxy_cluster(
             stix_object, galaxy_type
         )
         if galaxy_type not in self._galaxies:
-            self._create_galaxy_args(
-                galaxy_description, galaxy_type, galaxy_name
-            )
+            self._create_galaxy_args(galaxy_type, galaxy_name)
         return {
             'cluster': cluster,
             'used': {self.misp_event.uuid: False}
@@ -501,25 +499,19 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
             'used': {self.misp_event.uuid: False}
         }
 
-    def _parse_galaxy_cluster(self, stix_object: _GALAXY_OBJECTS_TYPING,
-                              galaxy_type: str) -> tuple:
+    def _parse_galaxy_cluster(
+            self, stix_object: _GALAXY_OBJECTS_TYPING, galaxy_type: str,
+            description: Optional[str] = None) -> tuple:
+        if ' | ' in getattr(stix_object, 'description', ''):
+            _, description = stix_object.description.split(' | ')
         object_type = stix_object.type.replace('-', '_')
-        if ' | ' in stix_object.description:
-            galaxy_desc, cluster_desc = stix_object.description.split(' | ')
-            cluster = getattr(self, f'_parse_{object_type}_cluster')(
-                stix_object,
-                description=cluster_desc,
-                galaxy_type=galaxy_type
-            )
-            return cluster, galaxy_desc
-        cluster = getattr(self, f'_parse_{object_type}_cluster')(
-            stix_object, galaxy_type=galaxy_type
+        return getattr(self, f'_parse_{object_type}_cluster')(
+            stix_object, galaxy_type=galaxy_type, description=description
         )
-        return cluster, stix_object.description
 
     def _parse_identity_cluster(
-            self, identity: _IDENTITY_TYPING, description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            self, identity: _IDENTITY_TYPING,  galaxy_type: str,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         identity_args = self._create_cluster_args(
             identity, galaxy_type, description=description
         )
@@ -576,14 +568,16 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         self._add_misp_object(misp_object, identity)
 
     def _parse_location_cluster(
-            self, location: Location, description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
-        location_args = {
-            'type': galaxy_type,
-            'description': description,
-            'value': location.name if galaxy_type == 'country'
-            else self._mapping.regions_mapping(location.region, location.name)
-        }
+            self, location: Location,
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
+        location_args = self._create_cluster_args(
+            location, galaxy_type, description=description,
+            cluster_value=(
+                location.name if galaxy_type == 'country' else
+                self._mapping.regions_mapping(location.region, location.name)
+            )
+        )
         meta = self._handle_meta_fields(location)
         if meta:
             location_args['meta'] = meta

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -714,8 +714,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_attack_pattern_cluster(
             self, attack_pattern: _ATTACK_PATTERN_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         attack_pattern_args = self._create_cluster_args(
             attack_pattern, galaxy_type, description=description
         )
@@ -736,8 +736,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_campaign_cluster(
             self, campaign: _CAMPAIGN_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         campaign_args = self._create_cluster_args(
             campaign, galaxy_type, description=description
         )
@@ -752,8 +752,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_course_of_action_cluster(
             self, course_of_action: _COURSE_OF_ACTION_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         course_of_action_args = self._create_cluster_args(
             course_of_action, galaxy_type, description=description
         )
@@ -770,8 +770,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_intrusion_set_cluster(
             self, intrusion_set: _INTRUSION_SET_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         intrusion_set_args = self._create_cluster_args(
             intrusion_set, galaxy_type, description=description
         )
@@ -788,8 +788,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_malware_cluster(
             self, malware: _MALWARE_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         malware_args = self._create_cluster_args(
             malware, galaxy_type, description=description
         )
@@ -810,8 +810,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_threat_actor_cluster(
             self, threat_actor: _THREAT_ACTOR_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         threat_actor_args = self._create_cluster_args(
             threat_actor, galaxy_type, description=description
         )
@@ -829,8 +829,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         return self._create_misp_galaxy_cluster(threat_actor_args)
 
     def _parse_tool_cluster(
-            self, tool: _TOOL_TYPING, description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            self, tool: _TOOL_TYPING, galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         tool_args = self._create_cluster_args(
             tool, galaxy_type, description=description
         )
@@ -855,8 +855,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _parse_vulnerability_cluster(
             self, vulnerability: _VULNERABILITY_TYPING,
-            description: Optional[str] = None,
-            galaxy_type: Optional[str] = None) -> MISPGalaxyCluster:
+            galaxy_type: Optional[str] = None,
+            description: Optional[str] = None) -> MISPGalaxyCluster:
         vulnerability_args = self._create_cluster_args(
             vulnerability, galaxy_type, description=description
         )

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -255,8 +255,7 @@ class TestSTIX2Export(TestSTIX):
         self.assertEqual(stix_object.name, cluster['value'])
         description = galaxy['description']
         if cluster.get('description'):
-            description = f"{description} | {cluster['description']}"
-        self.assertEqual(stix_object.description, description)
+            self.assertEqual(stix_object.description, cluster['description'])
         self.assertEqual(stix_object.labels[0], f'misp:galaxy-name="{galaxy["name"]}"')
         self.assertEqual(stix_object.labels[1], f'misp:galaxy-type="{galaxy["type"]}"')
         if cluster.get('meta'):

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -562,19 +562,15 @@ class TestInternalSTIX2Import(TestSTIX2Import):
         cluster = galaxy.clusters[0]
         self._assert_multiple_equal(galaxy.type, cluster.type, 'tea-matrix')
         self.assertEqual(galaxy.name, 'Tea Matrix')
-        galaxy_description, cluster_description = custom.x_misp_description.split(' | ')
-        self.assertEqual(galaxy.description, galaxy_description)
         self.assertEqual(cluster.value, custom.x_misp_value)
-        self.assertEqual(cluster.description, cluster_description)
+        self.assertEqual(cluster.description, custom.x_misp_description)
 
     def _check_galaxy_fields(self, galaxy, stix_object, galaxy_type, galaxy_name):
         cluster = galaxy.clusters[0]
         self._assert_multiple_equal(galaxy.type, cluster.type, galaxy_type)
         self.assertEqual(galaxy.name, galaxy_name)
-        galaxy_description, cluster_description = stix_object.description.split(' | ')
-        self.assertEqual(galaxy.description, galaxy_description)
         self.assertEqual(cluster.value, stix_object.name)
-        self.assertEqual(cluster.description, cluster_description)
+        self.assertEqual(cluster.description, stix_object.description)
 
     def _check_generic_malware_galaxy(self, galaxy, malware):
         self._check_galaxy_fields(galaxy, malware, 'mitre-malware', 'Malware')

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -576,7 +576,7 @@ _ATTACK_PATTERN_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Test malware in various execution environments - PRE-T1134",
-    "description": "ATT&CK Tactic | Malware may perform differently on different platforms and different operating systems.",
+    "description": "Malware may perform differently on different platforms and different operating systems.",
     "kill_chain_phases": [
         {
             "kill_chain_name": "mitre-pre-attack",
@@ -637,7 +637,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Access Token Manipulation - T1134",
-        "description": "ATT&CK Tactic | Windows uses access tokens to determine the ownership of a running process.",
+        "description": "Windows uses access tokens to determine the ownership of a running process.",
         "labels": [
             "misp:galaxy-name=\"Attack Pattern\"",
             "misp:galaxy-type=\"mitre-attack-pattern\""
@@ -655,7 +655,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Automated Exfiltration Mitigation - T1020",
-        "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+        "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
         "labels": [
             "misp:galaxy-name=\"Course of Action\"",
             "misp:galaxy-type=\"mitre-course-of-action\""
@@ -688,7 +688,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "labels": [
             "misp:galaxy-name=\"Malware\"",
             "misp:galaxy-type=\"mitre-malware\""
@@ -761,7 +761,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Access Token Manipulation - T1134",
-        "description": "ATT&CK Tactic | Windows uses access tokens to determine the ownership of a running process.",
+        "description": "Windows uses access tokens to determine the ownership of a running process.",
         "labels": [
             "misp:galaxy-name=\"Attack Pattern\"",
             "misp:galaxy-type=\"mitre-attack-pattern\""
@@ -780,7 +780,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Automated Exfiltration Mitigation - T1020",
-        "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+        "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
         "labels": [
             "misp:galaxy-name=\"Course of Action\"",
             "misp:galaxy-type=\"mitre-course-of-action\""
@@ -814,7 +814,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "labels": [
             "misp:galaxy-name=\"Malware\"",
             "misp:galaxy-type=\"mitre-malware\""
@@ -1178,7 +1178,7 @@ _BUNDLE_WITH_MULTIPLE_REPORTS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "labels": [
             "misp:galaxy-name=\"Malware\"",
             "misp:galaxy-type=\"mitre-malware\""
@@ -1297,7 +1297,7 @@ _BUNDLE_WITH_NO_REPORT = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "labels": [
             "misp:galaxy-name=\"Malware\"",
             "misp:galaxy-type=\"mitre-malware\""
@@ -1524,7 +1524,7 @@ _COURSE_OF_ACTION_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Automated Exfiltration Mitigation - T1020",
-    "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+    "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
     "labels": [
         "misp:galaxy-name=\"Course of Action\"",
         "misp:galaxy-type=\"mitre-course-of-action\""
@@ -1759,7 +1759,7 @@ _CUSTOM_GALAXY = {
         "misp:galaxy-name=\"Tea Matrix\"",
         "misp:galaxy-type=\"tea-matrix\""
     ],
-    "x_misp_description": "Tea Matrix | Milk in tea",
+    "x_misp_description": "Milk in tea",
     "x_misp_name": "Tea Matrix",
     "x_misp_type": "tea-matrix",
     "x_misp_value": "Milk in tea"
@@ -4379,7 +4379,7 @@ _INTRUSION_SET_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "APT16 - G0023",
-    "description": "Name of ATT&CK Group | APT16 is a China-based threat group that has launched spearphishing campaigns targeting Japanese and Taiwanese organizations.",
+    "description": "APT16 is a China-based threat group that has launched spearphishing campaigns targeting Japanese and Taiwanese organizations.",
     "aliases": [
         "APT16"
     ],
@@ -4787,7 +4787,7 @@ _MALWARE_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "BISCUIT - S0017",
-    "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+    "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
     "labels": [
         "misp:galaxy-name=\"Malware\"",
         "misp:galaxy-type=\"mitre-malware\""
@@ -5713,7 +5713,7 @@ _THREAT_ACTOR_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Cutting Kitten",
-    "description": "Threat actors are characteristics of malicious actors. | These convincing profiles form a self-referenced network of seemingly established LinkedIn users.",
+    "description": "These convincing profiles form a self-referenced network of seemingly established LinkedIn users.",
     "aliases": [
         "Ghambar"
     ],
@@ -5731,7 +5731,7 @@ _TOOL_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "cmd - S0106",
-    "description": "Name of ATT&CK software | cmd is the Windows command-line interpreter that can be used to interact with systems and execute other processes and utilities.",
+    "description": "cmd is the Windows command-line interpreter that can be used to interact with systems and execute other processes and utilities.",
     "labels": [
         "misp:galaxy-name=\"Tool\"",
         "misp:galaxy-type=\"mitre-tool\""
@@ -5955,7 +5955,7 @@ _VULNERABILITY_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Ghost",
-    "description": "List of known vulnerabilities and exploits | The GHOST vulnerability is a serious weakness in the Linux glibc library.",
+    "description": "The GHOST vulnerability is a serious weakness in the Linux glibc library.",
     "labels": [
         "misp:galaxy-name=\"Branded Vulnerability\"",
         "misp:galaxy-type=\"branded-vulnerability\""

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -758,7 +758,7 @@ _ATTACK_PATTERN_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Test malware in various execution environments - PRE-T1134",
-    "description": "ATT&CK Tactic | Malware may perform differently on different platforms and different operating systems.",
+    "description": "Malware may perform differently on different platforms and different operating systems.",
     "kill_chain_phases": [
         {
             "kill_chain_name": "mitre-pre-attack",
@@ -821,7 +821,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Access Token Manipulation - T1134",
-        "description": "ATT&CK Tactic | Windows uses access tokens to determine the ownership of a running process.",
+        "description": "Windows uses access tokens to determine the ownership of a running process.",
         "labels": [
             "misp:galaxy-name=\"Attack Pattern\"",
             "misp:galaxy-type=\"mitre-attack-pattern\""
@@ -840,7 +840,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Automated Exfiltration Mitigation - T1020",
-        "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+        "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
         "labels": [
             "misp:galaxy-name=\"Course of Action\"",
             "misp:galaxy-type=\"mitre-course-of-action\""
@@ -877,7 +877,7 @@ _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "is_family": True,
         "aliases": [
             "BISCUIT"
@@ -960,7 +960,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Access Token Manipulation - T1134",
-        "description": "ATT&CK Tactic | Windows uses access tokens to determine the ownership of a running process.",
+        "description": "Windows uses access tokens to determine the ownership of a running process.",
         "labels": [
             "misp:galaxy-name=\"Attack Pattern\"",
             "misp:galaxy-type=\"mitre-attack-pattern\""
@@ -980,7 +980,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Automated Exfiltration Mitigation - T1020",
-        "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+        "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
         "labels": [
             "misp:galaxy-name=\"Course of Action\"",
             "misp:galaxy-type=\"mitre-course-of-action\""
@@ -1018,7 +1018,7 @@ _BUNDLE_WITH_INVALID_UUIDS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "is_family": True,
         "aliases": [
             "BISCUIT"
@@ -1430,7 +1430,7 @@ _BUNDLE_WITH_MULTIPLE_REPORTS = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "is_family": True,
         "aliases": [
             "BISCUIT"
@@ -1570,7 +1570,7 @@ _BUNDLE_WITH_NO_REPORT = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "BISCUIT - S0017",
-        "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+        "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
         "is_family": True,
         "aliases": [
             "BISCUIT"
@@ -1842,7 +1842,7 @@ _COURSE_OF_ACTION_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Automated Exfiltration Mitigation - T1020",
-    "description": "ATT&CK Mitigation | Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
+    "description": "Identify unnecessary system utilities, scripts, or potentially malicious software that may be used to transfer data outside of a network",
     "labels": [
         "misp:galaxy-name=\"Course of Action\"",
         "misp:galaxy-type=\"mitre-course-of-action\""
@@ -2103,7 +2103,7 @@ _CUSTOM_GALAXY = {
         "misp:galaxy-name=\"Tea Matrix\"",
         "misp:galaxy-type=\"tea-matrix\""
     ],
-    "x_misp_description": "Tea Matrix | Milk in tea",
+    "x_misp_description": "Milk in tea",
     "x_misp_name": "Tea Matrix",
     "x_misp_type": "tea-matrix",
     "x_misp_value": "Milk in tea"
@@ -5293,7 +5293,7 @@ _INTRUSION_SET_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "APT16 - G0023",
-    "description": "Name of ATT&CK Group | APT16 is a China-based threat group that has launched spearphishing campaigns targeting Japanese and Taiwanese organizations.",
+    "description": "APT16 is a China-based threat group that has launched spearphishing campaigns targeting Japanese and Taiwanese organizations.",
     "aliases": [
         "APT16"
     ],
@@ -5733,7 +5733,7 @@ _LOCATION_GALAXIES = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "sweden",
-        "description": "Country meta information | Sweden",
+        "description": "Sweden",
         "country": "SE",
         "labels": [
             "misp:galaxy-name=\"Country\"",
@@ -5756,7 +5756,7 @@ _LOCATION_GALAXIES = [
         "created": "2020-10-25T16:22:00.000Z",
         "modified": "2020-10-25T16:22:00.000Z",
         "name": "Northern Europe",
-        "description": "Regions based on UN M49 | Nothern Europe",
+        "description": "Nothern Europe",
         "region": "northern-europe",
         "labels": [
             "misp:galaxy-name=\"Regions UN M49\"",
@@ -5837,7 +5837,7 @@ _MALWARE_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "BISCUIT - S0017",
-    "description": "Name of ATT&CK software | BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
+    "description": "BISCUIT is a backdoor that has been used by APT1 since as early as 2007.",
     "is_family": False,
     "aliases": [
         "BISCUIT"
@@ -7076,7 +7076,7 @@ _THREAT_ACTOR_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Cutting Kitten",
-    "description": "Threat actors are characteristics of malicious actors. | These convincing profiles form a self-referenced network of seemingly established LinkedIn users.",
+    "description": "These convincing profiles form a self-referenced network of seemingly established LinkedIn users.",
     "aliases": [
         "Ghambar"
     ],
@@ -7095,7 +7095,7 @@ _TOOL_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "cmd - S0106",
-    "description": "Name of ATT&CK software | cmd is the Windows command-line interpreter that can be used to interact with systems and execute other processes and utilities.",
+    "description": "cmd is the Windows command-line interpreter that can be used to interact with systems and execute other processes and utilities.",
     "aliases": [
         "cmd",
         "cmd.exe"
@@ -7351,7 +7351,7 @@ _VULNERABILITY_GALAXY = {
     "created": "2020-10-25T16:22:00.000Z",
     "modified": "2020-10-25T16:22:00.000Z",
     "name": "Ghost",
-    "description": "List of known vulnerabilities and exploits | The GHOST vulnerability is a serious weakness in the Linux glibc library.",
+    "description": "The GHOST vulnerability is a serious weakness in the Linux glibc library.",
     "labels": [
         "misp:galaxy-name=\"Branded Vulnerability\"",
         "misp:galaxy-type=\"branded-vulnerability\""

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -1500,10 +1500,8 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         cluster = region.clusters[0]
         self._assert_multiple_equal(region.type, cluster.type, 'region')
         self.assertEqual(region.name, 'Regions UN M49')
-        galaxy_description, cluster_description = location2.description.split(' | ')
-        self.assertEqual(region.description, galaxy_description)
         self.assertEqual(cluster.value, f'154 - {location2.name}')
-        self.assertEqual(cluster.description, cluster_description)
+        self.assertEqual(cluster.description, location2.description)
         self.assertEqual(
             region.clusters[0].meta['subregion'], location2.x_misp_subregion
         )


### PR DESCRIPTION
The Galaxy Clusters description value is used alone and no longer concatenated with the Galaxies description

This includes fixes on the MISP -> STIX 2.x export feature as it is the main issue we're resolving here - as described in #37 
But it also includes changes to avoid potential issues on the STIX 2.x -> MISP import feature as well as it keeps a backward compatibility with the STIX content generated with the prior MISP -> STIX 2.x feature versions