### PR TITLE
fix: [stix2 export] Fixed MISP STIX2 export

### DIFF
--- a/misp_stix_converter/misp2stix/exportparser.py
+++ b/misp_stix_converter/misp2stix/exportparser.py
@@ -54,7 +54,8 @@ class MISPtoSTIXParser(metaclass=ABCMeta):
         if isinstance(json_content, (BufferedIOBase, TextIOBase)):
             json_content = json_content.read()
         if isinstance(json_content, (str, bytes)):
-            json_content = json.loads(json_content)
+            with open(json_content, 'r') as file:
+                json_content = json.loads(file.read())
         self._parse_json_content(json_content)
 
     ############################################################################


### PR DESCRIPTION
MISP v2 had a problem exporting events as STIX2.
I traced the code and log file which led me to a function named parse_json_content using json.loads which converts a JSON string into a Python object but not a file into a Python object.