### PR TITLE
use raw strings for regex

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -93,7 +93,7 @@ class MISPtoSTIX1Parser(MISPtoSTIXParser, metaclass=ABCMeta):
     def __init__(self, orgname: str, version: str):
         super().__init__()
         self._orgname = orgname
-        self._orgname_id = re.sub('[\W]+', '', orgname.replace(" ", "_"))
+        self._orgname_id = re.sub(r'[\W]+', '', orgname.replace(" ", "_"))
         self._version = version
         self._mapping = MISPtoSTIX1Mapping
 

--- a/misp_stix_converter/tools/stix1_framing.py
+++ b/misp_stix_converter/tools/stix1_framing.py
@@ -141,7 +141,7 @@ def stix_xml_separator():
 def _create_stix_package(
         orgname: str, version: str,  header: Optional[bool] = True,
         uuid: Optional[UUID | str] = None) -> STIXPackage:
-    parsed_orgname = re.sub('[\W]+', '', orgname.replace(' ', '_'))
+    parsed_orgname = re.sub(r'[\W]+', '', orgname.replace(' ', '_'))
     if uuid is None:
         uuid = uuid4()
     stix_package = STIXPackage(
@@ -158,7 +158,7 @@ def _create_stix_package(
 
 
 def _handle_namespaces(namespace: str, orgname: str) -> tuple:
-    parsed_orgname = re.sub('[\W]+', '', orgname.replace(' ', '_'))
+    parsed_orgname = re.sub(r'[\W]+', '', orgname.replace(' ', '_'))
     namespaces = {namespace: parsed_orgname}
     namespaces.update(NS_DICT)
     try:


### PR DESCRIPTION
Standardizes the regular expression syntax for removing non-word characters by consistently using a [raw string](https://docs.python.org/3/reference/lexical_analysis.html#raw-string-literals) (with `r''`) in all relevant places.

This fixes `SyntaxWarnings` like:

```
SyntaxWarning: invalid escape sequence '\W'
      self._orgname_id = re.sub('[\W]+', '', orgname.replace(" ", "_"))
```
