### PR TITLE
fix #68 Use UUID from MISP ObjectReference if available

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -4369,6 +4369,8 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                 'relationship_type': reference['relationship_type'],
                 'allow_custom': True, 'interoperability': True
             }
+            if reference.get('uuid'):
+                relationship['id'] = f"reference--{reference['uuid']}"
             if reference.get('timestamp'):
                 reference_timestamp = self._datetime_from_timestamp(
                     reference['timestamp']


### PR DESCRIPTION
This should fix the issue partially, when the `ObjectReference` already has a UUID. https://www.misp-standard.org/rfc/misp-standard-core.html#name-object-references