### PR TITLE
Remove KeyError bug

### DIFF
--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -166,8 +166,9 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser):
             return super()._handle_unparsed_content()
         unparsed_content = defaultdict(list)
         for object_id, content in self._observable.items():
-            if content['used'][self.misp_event.uuid]:
-                continue
+            if self.misp_event.uuid in content['used']:
+                if content['used'][self.misp_event.uuid]:
+                    continue
             unparsed_content[content['observable'].type].append(object_id)
         for observable_type in self._mapping.observable_object_types():
             if observable_type not in unparsed_content:
@@ -180,8 +181,9 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser):
                 continue
             to_call = f'_parse_{feature}_observable_object'
             for object_id in unparsed_content[observable_type]:
-                if self._observable[object_id]['used'][self.misp_event.uuid]:
-                    continue
+                if self.misp_event.uuid in self._observable[object_id]['used']:
+                    if self._observable[object_id]['used'][self.misp_event.uuid]:
+                        continue
                 try:
                     getattr(self.observable_object_parser, to_call)(object_id)
                 except Exception as exception:


### PR DESCRIPTION
When attempting to import a STIX file to MISP we got a KeyError, traced to the file external_stix2_to_misp.py, checking if the key exists before trying to access it removes the unhandled error, we were then able to import our STIX file.