### PR TITLE
Error handling: library exceptions, loader robustness, errors in the result dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Convert MISP <-> STIX
 
 options:
   -h, --help       show this help message and exit
-  --debug          Show errors and warnings
+  --debug          Show the full list of errors - errors and warnings are reported either way, this only controls the errors level of detail
 
 Main feature:
   {export,import}

--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ stix21_response = misp_event_collection_to_stix2_1(
 ```
 Again, all the responses should have a `success` field equal to 1 and the resulting STIX1 Package and STIX 2.0 & 2.1 Bundles are available in the specific output file names.
 
+Note that `success` = 1 only tells you the conversion wrote its output: a conversion that dropped part of the content says so as well. Any response - from the conversion functions in both directions - may therefore carry an `errors` field, and a `warnings` one, next to `success`, both keyed by the event or bundle identifier the messages belong to. The `debug` argument controls how detailed the `errors` field is, never whether failures are reported: by default each distinct message appears once with the number of times it happened, capped at ten messages per identifier, and `debug=True` returns the full list instead.
+
 ### Samples and examples
 
 Various examples are provided and used by the different tests scripts in the [tests](tests/) directory.

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -2,6 +2,7 @@ __version__ = '2026.7.8'
 
 import argparse
 from .misp2stix import InvalidMISPInputError  # noqa
+from .tools import STIXLoadingError  # noqa
 from .misp2stix import MISPtoSTIX1AttributesParser, MISPtoSTIX1EventsParser  # noqa
 from .misp2stix import MISPtoSTIX1Mapping  # noqa
 from .misp2stix import MISPtoSTIX20Parser, MISPtoSTIX21Parser  # noqa
@@ -16,6 +17,7 @@ from .misp_stix_converter import _misp_to_stix, _stix_to_misp  # noqa
 from .stix2misp import ExternalSTIX2toMISPParser, InternalSTIX2toMISPParser  # noqa
 from .stix2misp import ExternalSTIX2toMISPMapping, InternalSTIX2toMISPMapping  # noqa
 from .stix2misp import ExternalSTIX2Mapping  # noqa
+from .stix2misp import MissingSTIXContentError  # noqa
 from .stix2misp import STIX2PatternParser  # noqa
 from .stix2misp import MISP_org_uuid  # noqa
 from pathlib import Path

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -41,7 +41,9 @@ def main():
         version=f'{parser.prog} {__version__}'
     )
     parser.add_argument(
-        '--debug', action='store_true', help='Show errors and warnings'
+        '--debug', action='store_true',
+        help='Show the full list of errors - errors and warnings are reported '
+             'either way, this only controls the errors level of detail'
     )
 
     # SUBPARSERS TO SEPARATE THE 2 MAIN FEATURES

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -513,19 +513,19 @@ def stix_1_to_misp(filename: _files_type,
         filename = Path(filename).resolve()
     try:
         stix_package = load_stix1_package(filename)
+        detected = is_stix1_from_misp(stix_package)
+        parser, args = get_stix1_parser(
+            detected if from_misp is None else from_misp, distribution,
+            sharing_group_id, title, producer, force_contextual_data,
+            galaxies_as_tags, single_event, organisation_uuid,
+            cluster_distribution, cluster_sharing_group_id
+        )
+        stix_parser = parser()
+        stix_parser.load_stix_package(stix_package)
+        _handle_classification_warning(stix_parser, from_misp, detected)
+        stix_parser.parse_stix_package(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    detected = is_stix1_from_misp(stix_package)
-    parser, args = get_stix1_parser(
-        detected if from_misp is None else from_misp, distribution,
-        sharing_group_id, title, producer, force_contextual_data,
-        galaxies_as_tags, single_event, organisation_uuid,
-        cluster_distribution, cluster_sharing_group_id
-    )
-    stix_parser = parser()
-    stix_parser.load_stix_package(stix_package)
-    _handle_classification_warning(stix_parser, from_misp, detected)
-    stix_parser.parse_stix_package(**args)
     if output_dir is None:
         output_dir = filename.parent
     if stix_parser.single_event:
@@ -562,19 +562,19 @@ def stix1_to_misp_instance(misp: PyMISP, filename: _files_type,
         filename = Path(filename).resolve()
     try:
         stix_package = load_stix1_package(filename)
+        detected = is_stix1_from_misp(stix_package)
+        parser, args = get_stix1_parser(
+            detected if from_misp is None else from_misp, distribution,
+            sharing_group_id, title, producer, force_contextual_data,
+            galaxies_as_tags, single_event, organisation_uuid,
+            cluster_distribution, cluster_sharing_group_id
+        )
+        stix_parser = parser()
+        stix_parser.load_stix_package(stix_package)
+        _handle_classification_warning(stix_parser, from_misp, detected)
+        stix_parser.parse_stix_package(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    detected = is_stix1_from_misp(stix_package)
-    parser, args = get_stix1_parser(
-        detected if from_misp is None else from_misp, distribution,
-        sharing_group_id, title, producer, force_contextual_data,
-        galaxies_as_tags, single_event, organisation_uuid,
-        cluster_distribution, cluster_sharing_group_id
-    )
-    stix_parser = parser()
-    stix_parser.load_stix_package(stix_package)
-    _handle_classification_warning(stix_parser, from_misp, detected)
-    stix_parser.parse_stix_package(**args)
     if stix_parser.single_event:
         misp_event = misp.add_event(stix_parser.misp_event, pythonify=True)
         if not isinstance(misp_event, MISPEvent):
@@ -617,19 +617,19 @@ def stix_2_to_misp(filename: _files_type,
         filename = Path(filename).resolve()
     try:
         bundle = load_stix2_file(filename, invalid_objects := {})
+        detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
+        parser, args = get_stix2_parser(
+            detected if from_misp is None else from_misp, distribution,
+            sharing_group_id, title, producer, force_contextual_data,
+            galaxies_as_tags, single_event, organisation_uuid,
+            cluster_distribution, cluster_sharing_group_id
+        )
+        stix_parser = parser()
+        stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
+        _handle_classification_warning(stix_parser, from_misp, detected)
+        stix_parser.parse_stix_bundle(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
-    parser, args = get_stix2_parser(
-        detected if from_misp is None else from_misp, distribution,
-        sharing_group_id, title, producer, force_contextual_data,
-        galaxies_as_tags, single_event, organisation_uuid,
-        cluster_distribution, cluster_sharing_group_id
-    )
-    stix_parser = parser()
-    stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
-    _handle_classification_warning(stix_parser, from_misp, detected)
-    stix_parser.parse_stix_bundle(**args)
     if output_dir is None:
         output_dir = filename.parent
     if stix_parser.single_event:
@@ -666,19 +666,19 @@ def stix2_to_misp_instance(misp: PyMISP, filename: _files_type,
         filename = Path(filename).resolve()
     try:
         bundle = load_stix2_file(filename, invalid_objects := {})
+        detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
+        parser, args = get_stix2_parser(
+            detected if from_misp is None else from_misp, distribution,
+            sharing_group_id, title, producer, force_contextual_data,
+            galaxies_as_tags, single_event, organisation_uuid,
+            cluster_distribution, cluster_sharing_group_id
+        )
+        stix_parser = parser()
+        stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
+        _handle_classification_warning(stix_parser, from_misp, detected)
+        stix_parser.parse_stix_bundle(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
-    parser, args = get_stix2_parser(
-        detected if from_misp is None else from_misp, distribution,
-        sharing_group_id, title, producer, force_contextual_data,
-        galaxies_as_tags, single_event, organisation_uuid,
-        cluster_distribution, cluster_sharing_group_id
-    )
-    stix_parser = parser()
-    stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
-    _handle_classification_warning(stix_parser, from_misp, detected)
-    stix_parser.parse_stix_bundle(**args)
     if stix_parser.single_event:
         misp_event = misp.add_event(stix_parser.misp_event, pythonify=True)
         if not isinstance(misp_event, MISPEvent):

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -18,7 +18,7 @@ from .tools.stix1_writing_helpers import (
     write_observables, write_threat_actors, write_ttps, _write_raw_stix)
 from .tools.stix2_loading_helpers import load_stix2_file
 from .tools.stix2_to_misp_helpers import get_stix2_parser, is_stix2_from_misp
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 from pymisp import MISPEvent, PyMISP, PyMISPError
 from stix2.base import STIXJSONEncoder
@@ -797,8 +797,12 @@ def _process_stix_to_misp_files(args) -> dict:
             if isinstance(content, list):
                 results['fails'][filename.name] = content
                 continue
-            for identifier, values in traceback[field].items():
-                results['fails'][identifier] = tuple(values)
+            # errors and warnings key on the same identifier: gather them
+            # instead of letting the warnings overwrite the errors
+            for identifier, values in content.items():
+                results['fails'][identifier] = (
+                    *results['fails'].get(identifier, ()), *values
+                )
     if success:
         results['results'] = success
     return results
@@ -842,8 +846,12 @@ def _process_stix_to_misp_instance(misp: PyMISP, args) -> dict:
             if isinstance(content, list):
                 results['fails'][filename.name] = content
                 continue
-            for identifier, values in traceback[field].items():
-                results['fails'][identifier] = tuple(values)
+            # errors and warnings key on the same identifier: gather them
+            # instead of letting the warnings overwrite the errors
+            for identifier, values in content.items():
+                results['fails'][identifier] = (
+                    *results['fails'].get(identifier, ()), *values
+                )
     if success:
         results['event_ids'] = success
     return results
@@ -910,13 +918,18 @@ def _handle_classification_warning(
 def _generate_traceback(
         debug: bool, parser, *output_names: tuple, errors: dict = {}) -> dict:
     traceback = {'pymisp_errors': errors} if errors else {'success': 1}
-    # Warnings surface regardless of `debug`;
-    # only the errors verbosity is debug-gated
+    # Warnings and errors surface regardless of `debug`: a conversion that
+    # dropped content never reports a bare success. `debug` only selects the
+    # errors detail - warnings are reported in full either way
     warnings = parser.warnings
     if warnings:
         traceback['warnings'] = warnings
-    if debug and parser.errors:
-        traceback['errors'] = parser.errors
+    if parser.errors:
+        # `parser.errors` is the parser's own `defaultdict` - copy it, so a
+        # caller looking up an identifier neither aliases nor grows it
+        traceback['errors'] = (
+            dict(parser.errors) if debug else _summarise_errors(parser.errors)
+        )
     traceback['results'] = list(output_names)
     return traceback
 
@@ -931,3 +944,32 @@ def _get_stix_ingestion_method(version):
     if version == '2':
         return stix2_to_misp_instance
     return stix1_to_misp_instance
+
+
+_ERRORS_SUMMARY_LIMIT = 10
+
+
+def _summarise_errors(errors: dict) -> dict:
+    # Default reporting: one entry per distinct message, capped - a single
+    # document can produce an error per object it carries - with the number
+    # of remaining messages and where to get them. Messages carrying no
+    # object id are indistinguishable, so how many times each happened is
+    # part of the signal: hundreds of objects dropped the same way must not
+    # read like one
+    summary = {}
+    for identifier, messages in errors.items():
+        occurrences = Counter(messages)
+        distinct = [
+            message if occurrence == 1 else f'{message} ({occurrence} times)'
+            for message, occurrence in occurrences.items()
+        ]
+        remaining = len(distinct) - _ERRORS_SUMMARY_LIMIT
+        if remaining > 0:
+            distinct = distinct[:_ERRORS_SUMMARY_LIMIT]
+            distinct.append(
+                f'... and {remaining} more error'
+                f"{'s' if remaining > 1 else ''} - use the debug option "
+                'to get the full list'
+            )
+        summary[identifier] = distinct
+    return summary

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -616,7 +616,7 @@ def stix_2_to_misp(filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        bundle = load_stix2_file(filename, invalid_objects := {})
+        bundle = load_stix2_file(filename)
         detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
         parser, args = get_stix2_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -625,7 +625,7 @@ def stix_2_to_misp(filename: _files_type,
             cluster_distribution, cluster_sharing_group_id
         )
         stix_parser = parser()
-        stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
+        stix_parser.load_stix_bundle(bundle)
         _handle_classification_warning(stix_parser, from_misp, detected)
         stix_parser.parse_stix_bundle(**args)
     except Exception as error:
@@ -665,7 +665,7 @@ def stix2_to_misp_instance(misp: PyMISP, filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        bundle = load_stix2_file(filename, invalid_objects := {})
+        bundle = load_stix2_file(filename)
         detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
         parser, args = get_stix2_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -674,7 +674,7 @@ def stix2_to_misp_instance(misp: PyMISP, filename: _files_type,
             cluster_distribution, cluster_sharing_group_id
         )
         stix_parser = parser()
-        stix_parser.load_stix_bundle(bundle, invalid_objects=invalid_objects)
+        stix_parser.load_stix_bundle(bundle)
         _handle_classification_warning(stix_parser, from_misp, detected)
         stix_parser.parse_stix_bundle(**args)
     except Exception as error:

--- a/misp_stix_converter/stix2misp/__init__.py
+++ b/misp_stix_converter/stix2misp/__init__.py
@@ -1,4 +1,5 @@
 from .converters import ExternalSTIX2Mapping  # noqa
+from .exceptions import MissingSTIXContentError  # noqa
 from .external_stix1_to_misp import ExternalSTIX1toMISPParser  # noqa
 from .external_stix2_mapping import ExternalSTIX2toMISPMapping  # noqa
 from .external_stix2_to_misp import ExternalSTIX2toMISPParser  # noqa

--- a/misp_stix_converter/stix2misp/exceptions.py
+++ b/misp_stix_converter/stix2misp/exceptions.py
@@ -20,6 +20,10 @@ class MarkingDefinitionLoadingError(STIXtoMISPError):
     pass
 
 
+class MissingSTIXContentError(STIXtoMISPError):
+    pass
+
+
 class ObjectRefLoadingError(STIXtoMISPError):
     pass
 

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -145,8 +145,14 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._vulnerability: dict
 
     def load_stix_bundle(self, bundle: Bundle_v20 | Bundle_v21,
-                         invalid_objects: Optional[dict] = {}):
+                         invalid_objects: Optional[dict] = None):
         self._reset_bundle_state()
+        if invalid_objects is None:
+            # the loading helpers keep the invalid objects they recovered
+            # with the bundle they were recovered from
+            invalid_objects = getattr(bundle, '_invalid_objects', None)
+            if invalid_objects is None:
+                invalid_objects = {}
         self.__invalid_objects = invalid_objects
         self._set_identifier(bundle.id)
         self.__stix_version = getattr(bundle, 'spec_version', '2.1')
@@ -155,13 +161,13 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def parse_stix_content(self, filename: str, **kwargs):
         try:
-            bundle = load_stix2_file(filename, invalid_objects := {})
+            bundle = load_stix2_file(filename)
         except Exception as exception:
             raise STIXLoadingError(
                 'Error while loading the STIX 2 content: '
                 f'{_reduce_input_path(str(exception), filename)}'
             ) from exception
-        self.load_stix_bundle(bundle, invalid_objects=invalid_objects)
+        self.load_stix_bundle(bundle)
         del bundle
         self.parse_stix_bundle(**kwargs)
 

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-import sys
+from ..tools.exceptions import STIXLoadingError, _reduce_input_path
 from ..tools.stix2_loading_helpers import load_stix2_file
 from .exceptions import (
-    MarkingDefinitionLoadingError, ObjectRefLoadingError,
-    ObjectTypeLoadingError, UndefinedIndicatorError, UndefinedSTIXObjectError,
-    UndefinedObservableError, UnknownAttributeTypeError, UnknownObjectNameError,
+    MarkingDefinitionLoadingError, MissingSTIXContentError,
+    ObjectRefLoadingError, ObjectTypeLoadingError, UndefinedIndicatorError,
+    UndefinedSTIXObjectError, UndefinedObservableError,
+    UnknownAttributeTypeError, UnknownObjectNameError,
     UnknownParsingFunctionError, UnknownPatternTypeError,
     UnknownStixObjectTypeError)
 from .external_stix2_mapping import ExternalSTIX2toMISPMapping
@@ -156,7 +157,10 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         try:
             bundle = load_stix2_file(filename, invalid_objects := {})
         except Exception as exception:
-            sys.exit(exception)
+            raise STIXLoadingError(
+                'Error while loading the STIX 2 content: '
+                f'{_reduce_input_path(str(exception), filename)}'
+            ) from exception
         self.load_stix_bundle(bundle, invalid_objects=invalid_objects)
         del bundle
         self.parse_stix_bundle(**kwargs)
@@ -183,18 +187,19 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             self._critical_error(exception)
 
     def _parse_stix_bundle(self):
+        # `stix_version` is only set by `load_stix_bundle` - without it the
+        # dispatch below would build a generic event from unloaded state
+        if not hasattr(self, 'stix_version'):
+            raise MissingSTIXContentError(
+                'No STIX content loaded, please run `load_stix_bundle` first.'
+            )
         n_reports = sum(
             len(getattr(self, feature, {}))
             for feature in ('_report', '_grouping')
         )
-        try:
-            feature = self._mapping.bundle_to_misp_mapping(
-                str(2 if n_reports >= 2 else n_reports)
-            )
-        except AttributeError:
-            sys.exit(
-                'No STIX content loaded, please run `load_stix_content` first.'
-            )
+        feature = self._mapping.bundle_to_misp_mapping(
+            str(2 if n_reports >= 2 else n_reports)
+        )
         getattr(self, feature)()
 
     def _reset_bundle_state(self):

--- a/misp_stix_converter/tools/__init__.py
+++ b/misp_stix_converter/tools/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .exceptions import STIXLoadingError  # noqa
 from .stix1_framing import stix1_attributes_framing, stix1_framing  # noqa
 from .stix1_loading_helpers import load_stix1_package  # noqa
 from .stix1_to_misp_helpers import get_stix1_parser, is_stix1_from_misp  # noqa
@@ -16,6 +17,7 @@ from .stix2_loading_helpers import load_stix2_content, load_stix2_file  # noqa
 from .stix2_to_misp_helpers import get_stix2_parser, is_stix2_from_misp  # noqa
 
 __all__ = [
+    'STIXLoadingError',
     'get_stix1_parser', 'is_stix1_from_misp', 'load_stix1_package',
     'get_stix2_parser', 'is_stix2_from_misp', 'load_stix2_content', 'load_stix2_file',
     'stix1_attributes_framing', 'stix1_framing',

--- a/misp_stix_converter/tools/exceptions.py
+++ b/misp_stix_converter/tools/exceptions.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
+from pathlib import PurePath
+
+
+class STIXLoadingError(Exception):
+    """Raised when a STIX document cannot be loaded, instead of terminating
+    the calling process."""
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
+def _reduce_input_path(message: str, filename) -> str:
+    """Underlying parsing errors embed the resolved input path - keep the
+    operator-facing text down to the file name."""
+    filename = str(filename)
+    return message.replace(filename, PurePath(filename).name)

--- a/misp_stix_converter/tools/stix1_loading_helpers.py
+++ b/misp_stix_converter/tools/stix1_loading_helpers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
+from .exceptions import STIXLoadingError, _reduce_input_path
 from mixbox.namespaces import NamespaceNotFoundError
 from stix.core import STIXPackage
 
@@ -22,18 +22,21 @@ def _update_namespaces():
 def load_stix1_package(filename, tries=0):
     try:
         return STIXPackage.from_xml(filename)
-    except NamespaceNotFoundError:
+    except NamespaceNotFoundError as error:
         if tries > 0:
-            sys.exit('Cannot handle STIX namespace')
+            raise STIXLoadingError('Cannot handle STIX namespace') from error
         _update_namespaces()
         return load_stix1_package(filename, tries + 1)
-    except NotImplementedError:
-        sys.exit('Missing python library: stix_edh')
+    except NotImplementedError as error:
+        raise STIXLoadingError('Missing python library: stix_edh') from error
     except Exception:
         try:
             import maec
             return STIXPackage.from_xml(filename)
-        except ImportError:
-            sys.exit('Missing python library: maec')
+        except ImportError as error:
+            raise STIXLoadingError('Missing python library: maec') from error
         except Exception as error:
-            sys.exit(f'Error while loading STIX1 package: {error.__str__()}')
+            raise STIXLoadingError(
+                'Error while loading STIX1 package: '
+                f'{_reduce_input_path(error.__str__(), filename)}'
+            ) from error

--- a/misp_stix_converter/tools/stix1_loading_helpers.py
+++ b/misp_stix_converter/tools/stix1_loading_helpers.py
@@ -2,6 +2,7 @@
 
 from .exceptions import STIXLoadingError, _reduce_input_path
 from mixbox.namespaces import NamespaceNotFoundError
+from pathlib import Path
 from stix.core import STIXPackage
 
 
@@ -20,6 +21,10 @@ def _update_namespaces():
 
 
 def load_stix1_package(filename, tries=0):
+    # lxml treats a plain string argument as a filename *or* a URL - resolving
+    # it here keeps `file://` targets out of the parser for every caller
+    if isinstance(filename, str):
+        filename = Path(filename).resolve()
     try:
         return STIXPackage.from_xml(filename)
     except NamespaceNotFoundError as error:
@@ -29,14 +34,23 @@ def load_stix1_package(filename, tries=0):
         return load_stix1_package(filename, tries + 1)
     except NotImplementedError as error:
         raise STIXLoadingError('Missing python library: stix_edh') from error
-    except Exception:
-        try:
-            import maec
-            return STIXPackage.from_xml(filename)
-        except ImportError as error:
-            raise STIXLoadingError('Missing python library: maec') from error
-        except Exception as error:
-            raise STIXLoadingError(
-                'Error while loading STIX1 package: '
-                f'{_reduce_input_path(error.__str__(), filename)}'
-            ) from error
+    except ImportError as error:
+        # `stix` imports optional parsing dependencies (e.g. `maec`) lazily
+        # during the parse itself, so a missing one surfaces here
+        raise STIXLoadingError(
+            f'Missing python library: {error.name or error}'
+        ) from error
+    except MemoryError:
+        # memory exhaustion must surface as what it is, not as a document
+        # loading error
+        raise
+    except OSError as error:
+        raise STIXLoadingError(
+            'Error while reading the STIX1 document: '
+            f'{_reduce_input_path(str(error), filename)}'
+        ) from error
+    except Exception as error:
+        raise STIXLoadingError(
+            'Error while loading STIX1 package: '
+            f'{_reduce_input_path(str(error), filename)}'
+        ) from error

--- a/misp_stix_converter/tools/stix2_loading_helpers.py
+++ b/misp_stix_converter/tools/stix2_loading_helpers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+from .exceptions import STIXLoadingError
 from io import BytesIO
 from stix2.exceptions import InvalidValueError, ParseError
 from stix2.parsing import dict_to_stix2, parse as stix2_parser
@@ -19,70 +20,94 @@ def _get_stix_content_version(stix_content: dict) -> str:
 
 
 def _handle_invalid_stix_content(invalid_objects, *stix_objects):
-    for stix_object in stix_objects:
+    for index, stix_object in enumerate(stix_objects):
         try:
             valid_object = stix2_parser(
                 stix_object, allow_custom=True, interoperability=True
             )
         except Exception:
-            invalid_objects[stix_object['id']] = stix_object
+            object_id = (
+                stix_object.get('id') if isinstance(stix_object, dict)
+                else None
+            )
+            if object_id is None:
+                raise STIXLoadingError(
+                    f"STIX object without an 'id' property at index {index}"
+                )
+            invalid_objects[object_id] = stix_object
             continue
         yield valid_object
 
 
 def _handle_stix2_loading_error(
         stix_content: dict,
-        invalid_objects: Optional[dict] = {}) -> _BUNDLE_TYPING:
+        invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
+    if invalid_objects is None:
+        invalid_objects = {}
+    if 'objects' not in stix_content:
+        raise STIXLoadingError(
+            "The STIX 2 content has no 'objects' property"
+        )
     version = _get_stix_content_version(stix_content)
-    if isinstance(stix_content, dict):
-        try:
-            if version == '2.1' and stix_content.get('spec_version') == '2.0':
-                del stix_content['spec_version']
-                return dict_to_stix2(
-                    stix_content, allow_custom=True, interoperability=True
-                )
-            elif version == '2.0' and stix_content.get('spec_version') == '2.1':
-                stix_content['spec_version'] = '2.0'
-                return dict_to_stix2(
-                    stix_content, allow_custom=True, interoperability=True
-                )
-        except Exception:
-            pass
+    try:
+        # the `spec_version` repair works on a copy so the caller's dict
+        # is never mutated
+        if version == '2.1' and stix_content.get('spec_version') == '2.0':
+            stix_content = dict(stix_content)
+            del stix_content['spec_version']
+            return dict_to_stix2(
+                stix_content, allow_custom=True, interoperability=True
+            )
+        elif version == '2.0' and stix_content.get('spec_version') == '2.1':
+            stix_content = dict(stix_content)
+            stix_content['spec_version'] = '2.0'
+            return dict_to_stix2(
+                stix_content, allow_custom=True, interoperability=True
+            )
+    except Exception:
+        pass
     bundle_id = stix_content.get('id')
     bundle = Bundle_v21 if version == '2.1' else Bundle_v20
-    if 'objects' in stix_content:
-        stix_content = stix_content['objects']
     return bundle(
-        *_handle_invalid_stix_content(invalid_objects, *stix_content),
+        *_handle_invalid_stix_content(invalid_objects, *stix_content['objects']),
         id=bundle_id, allow_custom=True, interoperability=True
     )
 
 
 def load_stix2_content(stix_content: BytesIO | dict | list | str,
-                       invalid_objects: Optional[dict] = {}) -> _BUNDLE_TYPING:
+                       invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
+    if invalid_objects is None:
+        invalid_objects = {}
     if isinstance(stix_content, dict):
         try:
-            return dict_to_stix2(
+            bundle = dict_to_stix2(
                 stix_content, allow_custom=True, interoperability=True
             )
-        except (InvalidValueError, ParseError, ValueError):
-            return _handle_stix2_loading_error(
+        except (InvalidValueError, KeyError, ParseError, ValueError):
+            # the 2.1 code path in `stix2` reports an object without a `type`
+            # property as a bare KeyError where the 2.0 one uses ParseError
+            bundle = _handle_stix2_loading_error(
                 stix_content, invalid_objects
             )
-    if isinstance(stix_content, BytesIO):
-        stix_content = stix_content.getvalue().decode('utf-8')
-    try:
-        return stix2_parser(
-            stix_content, allow_custom=True, interoperability=True
-        )
-    except (InvalidValueError, ParseError, ValueError):
-        return _handle_stix2_loading_error(
-            json.loads(stix_content), invalid_objects
-        )
+    else:
+        if isinstance(stix_content, BytesIO):
+            stix_content = stix_content.getvalue().decode('utf-8')
+        try:
+            bundle = stix2_parser(
+                stix_content, allow_custom=True, interoperability=True
+            )
+        except (InvalidValueError, KeyError, ParseError, ValueError):
+            bundle = _handle_stix2_loading_error(
+                json.loads(stix_content), invalid_objects
+            )
+    # keeps the recovered invalid objects with the bundle they came from, so
+    # `load_stix_bundle` sees them even when the caller does not pass the dict
+    bundle._invalid_objects = invalid_objects
+    return bundle
 
 
 def load_stix2_file(
-        filename, invalid_objects: Optional[dict] = {}) -> _BUNDLE_TYPING:
+        filename, invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
     with open(filename, 'rt', encoding='utf-8') as f:
         stix_content = f.read()
     return load_stix2_content(stix_content, invalid_objects)

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -73,6 +73,26 @@ class TestCollectionSTIX1Export(TestCollectionSTIXExport):
 
 
 class TestCollectionSTIX2Export(TestCollectionSTIXExport):
+    def _export_event_with_invalid_hash(self, version: str) -> dict:
+        # A `to_ids` file object with an invalid hash is recorded as an error
+        # and the hash is dropped: the partial failure a result dict has to
+        # report.
+        from misp_stix_converter import misp_to_stix2
+        from tempfile import TemporaryDirectory
+        from .test_events import get_event_with_file_object
+        event = get_event_with_file_object()
+        event['Event']['Object'][0]['Attribute'].append(
+            {
+                'type': 'tlsh', 'object_relation': 'tlsh',
+                'value': 'T1' + 'a1b2c3d4e5' * 7, 'to_ids': True
+            }
+        )
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'event_with_invalid_hash.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                json.dump(event, f)
+            return misp_to_stix2(filename, version=version)
+
     def _check_stix2_results_export(self, to_test_file, reference_file):
         with open(to_test_file, 'rt', encoding='utf-8') as f:
             to_test = json.load(f)

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -7,7 +7,9 @@ from collections import defaultdict
 from datetime import datetime
 from misp_stix_converter import (
     ExternalSTIX2Mapping, ExternalSTIX2toMISPParser, InternalSTIX2toMISPParser,
-    MISP_org_uuid)
+    MISP_org_uuid, stix_2_to_misp)
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from uuid import UUID, uuid5
 from ._test_stix import TestSTIX
 from .update_documentation import (
@@ -92,6 +94,31 @@ class TestSTIX2Bundles:
 
 class TestSTIX2Import(TestSTIX):
     _UUIDv4 = UUID('76beed5f-7251-457e-8c2a-b45f7b589d3d')
+
+    def _import_bundle_with_unloadable_objects(
+            self, bundle, count: int = 1, distinct_types: bool = True,
+            debug: bool = False) -> dict:
+        # Objects whose type has no loading mapping are recorded as errors and
+        # dropped: the partial failure a result dict has to report. With
+        # `distinct_types` unset they all share one type, so every dropped
+        # object produces the same error message.
+        content = json.loads(bundle.serialize())
+        content['objects'].extend(
+            {
+                'type': f'x-unloadable-type-{index if distinct_types else 0}',
+                'id': f'x-unloadable-type-{index if distinct_types else 0}'
+                      f'--2f2e4b1a-9f3d-4c5e-8a6b-0c1d2e3f4a{index:02d}',
+                'created': '2020-10-25T16:22:00.000Z',
+                'modified': '2020-10-25T16:22:00.000Z'
+            } for index in range(count)
+        )
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'unloadable.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                json.dump(content, f)
+            return stix_2_to_misp(
+                filename, debug=debug, output_dir=Path(tmp_dir)
+            )
 
     def _check_object_attribute_uuid(self, attr, object_id, value=None):
         self.assertEqual(

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -55,6 +55,51 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
                 )
             )
 
+    def test_stix20_parse_stix_content_raises_a_catchable_error(self):
+        # `parse_stix_content` called `sys.exit()` when loading failed -
+        # `SystemExit` derives from `BaseException`, so a caller's
+        # `except Exception` never saw it and one malformed document killed
+        # the hosting process.
+        from misp_stix_converter import STIXLoadingError
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'malformed.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write('{"not": "a bundle"')
+            with self.assertRaises(STIXLoadingError):
+                self.parser.parse_stix_content(filename)
+
+    def test_stix20_parsing_before_loading_raises_a_catchable_error(self):
+        # same `sys.exit()` class of defect on the call-order guard
+        from misp_stix_converter import MissingSTIXContentError
+        with self.assertRaises(MissingSTIXContentError):
+            self.parser.parse_stix_bundle()
+
+    def test_stix20_entry_point_returns_error_dict_when_parsing_fails(self):
+        # only the loading call was guarded - a crash in the parsing stage
+        # escaped `stix_2_to_misp` as a traceback instead of the documented
+        # error dict.
+        from misp_stix_converter import stix_2_to_misp
+        from misp_stix_converter.stix2misp.external_stix2_to_misp import (
+            ExternalSTIX2toMISPParser)
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'external.stix20.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with patch.object(
+                    ExternalSTIX2toMISPParser, 'parse_stix_bundle',
+                    side_effect=RuntimeError('parser stage crash')):
+                results = stix_2_to_misp(filename, output_dir=Path(tmp_dir))
+        self.assertNotIn('success', results)
+        self.assertTrue(
+            any('parser stage crash' in error for error in results['errors'])
+        )
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -100,6 +100,54 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             any('parser stage crash' in error for error in results['errors'])
         )
 
+    def test_stix20_dropped_objects_are_reported_without_debug(self):
+        # objects the parser failed to load were recorded as errors, but
+        # `_generate_traceback` only attached them when `debug` was set - the
+        # default result was a bare `{'success': 1}` for a conversion that
+        # dropped content, leaving no signal that the MISP event is an
+        # incomplete rendering of the bundle.
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        results = self._import_bundle_with_unloadable_objects(bundle)
+        self.assertTrue(
+            any(
+                'x-unloadable-type-0' in error
+                for error in results['errors'][bundle.id]
+            )
+        )
+
+    def test_stix20_debug_only_controls_the_errors_verbosity(self):
+        # `debug` selects how much detail is reported, not whether failures
+        # are reported at all: the default summary is deduplicated, capped -
+        # a hostile bundle can produce an error per object - and names the
+        # number of errors left out.
+        from misp_stix_converter.misp_stix_converter import (
+            _ERRORS_SUMMARY_LIMIT)
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        summary = self._import_bundle_with_unloadable_objects(
+            bundle, count=_ERRORS_SUMMARY_LIMIT
+        )['errors'][bundle.id]
+        detailed = self._import_bundle_with_unloadable_objects(
+            bundle, count=_ERRORS_SUMMARY_LIMIT, debug=True
+        )['errors'][bundle.id]
+        self.assertGreater(len(detailed), _ERRORS_SUMMARY_LIMIT)
+        self.assertEqual(len(summary), _ERRORS_SUMMARY_LIMIT + 1)
+        self.assertEqual(summary[:-1], detailed[:_ERRORS_SUMMARY_LIMIT])
+        self.assertIn(
+            f'{len(detailed) - _ERRORS_SUMMARY_LIMIT} more', summary[-1]
+        )
+        self.assertIn('debug', summary[-1])
+
+    def test_stix20_repeated_errors_are_summarised_with_their_count(self):
+        # deduplicating on the message alone made a bundle dropping a dozen
+        # objects read exactly like one dropping a single object: most error
+        # messages carry no object id, so how many times each happened is the
+        # only volume signal left in the default report.
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        errors = self._import_bundle_with_unloadable_objects(
+            bundle, count=12, distinct_types=False
+        )['errors'][bundle.id]
+        self.assertTrue(all('(12 times)' in error for error in errors))
+
     def test_stix20_content_without_objects_produces_a_meaningful_error(self):
         # the fallback loading path read `stix_content['objects']` unguarded -
         # a document without an `objects` property surfaced as the bare

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -100,6 +100,160 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             any('parser stage crash' in error for error in results['errors'])
         )
 
+    def test_stix20_content_without_objects_produces_a_meaningful_error(self):
+        # the fallback loading path read `stix_content['objects']` unguarded -
+        # a document without an `objects` property surfaced as the bare
+        # string `'objects'`, indistinguishable from a STIX field problem.
+        from misp_stix_converter import STIXLoadingError
+        from misp_stix_converter.tools import load_stix2_content
+        with self.assertRaises(STIXLoadingError) as context:
+            load_stix2_content('{"foo": "bar"}')
+        self.assertIn("no 'objects' property", str(context.exception))
+
+    def test_stix20_fallback_object_without_id_is_located_in_the_error(self):
+        # recovering the valid objects one by one indexed the invalid ones
+        # with `stix_object['id']` - an object without an `id` property
+        # crashed the recovery with `KeyError: 'id'` raised from inside an
+        # except handler, instead of locating the object.
+        from misp_stix_converter import STIXLoadingError
+        from misp_stix_converter.tools import load_stix2_content
+        with self.assertRaises(STIXLoadingError) as context:
+            load_stix2_content(
+                {
+                    'type': 'bundle',
+                    'id': 'bundle--4d3f5e19-9c11-42b5-9b93-6337d443f0f1',
+                    'spec_version': '2.0',
+                    'objects': [
+                        {
+                            'type': 'identity',
+                            'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'name': 'CIRCL',
+                            'identity_class': 'organization'
+                        },
+                        {'foo': 'bar'}
+                    ]
+                }
+            )
+        error_message = str(context.exception)
+        self.assertIn("'id'", error_message)
+        self.assertIn('index 1', error_message)
+
+    def test_stix20_repeated_loads_share_no_invalid_objects_state(self):
+        # the `invalid_objects={}` mutable defaults shared a single dict
+        # across every call that omitted the argument - attacker-supplied
+        # objects accumulated for the process lifetime and references from
+        # a later document resolved against an earlier, unrelated one.
+        from misp_stix_converter.tools import load_stix2_content
+        first_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        second_id = 'indicator--b6f1a83b-6d92-40dc-83b3-e575a04a5c29'
+        bundles = {
+            first_id: 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            second_id: 'bundle--6a99f66a-8d92-4653-a481-b7cbeef97e95'
+        }
+        _, second = (
+            load_stix2_content(
+                {
+                    'type': 'bundle',
+                    'id': bundle_id,
+                    'spec_version': '2.0',
+                    'objects': [
+                        {
+                            'type': 'identity',
+                            'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'name': 'CIRCL',
+                            'identity_class': 'organization'
+                        },
+                        {
+                            'type': 'indicator',
+                            'id': indicator_id,
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'labels': ['malicious-activity'],
+                            'pattern': 'NOT A VALID PATTERN',
+                            'valid_from': '2020-10-25T16:22:00.000Z'
+                        }
+                    ]
+                }
+            ) for indicator_id, bundle_id in bundles.items()
+        )
+        self.parser.load_stix_bundle(second)
+        self.assertIn(second_id, self.parser.invalid_objects)
+        self.assertNotIn(first_id, self.parser.invalid_objects)
+
+    def test_stix20_parser_inherits_the_invalid_objects_from_the_loader(self):
+        # `load_stix2_file` populated its own `invalid_objects` dict, but
+        # `load_stix_bundle` created another one when the argument was
+        # omitted - the documented sequence of both calls silently lost the
+        # objects the loader had recovered.
+        from misp_stix_converter.tools import load_stix2_file
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        import json
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        stix_content = {
+            'type': 'bundle',
+            'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            'spec_version': '2.0',
+            'objects': [
+                {
+                    'type': 'identity',
+                    'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'name': 'CIRCL',
+                    'identity_class': 'organization'
+                },
+                {
+                    'type': 'indicator',
+                    'id': indicator_id,
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'labels': ['malicious-activity'],
+                    'pattern': 'NOT A VALID PATTERN',
+                    'valid_from': '2020-10-25T16:22:00.000Z'
+                }
+            ]
+        }
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'invalid_indicator.stix20.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                json.dump(stix_content, f)
+            bundle = load_stix2_file(filename)
+        self.parser.load_stix_bundle(bundle)
+        self.assertIn(indicator_id, self.parser.invalid_objects)
+
+    def test_stix20_loading_does_not_mutate_the_caller_content(self):
+        # recovering from a `spec_version` mismatch deleted the property on
+        # the dict the caller passed in - a surprising side effect for a
+        # function named `load`.
+        from copy import deepcopy
+        from misp_stix_converter.tools import load_stix2_content
+        stix_content = {
+            'type': 'bundle',
+            'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            'spec_version': '2.0',
+            'objects': [
+                {
+                    'type': 'indicator',
+                    'id': 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e',
+                    'spec_version': '2.1',
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'labels': ['malicious-activity'],
+                    'pattern': 'NOT A VALID PATTERN',
+                    'pattern_type': 'stix',
+                    'valid_from': '2020-10-25T16:22:00.000Z'
+                }
+            ]
+        }
+        original = deepcopy(stix_content)
+        load_stix2_content(stix_content)
+        self.assertEqual(stix_content, original)
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -111,6 +111,91 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             any('parser stage crash' in error for error in results['errors'])
         )
 
+    def test_stix21_dropped_objects_are_reported_without_debug(self):
+        # objects the parser failed to load were recorded as errors, but
+        # `_generate_traceback` only attached them when `debug` was set - the
+        # default result was a bare `{'success': 1}` for a conversion that
+        # dropped content, leaving no signal that the MISP event is an
+        # incomplete rendering of the bundle.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        results = self._import_bundle_with_unloadable_objects(bundle)
+        self.assertTrue(
+            any(
+                'x-unloadable-type-0' in error
+                for error in results['errors'][bundle.id]
+            )
+        )
+
+    def test_stix21_debug_only_controls_the_errors_verbosity(self):
+        # `debug` selects how much detail is reported, not whether failures
+        # are reported at all: the default summary is deduplicated, capped -
+        # a hostile bundle can produce an error per object - and names the
+        # number of errors left out.
+        from misp_stix_converter.misp_stix_converter import (
+            _ERRORS_SUMMARY_LIMIT)
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        summary = self._import_bundle_with_unloadable_objects(
+            bundle, count=_ERRORS_SUMMARY_LIMIT
+        )['errors'][bundle.id]
+        detailed = self._import_bundle_with_unloadable_objects(
+            bundle, count=_ERRORS_SUMMARY_LIMIT, debug=True
+        )['errors'][bundle.id]
+        self.assertGreater(len(detailed), _ERRORS_SUMMARY_LIMIT)
+        self.assertEqual(len(summary), _ERRORS_SUMMARY_LIMIT + 1)
+        self.assertEqual(summary[:-1], detailed[:_ERRORS_SUMMARY_LIMIT])
+        self.assertIn(
+            f'{len(detailed) - _ERRORS_SUMMARY_LIMIT} more', summary[-1]
+        )
+        self.assertIn('debug', summary[-1])
+
+    def test_stix2_cli_aggregation_keeps_both_errors_and_warnings(self):
+        # the CLI aggregation wrote errors then warnings into the same `fails`
+        # entry, keyed on the same identifier - now that both are reported
+        # without `debug`, the warnings overwrote the errors this ticket
+        # exists to surface.
+        from misp_stix_converter.misp_stix_converter import (
+            _process_stix_to_misp_instance)
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        identifier = 'bundle--5b8e0f9a-0000-4000-8000-0000000000e1'
+        traceback = {
+            'pymisp_errors': {identifier: 'MISP refused the event'},
+            'errors': {identifier: ['Unable to load STIX object type: x-nope']},
+            'warnings': {identifier: ['The Internal parser was selected']}
+        }
+        args = SimpleNamespace(
+            classification=None, cluster_distribution=0,
+            cluster_sharing_group=None, debug=False, distribution=0,
+            file=[Path('bundle.json')], galaxies_as_tags=False,
+            no_force_contextual_data=False, org_uuid=MISP_org_uuid,
+            producer=None, sharing_group=None, single_event=False,
+            title=None, version='2'
+        )
+        with patch(
+                'misp_stix_converter.misp_stix_converter.'
+                '_get_stix_ingestion_method',
+                return_value=lambda *_, **__: traceback):
+            results = _process_stix_to_misp_instance(None, args)
+        self.assertEqual(
+            results['fails'][identifier],
+            (
+                'Unable to load STIX object type: x-nope',
+                'The Internal parser was selected'
+            )
+        )
+
+    def test_stix21_repeated_errors_are_summarised_with_their_count(self):
+        # deduplicating on the message alone made a bundle dropping a dozen
+        # objects read exactly like one dropping a single object: most error
+        # messages carry no object id, so how many times each happened is the
+        # only volume signal left in the default report.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        errors = self._import_bundle_with_unloadable_objects(
+            bundle, count=12, distinct_types=False
+        )['errors'][bundle.id]
+        self.assertTrue(all('(12 times)' in error for error in errors))
+
     def test_stix21_content_without_objects_produces_a_meaningful_error(self):
         # the fallback loading path read `stix_content['objects']` unguarded -
         # a document without an `objects` property surfaced as the bare

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -66,6 +66,51 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self.assertNotIn('errors', results)
         self.assertEqual(results['success'], 1)
 
+    def test_stix21_parse_stix_content_raises_a_catchable_error(self):
+        # `parse_stix_content` called `sys.exit()` when loading failed -
+        # `SystemExit` derives from `BaseException`, so a caller's
+        # `except Exception` never saw it and one malformed document killed
+        # the hosting process.
+        from misp_stix_converter import STIXLoadingError
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'malformed.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write('{"not": "a bundle"')
+            with self.assertRaises(STIXLoadingError):
+                self.parser.parse_stix_content(filename)
+
+    def test_stix21_parsing_before_loading_raises_a_catchable_error(self):
+        # same `sys.exit()` class of defect on the call-order guard
+        from misp_stix_converter import MissingSTIXContentError
+        with self.assertRaises(MissingSTIXContentError):
+            self.parser.parse_stix_bundle()
+
+    def test_stix21_entry_point_returns_error_dict_when_parsing_fails(self):
+        # only the loading call was guarded - a crash in the parsing stage
+        # escaped `stix_2_to_misp` as a traceback instead of the documented
+        # error dict.
+        from misp_stix_converter import stix_2_to_misp
+        from misp_stix_converter.stix2misp.external_stix2_to_misp import (
+            ExternalSTIX2toMISPParser)
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'external.stix21.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with patch.object(
+                    ExternalSTIX2toMISPParser, 'parse_stix_bundle',
+                    side_effect=RuntimeError('parser stage crash')):
+                results = stix_2_to_misp(filename, output_dir=Path(tmp_dir))
+        self.assertNotIn('success', results)
+        self.assertTrue(
+            any('parser stage crash' in error for error in results['errors'])
+        )
+
     def test_stix21_classification_forced_internal_warns_on_mismatch(self):
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -111,6 +111,160 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             any('parser stage crash' in error for error in results['errors'])
         )
 
+    def test_stix21_content_without_objects_produces_a_meaningful_error(self):
+        # the fallback loading path read `stix_content['objects']` unguarded -
+        # a document without an `objects` property surfaced as the bare
+        # string `'objects'`, indistinguishable from a STIX field problem.
+        from misp_stix_converter import STIXLoadingError
+        from misp_stix_converter.tools import load_stix2_content
+        with self.assertRaises(STIXLoadingError) as context:
+            load_stix2_content('{"foo": "bar"}')
+        self.assertIn("no 'objects' property", str(context.exception))
+
+    def test_stix21_fallback_object_without_id_is_located_in_the_error(self):
+        # recovering the valid objects one by one indexed the invalid ones
+        # with `stix_object['id']` - an object without an `id` property
+        # crashed the recovery with `KeyError: 'id'` raised from inside an
+        # except handler, instead of locating the object.
+        from misp_stix_converter import STIXLoadingError
+        from misp_stix_converter.tools import load_stix2_content
+        with self.assertRaises(STIXLoadingError) as context:
+            load_stix2_content(
+                {
+                    'type': 'bundle',
+                    'id': 'bundle--4d3f5e19-9c11-42b5-9b93-6337d443f0f1',
+                    'objects': [
+                        {
+                            'type': 'identity',
+                            'spec_version': '2.1',
+                            'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'name': 'CIRCL',
+                            'identity_class': 'organization'
+                        },
+                        {'foo': 'bar'}
+                    ]
+                }
+            )
+        error_message = str(context.exception)
+        self.assertIn("'id'", error_message)
+        self.assertIn('index 1', error_message)
+
+    def test_stix21_repeated_loads_share_no_invalid_objects_state(self):
+        # the `invalid_objects={}` mutable defaults shared a single dict
+        # across every call that omitted the argument - attacker-supplied
+        # objects accumulated for the process lifetime and references from
+        # a later document resolved against an earlier, unrelated one.
+        from misp_stix_converter.tools import load_stix2_content
+        first_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        second_id = 'indicator--b6f1a83b-6d92-40dc-83b3-e575a04a5c29'
+        bundles = {
+            first_id: 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            second_id: 'bundle--6a99f66a-8d92-4653-a481-b7cbeef97e95'
+        }
+        _, second = (
+            load_stix2_content(
+                {
+                    'type': 'bundle',
+                    'id': bundle_id,
+                    'objects': [
+                        {
+                            'type': 'identity',
+                            'spec_version': '2.1',
+                            'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'name': 'CIRCL',
+                            'identity_class': 'organization'
+                        },
+                        {
+                            'type': 'indicator',
+                            'spec_version': '2.1',
+                            'id': indicator_id,
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'pattern': 'NOT A VALID PATTERN',
+                            'pattern_type': 'stix',
+                            'valid_from': '2020-10-25T16:22:00.000Z'
+                        }
+                    ]
+                }
+            ) for indicator_id, bundle_id in bundles.items()
+        )
+        self.parser.load_stix_bundle(second)
+        self.assertIn(second_id, self.parser.invalid_objects)
+        self.assertNotIn(first_id, self.parser.invalid_objects)
+
+    def test_stix21_parser_inherits_the_invalid_objects_from_the_loader(self):
+        # `load_stix2_file` populated its own `invalid_objects` dict, but
+        # `load_stix_bundle` created another one when the argument was
+        # omitted - the documented sequence of both calls silently lost the
+        # objects the loader had recovered.
+        from misp_stix_converter.tools import load_stix2_file
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        import json
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        stix_content = {
+            'type': 'bundle',
+            'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            'objects': [
+                {
+                    'type': 'identity',
+                    'spec_version': '2.1',
+                    'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'name': 'CIRCL',
+                    'identity_class': 'organization'
+                },
+                {
+                    'type': 'indicator',
+                    'spec_version': '2.1',
+                    'id': indicator_id,
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'pattern': 'NOT A VALID PATTERN',
+                    'pattern_type': 'stix',
+                    'valid_from': '2020-10-25T16:22:00.000Z'
+                }
+            ]
+        }
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'invalid_indicator.stix21.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                json.dump(stix_content, f)
+            bundle = load_stix2_file(filename)
+        self.parser.load_stix_bundle(bundle)
+        self.assertIn(indicator_id, self.parser.invalid_objects)
+
+    def test_stix21_loading_does_not_mutate_the_caller_content(self):
+        # recovering from a `spec_version` mismatch reassigned the property
+        # on the dict the caller passed in - a surprising side effect for a
+        # function named `load`.
+        from copy import deepcopy
+        from misp_stix_converter.tools import load_stix2_content
+        stix_content = {
+            'type': 'bundle',
+            'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+            'spec_version': '2.1',
+            'objects': [
+                {
+                    'type': 'indicator',
+                    'id': 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e',
+                    'created': '2020-10-25T16:22:00.000Z',
+                    'modified': '2020-10-25T16:22:00.000Z',
+                    'labels': ['malicious-activity'],
+                    'pattern': 'NOT A VALID PATTERN',
+                    'valid_from': '2020-10-25T16:22:00.000Z'
+                }
+            ]
+        }
+        original = deepcopy(stix_content)
+        load_stix2_content(stix_content)
+        self.assertEqual(stix_content, original)
+
     def test_stix21_classification_forced_internal_warns_on_mismatch(self):
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -4,11 +4,13 @@
 from cybox.core import Object, Observable, Observables, RelatedObject
 from cybox.objects.domain_name_object import DomainName
 from cybox.objects.file_object import File
-from misp_stix_converter import stix_1_to_misp
+from misp_stix_converter import stix_1_to_misp, STIXLoadingError
+from misp_stix_converter.tools import load_stix1_package
 from misp_stix_converter.stix2misp.external_stix1_to_misp import (
     ExternalSTIX1toMISPParser)
 from misp_stix_converter.stix2misp.internal_stix1_to_misp import (
     InternalSTIX1toMISPParser)
+from unittest.mock import patch
 from stix.coa import CourseOfAction, Objective
 from stix.common import Statement
 from stix.common.related import RelatedPackage, RelatedPackages
@@ -219,6 +221,48 @@ class TestSTIX1Import(TestSTIX):
             results = stix_1_to_misp(filename, single_event=True)
         self.assertNotIn('errors', results)
         self.assertEqual(results['success'], 1)
+
+    ############################################################################
+    #                          ERROR HANDLING TESTS.                           #
+    ############################################################################
+
+    def test_load_stix1_package_raises_a_catchable_error(self):
+        """The loader called `sys.exit()` on malformed content - `SystemExit`
+        derives from `BaseException`, so a caller's `except Exception` never
+        saw it and one hostile document killed the hosting process."""
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'malformed.xml'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write('<not-stix>not a STIX package</not-stix')
+            with self.assertRaises(STIXLoadingError):
+                load_stix1_package(filename)
+
+    def test_stix_1_to_misp_returns_error_dict_on_malformed_content(self):
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'malformed.xml'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write('not even xml')
+            results = stix_1_to_misp(filename)
+        self.assertIn('errors', results)
+
+    def test_stix_1_to_misp_returns_error_dict_when_parsing_fails(self):
+        """Only the loading call was guarded - a crash in the parsing stage
+        escaped `stix_1_to_misp` as a traceback instead of the documented
+        error dict."""
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'course_of_action.xml'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(stix_package.to_xml().decode())
+            with patch.object(
+                    ExternalSTIX1toMISPParser, 'parse_stix_package',
+                    side_effect=RuntimeError('parser stage crash')):
+                results = stix_1_to_misp(filename, single_event=True)
+        self.assertNotIn('success', results)
+        self.assertTrue(
+            any('parser stage crash' in error for error in results['errors'])
+        )
 
     ############################################################################
     #                         CLASSIFICATION OVERRIDE.                         #

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -5,7 +5,8 @@ from cybox.core import Object, Observable, Observables, RelatedObject
 from cybox.objects.domain_name_object import DomainName
 from cybox.objects.file_object import File
 from misp_stix_converter import stix_1_to_misp, STIXLoadingError
-from misp_stix_converter.tools import load_stix1_package
+from misp_stix_converter.tools import load_stix1_package, stix1_loading_helpers
+from mixbox.namespaces import NamespaceNotFoundError
 from misp_stix_converter.stix2misp.external_stix1_to_misp import (
     ExternalSTIX1toMISPParser)
 from misp_stix_converter.stix2misp.internal_stix1_to_misp import (
@@ -93,6 +94,13 @@ class TestSTIX1Import(TestSTIX):
         header = STIXHeader()
         header.title = title
         return header
+
+    @staticmethod
+    def _write_package(tmp_dir, stix_package, name='package.xml'):
+        filename = Path(tmp_dir) / name
+        with open(filename, 'wt', encoding='utf-8') as f:
+            f.write(stix_package.to_xml().decode())
+        return filename
 
     @classmethod
     def _internal_package(cls, incident, inner_title=None, outer_title=None):
@@ -215,9 +223,9 @@ class TestSTIX1Import(TestSTIX):
         stix_package = STIXPackage()
         stix_package.add_course_of_action(self._course_of_action())
         with TemporaryDirectory() as tmp_dir:
-            filename = Path(tmp_dir) / 'course_of_action.xml'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(stix_package.to_xml().decode())
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
             results = stix_1_to_misp(filename, single_event=True)
         self.assertNotIn('errors', results)
         self.assertEqual(results['success'], 1)
@@ -237,6 +245,130 @@ class TestSTIX1Import(TestSTIX):
             with self.assertRaises(STIXLoadingError):
                 load_stix1_package(filename)
 
+    def test_load_stix1_package_does_not_honour_file_url_strings(self):
+        """lxml treats a plain string argument as a filename *or* a URL, so a
+        `file://` string turned a conversion request into a local file read.
+        String input is now resolved to a `Path` first, like the top-level
+        helpers already did."""
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            with self.assertRaises(STIXLoadingError):
+                load_stix1_package(f'file://{filename}')
+
+    def test_parse_stix_content_does_not_honour_file_url_strings(self):
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            parser = ExternalSTIX1toMISPParser()
+            with self.assertRaises(STIXLoadingError):
+                parser.parse_stix_content(f'file://{filename}')
+
+    def test_parse_stix_content_accepts_a_plain_path_string(self):
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            parser = ExternalSTIX1toMISPParser()
+            parser.parse_stix_content(str(filename))
+        self.assertEqual(len(parser.misp_event.objects), 1)
+
+    def test_load_stix1_package_parses_a_failing_document_exactly_once(self):
+        """A document engineered to be expensive to parse and then fail was
+        parsed twice: the generic fallback imported `maec` and retried, even
+        though a successful `import maec` never changes the parse outcome -
+        `stix` imports it lazily during the first attempt when it is needed."""
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=ValueError('generic parse failure')) as from_xml:
+            with self.assertRaises(STIXLoadingError) as context:
+                load_stix1_package('input.xml')
+        self.assertEqual(from_xml.call_count, 1)
+        self.assertIn('generic parse failure', str(context.exception))
+
+    def test_load_stix1_package_retries_once_for_unregistered_namespaces(self):
+        stix_package = STIXPackage()
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=[
+                    NamespaceNotFoundError('http://us-cert.gov/ciscp'),
+                    stix_package
+                ]) as from_xml:
+            self.assertIs(load_stix1_package('input.xml'), stix_package)
+        self.assertEqual(from_xml.call_count, 2)
+
+    def test_load_stix1_package_namespace_retry_is_bounded(self):
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=NamespaceNotFoundError(
+                    'http://unknown.namespace')) as from_xml:
+            with self.assertRaises(STIXLoadingError) as context:
+                load_stix1_package('input.xml')
+        self.assertEqual(from_xml.call_count, 2)
+        self.assertIn('Cannot handle STIX namespace', str(context.exception))
+
+    def test_load_stix1_package_propagates_memory_error(self):
+        """`MemoryError` from a memory bomb was swallowed into the generic
+        retry - the document was parsed a second time and the exhaustion
+        reported as a plain loading error."""
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=MemoryError()) as from_xml:
+            with self.assertRaises(MemoryError):
+                load_stix1_package('input.xml')
+        self.assertEqual(from_xml.call_count, 1)
+
+    def test_load_stix1_package_reports_io_errors_without_retry(self):
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=OSError('Error reading file')) as from_xml:
+            with self.assertRaises(STIXLoadingError) as context:
+                load_stix1_package('input.xml')
+        self.assertEqual(from_xml.call_count, 1)
+        self.assertIn(
+            'Error while reading the STIX1 document', str(context.exception)
+        )
+
+    def test_load_stix1_package_reports_a_missing_parsing_dependency(self):
+        """`stix` raises `ImportError` from its lazy `maec` import when the
+        library is missing - the loader turns it into the diagnostic the old
+        import-and-retry fallback existed to produce."""
+        with patch.object(
+                stix1_loading_helpers.STIXPackage, 'from_xml',
+                side_effect=ModuleNotFoundError(
+                    "No module named 'maec'", name='maec')) as from_xml:
+            with self.assertRaises(STIXLoadingError) as context:
+                load_stix1_package('input.xml')
+        self.assertEqual(from_xml.call_count, 1)
+        self.assertEqual(
+            str(context.exception), 'Missing python library: maec'
+        )
+
+    def test_load_stix1_package_loads_maec_carrying_documents(self):
+        """MAEC support must survive the removal of the import-and-retry
+        fallback: `stix` imports `maec` on its own during the first parse."""
+        from maec.package.package import Package as MAECPackage
+        from stix.extensions.malware.maec_4_1_malware import MAECInstance
+        from stix.ttp import TTP, Behavior
+        ttp = TTP(title='MAEC carrying TTP')
+        behavior = Behavior()
+        behavior.add_malware_instance(MAECInstance(MAECPackage()))
+        ttp.behavior = behavior
+        stix_package = STIXPackage()
+        stix_package.add_ttp(ttp)
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(tmp_dir, stix_package, 'maec_ttp.xml')
+            package = load_stix1_package(filename)
+        self.assertEqual(package.ttps.ttp[0].title, 'MAEC carrying TTP')
+
     def test_stix_1_to_misp_returns_error_dict_on_malformed_content(self):
         with TemporaryDirectory() as tmp_dir:
             filename = Path(tmp_dir) / 'malformed.xml'
@@ -252,9 +384,9 @@ class TestSTIX1Import(TestSTIX):
         stix_package = STIXPackage()
         stix_package.add_course_of_action(self._course_of_action())
         with TemporaryDirectory() as tmp_dir:
-            filename = Path(tmp_dir) / 'course_of_action.xml'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(stix_package.to_xml().decode())
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
             with patch.object(
                     ExternalSTIX1toMISPParser, 'parse_stix_package',
                     side_effect=RuntimeError('parser stage crash')):
@@ -280,9 +412,7 @@ class TestSTIX1Import(TestSTIX):
     def test_stix_1_classification_auto_detection_warns_and_explicit_is_silent(self):
         stix_package = self._internal_titled_package()
         with TemporaryDirectory() as tmp_dir:
-            filename = Path(tmp_dir) / 'internal.xml'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(stix_package.to_xml().decode())
+            filename = self._write_package(tmp_dir, stix_package, 'internal.xml')
             results = stix_1_to_misp(filename, single_event=True)
             self.assertEqual(results['success'], 1)
             self.assertTrue(
@@ -301,9 +431,7 @@ class TestSTIX1Import(TestSTIX):
     def test_stix_1_classification_forced_external_warns_on_mismatch(self):
         stix_package = self._internal_titled_package()
         with TemporaryDirectory() as tmp_dir:
-            filename = Path(tmp_dir) / 'internal.xml'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(stix_package.to_xml().decode())
+            filename = self._write_package(tmp_dir, stix_package, 'internal.xml')
             results = stix_1_to_misp(
                 filename, single_event=True, classification='external'
             )

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -5585,6 +5585,21 @@ class TestSTIX20MISPExportInteroperability(TestSTIX20ExportInteroperability):
 
 
 class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
+    def test_export_reports_dropped_content_without_debug(self):
+        # export records an error for every attribute or object it could not
+        # convert, but `_generate_traceback` only attached them when `debug`
+        # was set - the default result claimed a plain success for a bundle
+        # rendering only part of the event.
+        results = self._export_event_with_invalid_hash('2.0')
+        self.assertEqual(results['success'], 1)
+        self.assertTrue(
+            any(
+                'Invalid TLSH value' in error
+                for errors in results['errors'].values()
+                for error in errors
+            )
+        )
+
     def test_attributes_collection(self):
         name = 'test_attributes_collection'
         output_file = self._current_path / f'{name}.json.out'

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -6788,6 +6788,21 @@ class TestSTIX21MISPExportInteroperability(TestSTIX21ExportInteroperability):
 
 
 class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
+    def test_export_reports_dropped_content_without_debug(self):
+        # export records an error for every attribute or object it could not
+        # convert, but `_generate_traceback` only attached them when `debug`
+        # was set - the default result claimed a plain success for a bundle
+        # rendering only part of the event.
+        results = self._export_event_with_invalid_hash('2.1')
+        self.assertEqual(results['success'], 1)
+        self.assertTrue(
+            any(
+                'Invalid TLSH value' in error
+                for errors in results['errors'].values()
+                for error in errors
+            )
+        )
+
     def test_attributes_collection(self):
         name = 'test_attributes_collection'
         output_file = self._current_path / f'{name}.json.out'


### PR DESCRIPTION
## What changed

  - **`sys.exit()` in library code (#88).** `SystemExit` derives from `BaseException`, so a caller's `except Exception` never saw a loading
  failure and one malformed document could kill a long-lived importer process. Loading failures now raise the exported `STIXLoadingError`,
  parsing before loading raises `MissingSTIXContentError`, and the import entry functions guard the whole conversion — detection, parser
  construction and parsing — returning the documented error dict.
  - **STIX 2 loading helpers (#89).** A document without an `objects` property, or with an object missing its `id`, surfaced as the bare
  strings `'objects'` / `'id'`; a typeless object escaped as a raw `KeyError` on the 2.1 path. Mutable `invalid_objects={}` defaults shared
  one dict across every call for the process lifetime, and recovering from a `spec_version` mismatch mutated the caller's dict.
  - **STIX 1 loader (#90).** lxml treats a plain string as a filename or URL, so an untrusted `file://` string turned a conversion request
  into a local file read — string input is resolved to a `Path` at loader entry now. The import-maec-and-retry fallback parsed hostile
  documents twice for no change in outcome and swallowed I/O errors and `MemoryError`; only the unregistered-namespace case re-parses.
  - **Errors hidden behind `debug` (#104).** A conversion that dropped objects returned a bare `{'success': 1}` unless the caller asked for
  `debug`, so an operator had no signal that the MISP event or STIX bundle was an incomplete rendering of what was sent.

  ## Behaviour worth reviewing on the consumer side

  - A result dict may now carry `errors` (and `warnings`) **next to** `success` = 1 — partial success is reported rather than hidden.
  Consumers that treat the presence of `errors` as a hard failure will want a look.
  - `debug` / `--debug` now selects the errors detail level, never whether failures are reported: by default each distinct message appears
  once with the number of times it happened (most messages carry no object id, so volume is the only remaining signal), capped at ten messages
  per identifier with a final entry naming how many were left out.
  - The CLI aggregation used to overwrite an identifier's errors with its warnings — harmless while errors were debug-gated, a regression once
  both are unconditional.
  - Loading failures now raise instead of exiting the process; direct callers of the loading helpers need an `except` where `sys.exit()` used
  to end things.

  ## Testing

  Full suite green locally (1842 tests). New coverage is symmetric across 2.0/2.1 for the shared behaviour, and includes the STIX 1 loader
  path handling, the loader state hygiene, and both axes of the error reporting (presence without `debug`, detail with it).

  ## Known gaps, deliberately out of scope

  - The `except` paths returning `{'fails': [...]}` and collection paths that wrote no output still discard errors recorded before the
  exception. Those results do carry a failure signal, so they are not the silent-success gap #104 names.
  - A dangling `object_ref` in a Report/Grouping is still dropped in complete silence — same class as #91, better handled with it.

  Fixes #88
  Fixes #89
  Fixes #90
  Fixes #104