### PR TITLE
fix: KeyError('misp_attribute') on reused domain observables in external STIX2 parsing

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
@@ -856,9 +856,13 @@ class ExternalSTIX2ObservedDataConverter(
                             )
                 continue
             if observable['used'].get(self.event_uuid, False):
-                self._handle_misp_object_fields(
-                    observable['misp_attribute'], observed_data
+                misp_content = observable.get(
+                    'misp_attribute', observable.get('misp_object')
                 )
+                if misp_content:
+                    self._handle_misp_object_fields(
+                        misp_content, observed_data
+                    )
                 continue
             attribute = self._parse_generic_observable_object_ref_as_attribute(
                 domain, observed_data, 'domain'
@@ -980,9 +984,13 @@ class ExternalSTIX2ObservedDataConverter(
                 )
                 continue
             if observable['used'].get(self.event_uuid, False):
-                self._handle_misp_object_fields(
-                    observable['misp_attribute'], observed_data
+                misp_content = observable.get(
+                    'misp_attribute', observable.get('misp_object')
                 )
+                if misp_content:
+                    self._handle_misp_object_fields(
+                        misp_content, observed_data
+                    )
                 continue
             domain = observable['observable']
             if hasattr(domain, 'resolves_to_refs'):


### PR DESCRIPTION
Summary
This PR fixes a KeyError in external STIX2 observed-data conversion when domain observables are reused across parsing paths.

Problem
In domain ref parsing, reused observables were treated as if they always had misp_attribute. In mixed domain/domain-ip flows, the same observable may have been stored as misp_object, causing KeyError('misp_attribute').

Root cause
Direct indexing of observable['misp_attribute'] in reused-observable branches of domain parser methods.

Changes
Added defensive lookup fallback in both methods:
1. _parse_domain_ip_observable_object_refs
2. _parse_domain_observable_object_refs

Fallback logic:
1. observable.get('misp_attribute', observable.get('misp_object'))
2. only handle fields when content is present

Reproduction
A minimal trigger bundle is available at trigger.json in local validation.

Validation
Branch comparison with the same trigger bundle:
1. main: reproduces KeyError('misp_attribute')
2. eset-edge: parses successfully

Impact
1. No behavior change for normal cases where misp_attribute exists.
2. Prevents hard failure for valid mixed domain/domain-ip observable reuse cases.
3. Aligns domain parser behavior with existing defensive handling patterns elsewhere in the converter.
[trigger.json](https://github.com/user-attachments/files/29006540/trigger.json)
