### PR TITLE
Import hardening: template names, galaxy labels, duplicate ids, dict-form objects

### DIFF
--- a/misp_stix_converter/misp2stix/exportparser.py
+++ b/misp_stix_converter/misp2stix/exportparser.py
@@ -4,6 +4,8 @@
 import json
 import traceback
 from ..abstract import AbstractParser
+from ..tools.misp_object_templates import (
+    _rejected_name_note, _sanitise_template_name, _UNKNOWN_TEMPLATE_NAME)
 from .stix1_mapping import MISPtoSTIX1Mapping
 from .stix20_mapping import MISPtoSTIX20Mapping
 from .stix21_mapping import MISPtoSTIX21Mapping
@@ -11,9 +13,9 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from io import BufferedIOBase, TextIOBase
 from pathlib import Path
-from pymisp import MISPAttribute, MISPObject
+from pymisp import MISPAttribute, MISPEvent, MISPObject
 from stix2.hashes import Hash
-from typing import IO, Optional, Union
+from typing import Any, IO, Optional, Union
 
 
 class MISPtoSTIXParser(AbstractParser):
@@ -227,6 +229,64 @@ class MISPtoSTIXParser(AbstractParser):
             for cluster in galaxy["GalaxyCluster"]
         )
 
+    def _sanitise_event_object_names(
+            self, misp_event: Union[MISPEvent, dict]) -> Union[MISPEvent, dict]:
+        """Keep the object names of an event out of template resolution.
+
+        :param misp_event: MISP event, only handled in its dictionary form
+        :return: the event, with any unusable object name replaced
+        """
+        if not isinstance(misp_event, dict):
+            return misp_event
+        event = misp_event.get('Event', misp_event)
+        objects = event.get('Object') if isinstance(event, dict) else None
+        if not isinstance(objects, list):
+            return misp_event
+        # An event with no uuid of its own is only identified once pymisp has
+        # generated one: file under the default rather than under whichever
+        # event came before this one in a collection.
+        identifier = event.get('uuid') or 'misp event'
+        sanitised = [
+            self._sanitise_object_template_name(misp_object, identifier)
+            for misp_object in objects
+        ]
+        # Nothing to replace: every object came back as the very same one.
+        if all(new is old for new, old in zip(sanitised, objects)):
+            return misp_event
+        event = {**event, 'Object': sanitised}
+        return (
+            {**misp_event, 'Event': event} if 'Event' in misp_event else event
+        )
+
+    def _sanitise_object_template_name(
+            self, misp_object: Union[MISPObject, dict],
+            identifier: Optional[str] = None) -> Union[MISPObject, dict]:
+        """Keep an object name out of pymisp's template resolution.
+
+        A name that is not a plain template name is joined into a filesystem
+        path when pymisp looks the template up, so a name stored in an event -
+        which may have been written there by imported content - is replaced
+        before the object reaches that lookup.
+
+        :param misp_object: MISP object, only handled in its dictionary form
+        :param identifier: identifier the warning is filed under
+        :return: the object, with an unusable name replaced, kept as data
+        """
+        if not isinstance(misp_object, dict) or 'name' not in misp_object:
+            return misp_object
+        name, rejected_name = _sanitise_template_name(misp_object['name'])
+        if rejected_name is None:
+            return misp_object
+        self._invalid_object_template_name_warning(rejected_name, identifier)
+        # Nothing is silently dropped: the name the object cannot carry is
+        # kept as data, as it is on the import side.
+        note = _rejected_name_note(rejected_name)
+        comment = misp_object.get('comment')
+        return {
+            **misp_object, 'name': name,
+            'comment': f'{comment}\n{note}' if comment else note
+        }
+
     @staticmethod
     def _select_single_feature(
             attributes: dict, feature: str) -> Union[str, tuple]:
@@ -301,6 +361,13 @@ class MISPtoSTIXParser(AbstractParser):
         )
         if error not in self.errors[self.identifier]:
             self._add_error(error)
+
+    def _invalid_object_template_name_warning(
+            self, name: Any, identifier: Optional[str] = None):
+        self._add_warning(
+            f'Invalid MISP object template name {name!r}: the object is '
+            f'converted as a {_UNKNOWN_TEMPLATE_NAME} one.', identifier
+        )
 
     def _event_galaxy_not_mapped_warning(self, galaxy_type: str):
         self._add_warning(

--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -155,14 +155,21 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
             misp_object = misp_object['Object']
         errors = defaultdict(list)
         if isinstance(misp_object, list):
-            for obj in validate_objects(misp_object, errors):
+            objects = [
+                self._sanitise_object_template_name(obj) for obj in misp_object
+            ]
+            for obj in validate_objects(objects, errors):
                 self._bind_shared_args(
                     self._handle_identity_from_feed(obj.get('Event', event))
                 )
                 self._resolve_object(obj)
         else:
             self._bind_shared_args(self._handle_identity_from_feed(event))
-            self._resolve_object(validate_object(misp_object, errors))
+            self._resolve_object(
+                validate_object(
+                    self._sanitise_object_template_name(misp_object), errors
+                )
+            )
         if errors:
             self._handle_validation_errors(errors)
         if self._objects_to_parse:
@@ -184,7 +191,11 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
             self._bind_shared_args(
                 self._handle_identity_from_feed(misp_object.get('Event', {}))
             )
-            self._resolve_object(validate_object(misp_object, errors))
+            self._resolve_object(
+                validate_object(
+                    self._sanitise_object_template_name(misp_object), errors
+                )
+            )
         if errors:
             self._handle_validation_errors(errors)
         if self._objects_to_parse:
@@ -251,7 +262,8 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
 
     def _parse_misp_event(self, misp_event: MISPEvent | dict):
         self._misp_event = validate_event(
-            misp_event, errors := defaultdict(list)
+            self._sanitise_event_object_names(misp_event),
+            errors := defaultdict(list)
         )
         if errors:
             self._handle_validation_errors(errors)

--- a/misp_stix_converter/stix2misp/converters/stix2_attack_pattern_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_attack_pattern_converter.py
@@ -106,9 +106,7 @@ class InternalSTIX2AttackPatternConverter(InternalSTIX2Converter):
 
     def parse(self, attack_pattern_ref: str):
         attack_pattern = self.main_parser._get_stix_object(attack_pattern_ref)
-        feature = self._handle_mapping_from_labels(
-            attack_pattern.labels, attack_pattern.id
-        )
+        feature = self._handle_mapping_from_labels(attack_pattern)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_course_of_action_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_course_of_action_converter.py
@@ -76,9 +76,7 @@ class InternalSTIX2CourseOfActionConverter(InternalSTIX2Converter):
         course_of_action = self.main_parser._get_stix_object(
             course_of_action_ref
         )
-        feature = self._handle_mapping_from_labels(
-            course_of_action.labels, course_of_action.id
-        )
+        feature = self._handle_mapping_from_labels(course_of_action)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_custom_object_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_custom_object_converter.py
@@ -2,13 +2,15 @@
 # -*- coding: utf-8 -*-
 
 from ...misp_stix_mapping import Mapping
+from ...tools.misp_object_templates import (
+    _rejected_name_note, _sanitise_template_name, _UNKNOWN_TEMPLATE_NAME)
 from ..exceptions import UnknownParsingFunctionError
 from .stix2converter import InternalSTIX2Converter
 from .stix2mapping import InternalSTIX2Mapping
-from pymisp import MISPEventReport
+from pymisp import MISPEventReport, MISPObject
 from stix2.v20.sdo import CustomObject as CustomObject_v20
 from stix2.v21.sdo import CustomObject as CustomObject_v21
-from typing import TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from ..internal_stix2_to_misp import InternalSTIX2toMISPParser
@@ -114,12 +116,22 @@ class STIX2CustomObjectConverter(InternalSTIX2Converter):
                 self._create_galaxy_args(galaxy_type, custom_galaxy.x_misp_name)
 
     def _parse_custom_object(self, custom_object: _CUSTOM_OBJECT_TYPING):
-        name = custom_object.x_misp_name
+        # A name that is not a plain template name would be joined into a
+        # filesystem path by pymisp's template resolution: keep it out of that
+        # join and convert the object as a generic, template-less one.
+        name, rejected_name = _sanitise_template_name(custom_object.x_misp_name)
         misp_object = self._create_misp_object(name)
         misp_object.category = custom_object.x_misp_meta_category
         misp_object.from_dict(**self._parse_timeline(custom_object))
         if hasattr(custom_object, 'x_misp_comment'):
             misp_object.comment = custom_object.x_misp_comment
+        if rejected_name is not None:
+            self._record_rejected_template_name(misp_object, rejected_name)
+            self.main_parser._add_warning(
+                f'Invalid MISP object template name {rejected_name!r} in the '
+                f'Custom object with id {custom_object.id}: converted as a '
+                f'{_UNKNOWN_TEMPLATE_NAME} object.'
+            )
         self.main_parser._sanitise_object_uuid(misp_object, custom_object.id)
         dropped_fields = set()
         for custom_attribute in custom_object.x_misp_attributes:
@@ -146,6 +158,15 @@ class STIX2CustomObjectConverter(InternalSTIX2Converter):
                 f"{', '.join(sorted(dropped_fields))}"
             )
         self.main_parser._add_misp_object(misp_object, custom_object)
+
+    @staticmethod
+    def _record_rejected_template_name(misp_object: MISPObject, name: Any):
+        # Nothing is silently dropped: the name the object cannot carry is
+        # kept as data, in the comment, alongside whatever comment the STIX
+        # content provided.
+        note = _rejected_name_note(name)
+        comment = getattr(misp_object, 'comment', None)
+        misp_object.comment = f'{comment}\n{note}' if comment else note
 
     @staticmethod
     def _sanitise_value(value: str) -> str:

--- a/misp_stix_converter/stix2misp/converters/stix2_identity_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_identity_converter.py
@@ -309,9 +309,7 @@ class InternalSTIX2IdentityConverter(
     def parse(self, identity_ref: str):
         if identity_ref not in self.main_parser._creators:
             identity = self.main_parser._get_stix_object(identity_ref)
-            feature = self._handle_mapping_from_labels(
-                identity.labels, identity.id
-            )
+            feature = self._handle_mapping_from_labels(identity)
             try:
                 parser = getattr(self, feature)
             except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_indicator_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_indicator_converter.py
@@ -1715,9 +1715,7 @@ class InternalSTIX2IndicatorConverter(
             return
         indicator = self.main_parser._get_stix_object(indicator_ref)
         try:
-            feature = self._handle_mapping_from_labels(
-                indicator.labels, indicator.id
-            )
+            feature = self._handle_mapping_from_labels(indicator)
         except UndefinedSTIXObjectError as error:
             raise UndefinedIndicatorError(error)
         try:

--- a/misp_stix_converter/stix2misp/converters/stix2_intrusion_set_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_intrusion_set_converter.py
@@ -98,9 +98,7 @@ class InternalSTIX2IntrusionSetConverter(InternalSTIX2Converter):
 
     def parse(self, intrusion_set_ref: str):
         intrusion_set = self.main_parser._get_stix_object(intrusion_set_ref)
-        feature = self._handle_mapping_from_labels(
-            intrusion_set.labels, intrusion_set.id
-        )
+        feature = self._handle_mapping_from_labels(intrusion_set)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_location_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_location_converter.py
@@ -193,7 +193,7 @@ class InternalSTIX2LocationConverter(
 
     def parse(self, location_ref: str):
         location = self.main_parser._get_stix_object(location_ref)
-        feature = self._handle_mapping_from_labels(location.labels, location.id)
+        feature = self._handle_mapping_from_labels(location)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_malware_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_malware_converter.py
@@ -212,7 +212,7 @@ class InternalSTIX2MalwareConverter(
 
     def parse(self, malware_ref: str):
         malware = self.main_parser._get_stix_object(malware_ref)
-        feature = self._handle_mapping_from_labels(malware.labels, malware.id)
+        feature = self._handle_mapping_from_labels(malware)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_note_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_note_converter.py
@@ -6,7 +6,9 @@ from .stix2converter import InternalSTIX2Converter
 from .stix2mapping import InternalSTIX2Mapping, STIX2Mapping
 from pymisp import MISPEventReport
 from stix2.v21 import Note
-from typing import Any, Iterator, TYPE_CHECKING
+from typing import Any, Iterator, TYPE_CHECKING, Union
+
+_NOTE_TYPING = Union[Note, dict]
 
 if TYPE_CHECKING:
     from ..internal_stix2_to_misp import InternalSTIX2toMISPParser
@@ -39,37 +41,41 @@ class InternalSTIX2NoteConverter(InternalSTIX2Converter):
 
     def parse(self, note_ref: str):
         note = self.main_parser._get_stix_object(note_ref)
-        labels = getattr(note, 'labels', [])
+        # A Note in a STIX 2.0 Bundle is a dict rather than a typed object:
+        # reading its labels with attribute access would silently yield none
+        # and drop it here, without an error naming what was lost.
+        labels = note.get('labels', [])
         if 'misp:data-layer="Event Report"' in labels:
             self._parse_event_report(note)
         elif 'misp:name="annotation"' in labels:
             self._parse_annotation_object(note)
 
-    def _parse_annotation_object(self, note: Note):
+    def _parse_annotation_object(self, note: _NOTE_TYPING):
         misp_object = self._create_misp_object('annotation', note)
-        self.main_parser._sanitise_object_uuid(misp_object, note.id)
+        self.main_parser._sanitise_object_uuid(misp_object, note['id'])
         misp_object.from_dict(**self._parse_timeline(note))
         for field, mapping in self._mapping.annotation_object_mapping().items():
-            if hasattr(note, field):
+            if field in note:
                 attributes = self._populate_object_attributes_with_data(
-                    mapping, getattr(note, field), note.id
+                    mapping, note[field], note['id']
                 )
                 for attribute in attributes:
                     misp_object.add_attribute(**attribute)
-        if hasattr(note, 'object_refs'):
-            for object_ref in note.object_refs:
+        if 'object_refs' in note:
+            for object_ref in note['object_refs']:
                 misp_object.add_reference(
                     self.main_parser._sanitise_uuid(object_ref), 'annotates'
                 )
         self.main_parser._add_misp_object(misp_object, note)
 
-    def _parse_event_report(self, note: Note):
+    def _parse_event_report(self, note: _NOTE_TYPING):
         event_report = MISPEventReport()
         event_report.from_dict(
-            content=note.content, name=note.abstract, timestamp=note.modified,
-            uuid=self.main_parser._sanitise_uuid(note.id)
+            content=note['content'], name=note['abstract'],
+            timestamp=self.main_parser._stix_date(note['modified']),
+            uuid=self.main_parser._sanitise_uuid(note['id'])
         )
-        self.main_parser._add_event_report(event_report, note.id)
+        self.main_parser._add_event_report(event_report, note['id'])
 
     def _populate_object_attributes_with_data(self, mapping: dict, values: Any,
                                               object_id: str) -> Iterator[dict]:

--- a/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
@@ -2699,9 +2699,7 @@ class InternalSTIX2ObservedDataConverter(
     def parse(self, observed_data_ref: str):
         observed_data = self._get_observed_data(observed_data_ref)
         try:
-            feature = self._handle_mapping_from_labels(
-                observed_data.labels, observed_data.id
-            )
+            feature = self._handle_mapping_from_labels(observed_data)
         except UndefinedSTIXObjectError as error:
             raise UndefinedObservableError(error)
         version = getattr(observed_data, 'spec_version', '2.0')

--- a/misp_stix_converter/stix2misp/converters/stix2_threat_actor_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_threat_actor_converter.py
@@ -94,9 +94,7 @@ class InternalSTIX2ThreatActorConverter(
 
     def parse(self, threat_actor_ref: str):
         threat_actor = self.main_parser._get_stix_object(threat_actor_ref)
-        feature = self._handle_mapping_from_labels(
-            threat_actor.labels, threat_actor.id
-        )
+        feature = self._handle_mapping_from_labels(threat_actor)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_tool_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_tool_converter.py
@@ -88,7 +88,7 @@ class InternalSTIX2ToolConverter(InternalSTIX2Converter):
     
     def parse(self, tool_ref: str):
         tool = self.main_parser._get_stix_object(tool_ref)
-        feature = self._handle_mapping_from_labels(tool.labels, tool.id)
+        feature = self._handle_mapping_from_labels(tool)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2_vulnerability_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_vulnerability_converter.py
@@ -98,9 +98,7 @@ class InternalSTIX2VulnerabilityConverter(
 
     def parse(self, vulnerability_ref: str):
         vulnerability = self.main_parser._get_stix_object(vulnerability_ref)
-        feature = self._handle_mapping_from_labels(
-            vulnerability.labels, vulnerability.id
-        )
+        feature = self._handle_mapping_from_labels(vulnerability)
         try:
             parser = getattr(self, feature)
         except AttributeError:

--- a/misp_stix_converter/stix2misp/converters/stix2converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2converter.py
@@ -368,10 +368,9 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
 
     def _create_attribute_dict(self, stix_object: _SDO_TYPING) -> dict:
         attribute = super()._create_attribute_dict(stix_object)
-        for label in stix_object.labels:
-            if label.startswith('misp:'):
-                feature, value = label.split('=')
-                attribute[feature.split(':')[-1]] = value.strip('"')
+        for field, value in self._parse_labels(stix_object).items():
+            if field.startswith('misp:'):
+                attribute[field.split(':')[-1]] = value
         return attribute
 
     ############################################################################
@@ -449,10 +448,14 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
 
     def _parse_galaxy_as_container(
             self, stix_object: _GALAXY_OBJECTS_TYPING) -> dict:
-        galaxy_type, galaxy_name = self._extract_galaxy_labels(
-            stix_object.labels
-        )
+        galaxy_type, galaxy_name = self._extract_galaxy_labels(stix_object)
         cluster = self._parse_galaxy_cluster(stix_object, galaxy_type)
+        if galaxy_name is None:
+            self.main_parser._add_warning(
+                'Missing MISP galaxy name label on the object with id '
+                f'{stix_object.id}'
+            )
+            galaxy_name = galaxy_type
         if galaxy_type not in self.main_parser._galaxies:
             self._create_galaxy_args(galaxy_type, galaxy_name)
         return {
@@ -462,7 +465,7 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
 
     def _parse_galaxy_as_tag_names(
             self, stix_object: _GALAXY_OBJECTS_TYPING) -> dict:
-        galaxy_type = stix_object.labels[1].split('=')[1].strip('"')
+        galaxy_type, _ = self._extract_galaxy_labels(stix_object)
         return {
             'tag_names': [
                 f'misp-galaxy:{galaxy_type}="{stix_object.name}"'
@@ -483,14 +486,14 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
     #                             UTILITY METHODS.                             #
     ############################################################################
 
-    @staticmethod
-    def _extract_galaxy_labels(labels: list) -> dict:
-        for label in labels[:2]:
-            if 'galaxy-type' in label:
-                galaxy_type = label.split('=')[1].strip('"')
-            elif 'galaxy-name' in label:
-                galaxy_name = label.split('=')[1].strip('"')
-        return galaxy_type, galaxy_name
+    def _extract_galaxy_labels(
+            self, stix_object: _GALAXY_OBJECTS_TYPING
+            ) -> Tuple[str, Optional[str]]:
+        labels = self._parse_labels(stix_object)
+        galaxy_type = labels.get('misp:galaxy-type')
+        if not galaxy_type:
+            raise UndefinedSTIXObjectError(stix_object.id)
+        return galaxy_type, labels.get('misp:galaxy-name') or None
 
     @staticmethod
     def _handle_external_references(external_references: list) -> dict:
@@ -508,11 +511,8 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
             meta['external_id'] = meta.pop('external_id')[0]
         return meta
 
-    def _handle_mapping_from_labels(self, labels: list, object_id: str) -> str:
-        parsed_labels = {
-            key: value.strip('"') for key, value
-            in (label.split('=') for label in labels if '=' in label)
-        }
+    def _handle_mapping_from_labels(self, stix_object: _SDO_TYPING) -> str:
+        parsed_labels = self._parse_labels(stix_object)
         if 'misp:galaxy-type' in parsed_labels:
             return '_parse_galaxy'
         if 'misp:name' in parsed_labels:
@@ -525,4 +525,18 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
             )
             if to_call is not None:
                 return to_call
-        raise UndefinedSTIXObjectError(object_id)
+        raise UndefinedSTIXObjectError(stix_object.id)
+
+    @staticmethod
+    def _parse_labels(stix_object: _SDO_TYPING) -> dict:
+        """Index the `field=value` labels the Internal path dispatches on.
+
+        Labels are content: an object may carry none, and any of them may be
+        missing the `=` the field/value split needs.
+        """
+        parsed_labels = {}
+        for label in getattr(stix_object, 'labels', ()):
+            field, separator, value = label.partition('=')
+            if separator:
+                parsed_labels[field] = value.strip('"')
+        return parsed_labels

--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -13,7 +13,9 @@ from .converters import (
     ExternalSTIX2ToolConverter, ExternalSTIX2VulnerabilityConverter,
     STIX2ObservableObjectConverter)
 from .importparser import ExternalSTIXtoMISPParser
-from .stix2_to_misp import STIX2toMISPParser, _BUNDLE_TYPING, _OBSERVABLE_TYPING
+from .stix2_to_misp import (
+    STIX2toMISPParser, _BUNDLE_TYPING, _NOTE_TYPING, _OBSERVABLE_TYPING,
+    _OPINION_TYPING)
 from collections import defaultdict
 from pymisp import MISPAttribute, MISPObject
 from stix2.v20.observables import (
@@ -21,7 +23,6 @@ from stix2.v20.observables import (
 from stix2.v20.sro import Sighting as Sighting_v20
 from stix2.v21.observables import (
     _Extension as Extension_v21, _STIXBase21 as STIXBase_v21)
-from stix2.v21.sdo import Note, Opinion
 from stix2.v21.sro import Sighting as Sighting_v21
 from typing import Iterator, Optional, Union
 
@@ -31,7 +32,7 @@ _OBSERVABLE_FIELDS_TO_SKIP = (
     'spec_version', 'type'
 )
 _SDO_STORAGE_FIELDS = {'_indicator': 1, '_observable': 2, '_observed_data': 4}
-_SIGHTING_TYPING = Union[Sighting_v20, Sighting_v21]
+_SIGHTING_TYPING = Union[Sighting_v20, Sighting_v21, dict]
 
 
 class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
@@ -106,9 +107,9 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
         for stix_object in stix_objects:
             if stix_object['type'] in ('grouping', 'report'):
                 self._load_stix_object(stix_object)
-                object_refs.update(stix_object.object_refs)
-                if hasattr(stix_object, 'object_marking_refs'):
-                    object_refs.update(stix_object.object_marking_refs)
+                object_refs.update(stix_object['object_refs'])
+                if 'object_marking_refs' in stix_object:
+                    object_refs.update(stix_object['object_marking_refs'])
                 continue
             partitioned.append(stix_object)
             if stix_object['type'] not in ('relationship', 'sighting'):
@@ -127,35 +128,35 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
     #                       STIX OBJECTS LOADING METHODS                       #
     ############################################################################
 
-    def _load_analyst_note(self, note: Note):
+    def _load_analyst_note(self, note: _NOTE_TYPING):
         note_dict = self._parse_analyst_note(note)
-        if len(note.object_refs) == 1:
-            note_dict['uuid'] = self._sanitise_uuid(note.id)
-        for object_ref in note.object_refs:
-            self._analyst_data[object_ref].append(note.id)
-        super()._load_note(note.id, note_dict)
+        if len(note['object_refs']) == 1:
+            note_dict['uuid'] = self._sanitise_uuid(note['id'])
+        for object_ref in note['object_refs']:
+            self._analyst_data[object_ref].append(note['id'])
+        super()._load_note(note['id'], note_dict)
 
-    def _load_analyst_opinion(self, opinion: Opinion):
+    def _load_analyst_opinion(self, opinion: _OPINION_TYPING):
         opinion_dict = {
-            'opinion': self._mapping.opinion_mapping(opinion.opinion),
+            'opinion': self._mapping.opinion_mapping(opinion['opinion']),
             **self._parse_analyst_opinion(opinion)
         }
-        if len(opinion.object_refs) == 1:
-            opinion_dict['uuid'] = self._sanitise_uuid(opinion.id)
-        for object_ref in opinion.object_refs:
-            self._analyst_data[object_ref].append(opinion.id)
-        super()._load_opinion(opinion.id, opinion_dict)
+        if len(opinion['object_refs']) == 1:
+            opinion_dict['uuid'] = self._sanitise_uuid(opinion['id'])
+        for object_ref in opinion['object_refs']:
+            self._analyst_data[object_ref].append(opinion['id'])
+        super()._load_opinion(opinion['id'], opinion_dict)
 
     def _load_observable_object(self, observable: _OBSERVABLE_TYPING):
-        self._check_uuid(observable.id)
+        self._check_uuid(observable['id'])
         to_load = {'used': {}, 'observable': observable}
         try:
-            self._observable[observable.id] = to_load
+            self._observable[observable['id']] = to_load
         except AttributeError:
-            self._observable = {observable.id: to_load}
+            self._observable = {observable['id']: to_load}
 
     def _load_sighting(self, sighting: _SIGHTING_TYPING):
-        sighting_of_ref = self._sanitise_uuid(sighting.sighting_of_ref)
+        sighting_of_ref = self._sanitise_uuid(sighting['sighting_of_ref'])
         try:
             self._sighting[sighting_of_ref].append(sighting)
         except AttributeError:
@@ -354,7 +355,7 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
         self._indicator_references = {
             indicator_id: {obs_type: tuple(val[-1] for val in pattern)}
             for indicator_id, indicator in self._indicator.items()
-            if getattr(indicator, 'pattern_type', 'stix') == 'stix'
+            if indicator.get('pattern_type', 'stix') == 'stix'
             for obs_type, pattern in pattern_parser(indicator).comparisons.items()
         }
         if score in (3, 7):
@@ -379,10 +380,11 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
                     observable['indicator_ref'].add(indicator_reference)
         if score >= 5:
             for observed_id, observed_data in self._observed_data.items():
-                if not hasattr(observed_data, 'objects'):
+                if 'objects' not in observed_data:
                     continue
                 indicator_refs = defaultdict(set)
-                for observable_id, observable in observed_data.objects.items():
+                for observable_id, observable in observed_data[
+                        'objects'].items():
                     indicator_references = set(
                         self._fetch_indicator_reference(observable)
                     )

--- a/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
@@ -13,13 +13,14 @@ from .converters import (
     InternalSTIX2ThreatActorConverter, InternalSTIX2ToolConverter,
     InternalSTIX2VulnerabilityConverter, STIX2CustomObjectConverter)
 from .stix2_to_misp import (
-    STIX2toMISPParser, _BUNDLE_TYPING, _OBSERVABLE_TYPING, _SDO_TYPING)
+    STIX2toMISPParser, _BUNDLE_TYPING, _NOTE_TYPING, _OBSERVABLE_TYPING,
+    _OPINION_TYPING, _SDO_TYPING)
 from collections import defaultdict
 from pymisp import (
     MISPAttribute, MISPEvent, MISPEventReport, MISPGalaxy, MISPObject, MISPSighting)
 from stix2.v20.sdo import CustomObject as CustomObject_v20
 from stix2.v20.sro import Sighting as Sighting_v20
-from stix2.v21.sdo import CustomObject as CustomObject_v21, Note, Opinion
+from stix2.v21.sdo import CustomObject as CustomObject_v21
 from stix2.v21.sro import Sighting as Sighting_v21
 from typing import Iterator, Union
 
@@ -27,10 +28,11 @@ _STORAGE_VARIABLE_NAMES = ('_indicator', '_observed_data')
 
 _CUSTOM_TYPING = Union[
     CustomObject_v20,
-    CustomObject_v21
+    CustomObject_v21,
+    dict
 ]
 _SIGHTING_TYPING = Union[
-    Sighting_v20, Sighting_v21
+    Sighting_v20, Sighting_v21, dict
 ]
 
 
@@ -73,102 +75,107 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
     #                       STIX OBJECTS LOADING METHODS                       #
     ############################################################################
 
-    def _load_analyst_note(self, note: CustomObject_v20):
+    def _load_analyst_note(self, note: _CUSTOM_TYPING):
         note_dict = {
-            'created': note.created, 'modified': note.modified,
-            'note': note.x_misp_note, 'uuid': self._sanitise_uuid(note.id)
+            'created': self._stix_date(note['created']),
+            'modified': self._stix_date(note['modified']),
+            'note': note['x_misp_note'],
+            'uuid': self._sanitise_uuid(note['id'])
         }
-        if hasattr(note, 'x_misp_author'):
-            note_dict['authors'] = note.x_misp_author
-        if hasattr(note, 'x_misp_language'):
-            note_dict['language'] = note.x_misp_language
-        self._analyst_data[note.object_ref].append(note.id)
-        super()._load_note(note.id, note_dict)
+        if 'x_misp_author' in note:
+            note_dict['authors'] = note['x_misp_author']
+        if 'x_misp_language' in note:
+            note_dict['language'] = note['x_misp_language']
+        self._analyst_data[note['object_ref']].append(note['id'])
+        super()._load_note(note['id'], note_dict)
 
-    def _load_analyst_opinion(self, opinion: CustomObject_v20):
+    def _load_analyst_opinion(self, opinion: _CUSTOM_TYPING):
         opinion_dict = {
-            'comment': getattr(opinion, 'x_misp_comment', ''),
-            'created': opinion.created, 'modified': opinion.modified,
-            'opinion': opinion.x_misp_opinion,
-            'uuid': self._sanitise_uuid(opinion.id)
+            'comment': opinion.get('x_misp_comment', ''),
+            'created': self._stix_date(opinion['created']),
+            'modified': self._stix_date(opinion['modified']),
+            'opinion': opinion['x_misp_opinion'],
+            'uuid': self._sanitise_uuid(opinion['id'])
         }
-        if hasattr(opinion, 'x_misp_author'):
-            opinion_dict['authors'] = opinion.x_misp_author
-        self._analyst_data[opinion.object_ref].append(opinion.id)
-        super()._load_opinion(opinion.id, opinion_dict)
+        if 'x_misp_author' in opinion:
+            opinion_dict['authors'] = opinion['x_misp_author']
+        self._analyst_data[opinion['object_ref']].append(opinion['id'])
+        super()._load_opinion(opinion['id'], opinion_dict)
 
     def _load_custom_attribute(self, custom_attribute: _CUSTOM_TYPING):
-        self._check_uuid(custom_attribute.id)
+        self._check_uuid(custom_attribute['id'])
         try:
-            self._custom_attribute[custom_attribute.id] = custom_attribute
+            self._custom_attribute[custom_attribute['id']] = custom_attribute
         except AttributeError:
-            self._custom_attribute = {custom_attribute.id: custom_attribute}
+            self._custom_attribute = {custom_attribute['id']: custom_attribute}
 
     def _load_custom_galaxy_cluster(self, custom_galaxy: _CUSTOM_TYPING):
-        self._check_uuid(custom_galaxy.id)
+        self._check_uuid(custom_galaxy['id'])
         try:
-            self._custom_galaxy_cluster[custom_galaxy.id] = custom_galaxy
+            self._custom_galaxy_cluster[custom_galaxy['id']] = custom_galaxy
         except AttributeError:
-            self._custom_galaxy_cluster = {custom_galaxy.id: custom_galaxy}
+            self._custom_galaxy_cluster = {custom_galaxy['id']: custom_galaxy}
 
     def _load_custom_object(self, custom_object: _CUSTOM_TYPING):
-        self._check_uuid(custom_object.id)
+        self._check_uuid(custom_object['id'])
         try:
-            self._custom_object[custom_object.id] = custom_object
+            self._custom_object[custom_object['id']] = custom_object
         except AttributeError:
-            self._custom_object = {custom_object.id: custom_object}
+            self._custom_object = {custom_object['id']: custom_object}
 
-    def _load_custom_opinion(self, custom_object: CustomObject_v20):
+    def _load_custom_opinion(self, custom_object: _CUSTOM_TYPING):
         sighting = MISPSighting()
         sighting_args = {
-            'date_sighting': self._timestamp_from_date(custom_object.modified),
+            'date_sighting': self._timestamp_from_stix_date(
+                custom_object['modified']
+            ),
             'type': '1'
         }
-        if hasattr(custom_object, 'x_misp_source'):
-            sighting_args['source'] = custom_object.x_misp_source
-        if hasattr(custom_object, 'x_misp_author'):
+        if 'x_misp_source' in custom_object:
+            sighting_args['source'] = custom_object['x_misp_source']
+        if 'x_misp_author' in custom_object:
             sighting_args['Organisation'] = {
-                'uuid': custom_object.x_misp_author_ref.split('--')[1],
-                'name': custom_object.x_misp_author
+                'uuid': custom_object['x_misp_author_ref'].split('--')[1],
+                'name': custom_object['x_misp_author']
             }
         sighting.from_dict(**sighting_args)
-        object_ref = self._sanitise_uuid(custom_object.object_ref)
+        object_ref = self._sanitise_uuid(custom_object['object_ref'])
         try:
             self._sighting['custom_opinion'][object_ref].append(sighting)
         except AttributeError:
             self._sighting = defaultdict(lambda: defaultdict(list))
             self._sighting['custom_opinion'][object_ref].append(sighting)
 
-    def _load_note(self, note: Note):
-        if 'misp:context-layer="Analyst Note"' in getattr(note, 'labels', []):
+    def _load_note(self, note: _NOTE_TYPING):
+        if 'misp:context-layer="Analyst Note"' in note.get('labels', []):
             note_dict = {
-                'uuid': self._sanitise_uuid(note.id),
+                'uuid': self._sanitise_uuid(note['id']),
                 **self._parse_analyst_note(note)
             }
-            self._analyst_data[note.object_refs[0]].append(note.id)
-            super()._load_note(note.id, note_dict)
+            self._analyst_data[note['object_refs'][0]].append(note['id'])
+            super()._load_note(note['id'], note_dict)
         else:
-            self._check_uuid(note.id)
-            super()._load_note(note.id, note)
+            self._check_uuid(note['id'])
+            super()._load_note(note['id'], note)
 
     def _load_observable_object(self, observable: _OBSERVABLE_TYPING):
-        self._check_uuid(observable.id)
+        self._check_uuid(observable['id'])
         try:
-            self._observable[observable.id] = observable
+            self._observable[observable['id']] = observable
         except AttributeError:
-            self._observable = {observable.id: observable}
+            self._observable = {observable['id']: observable}
 
-    def _load_opinion(self, opinion: Opinion):
-        if 'misp:context-layer="Analyst Opinion"' in getattr(opinion, 'labels', []):
+    def _load_opinion(self, opinion: _OPINION_TYPING):
+        if 'misp:context-layer="Analyst Opinion"' in opinion.get('labels', []):
             opinion_dict = {
-                'opinion': opinion.x_misp_opinion,
-                'uuid': self._sanitise_uuid(opinion.id),
+                'opinion': opinion['x_misp_opinion'],
+                'uuid': self._sanitise_uuid(opinion['id']),
                 **self._parse_analyst_opinion(opinion)
             }
-            self._analyst_data[opinion.object_refs[0]].append(opinion.id)
-            super()._load_opinion(opinion.id, opinion_dict)
+            self._analyst_data[opinion['object_refs'][0]].append(opinion['id'])
+            super()._load_opinion(opinion['id'], opinion_dict)
         else:
-            object_ref = self._sanitise_uuid(opinion.object_refs[0])
+            object_ref = self._sanitise_uuid(opinion['object_refs'][0])
             try:
                 self._sighting['opinion'][object_ref].append(opinion)
             except AttributeError:
@@ -176,7 +183,7 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
                 self._sighting['opinion'][object_ref].append(opinion)
 
     def _load_sighting(self, sighting: _SIGHTING_TYPING):
-        sighting_of_ref = self._sanitise_uuid(sighting.sighting_of_ref)
+        sighting_of_ref = self._sanitise_uuid(sighting['sighting_of_ref'])
         try:
             self._sighting['sighting'][sighting_of_ref].append(sighting)
         except AttributeError:
@@ -243,19 +250,21 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
                 continue
             yield label
 
-    def _parse_opinion(self, opinion: Opinion) -> MISPSighting:
+    def _parse_opinion(self, opinion: _OPINION_TYPING) -> MISPSighting:
         misp_sighting = MISPSighting()
         sighting_args = {
-            'date_sighting': self._timestamp_from_date(opinion.modified),
-            'type': '1' if 'disagree' in opinion.opinion else '0'
+            'date_sighting': self._timestamp_from_stix_date(
+                opinion['modified']
+            ),
+            'type': '1' if 'disagree' in opinion['opinion'] else '0'
         }
-        if hasattr(opinion, 'x_misp_source'):
-            sighting_args['source'] = opinion.x_misp_source
-        if hasattr(opinion, 'x_misp_author_ref'):
-            identity = self._identity[opinion.x_misp_author_ref]
+        if 'x_misp_source' in opinion:
+            sighting_args['source'] = opinion['x_misp_source']
+        if 'x_misp_author_ref' in opinion:
+            identity = self._identity[opinion['x_misp_author_ref']]
             sighting_args['Organisation'] = {
-                'uuid': self._sanitise_uuid(identity.id),
-                'name': identity.name
+                'uuid': self._sanitise_uuid(identity['id']),
+                'name': identity['name']
             }
         misp_sighting.from_dict(**sighting_args)
         return misp_sighting
@@ -315,6 +324,6 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         self._indicator_references = {
             self._extract_uuid(indicator_id): tuple(val[-1] for val in pattern)
             for indicator_id, indicator in self._indicator.items()
-            if getattr(indicator, 'pattern_type', 'stix') == 'stix'
+            if indicator.get('pattern_type', 'stix') == 'stix'
             for pattern in pattern_parser(indicator).comparisons.values()
         }

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -458,6 +458,14 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 'Unknown pattern type in Indicator object with id '
                 f'{object_ref}: {pattern_type}'
             )
+        except Exception as exception:
+            # Converters make assumptions about the shape of what they get -
+            # labels above all - that content is free not to hold. Whatever
+            # they raise, the object is dropped: say which one and why.
+            self._add_error(
+                f'Error while parsing the STIX object with id {object_ref}: '
+                f'{self._parse_traceback(exception)}'
+            )
 
     def _handle_unparsed_content(self):
         if 'observed-data' in self._converter_cache:

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -121,6 +121,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._clusters: dict = {}
         self._converter_cache: dict = {}
         self._galaxies: dict = {}
+        self._loaded_object_ids: set = set()
 
         self._attack_pattern: dict
         self._campaign: dict
@@ -170,6 +171,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                     f'Unable to load STIX object type: {object_type}'
                 )
             return
+        self._check_duplicate_id(stix_object['id'])
         if hasattr(stix_object, 'created_by_ref'):
             self._creators.add(stix_object.created_by_ref)
         try:
@@ -181,6 +183,24 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             )
         except AttributeError as exception:
             self._critical_error(exception)
+
+    def _check_duplicate_id(self, object_id: str):
+        """Report the ids a bundle gives to more than one loaded object.
+
+        Most loading methods store the object they get by its id, so the last
+        occurrence of a duplicated id wins and the ones before it are
+        shadowed. That behaviour is kept - the converted content is a
+        rendering of the last version sent - but it is no longer silent. The
+        few methods keying on a referenced object instead (relationship,
+        sighting, opinion) keep every occurrence, hence a warning naming the
+        id and what it puts at stake rather than the objects lost.
+        """
+        if object_id in self._loaded_object_ids:
+            self._add_warning(
+                f'Duplicate STIX object id: {object_id} - the converted '
+                'content may be an altered rendering of the bundle'
+            )
+        self._loaded_object_ids.add(object_id)
 
     def _parse_stix_bundle(self):
         n_reports = sum(
@@ -205,6 +225,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._clusters = {}
         self._converter_cache.clear()
         self._galaxies = {}
+        self._loaded_object_ids = set()
         for feature in _SDOs:
             if hasattr(self, feature):
                 delattr(self, feature)

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -19,7 +19,9 @@ from collections import defaultdict
 from pymisp import (
     MISPEvent, MISPAttribute, MISPEventReport, MISPGalaxy, MISPGalaxyCluster,
     MISPObject, MISPSighting)
+from datetime import datetime
 from stix2 import TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE
+from stix2.utils import parse_into_datetime
 from stix2.v20.bundle import Bundle as Bundle_v20
 from stix2.v20.common import MarkingDefinition as MarkingDefinition_v20
 from stix2.v20.sdo import (
@@ -65,11 +67,14 @@ _SDOs = (
 )
 
 # Typing
+# `dict` is part of every incoming typing: content parsed with `allow_custom`
+# keeps the object types the STIX version it is parsed against does not know as
+# plain dictionaries, so any incoming object may reach us in that form.
 _OBSERVABLE_TYPING = Union[
     Artifact, AutonomousSystem, Directory, DomainName, EmailAddress,
     EmailMessage, File, IPv4Address, IPv6Address, MACAddress, Mutex,
     NetworkTraffic_v21, Process, Software, URL, UserAccount, WindowsRegistryKey,
-    X509Certificate
+    X509Certificate, dict
 ]
 
 _BUNDLE_TYPING = Union[
@@ -79,7 +84,7 @@ _DATA_LAYER_TYPING = Union[
     MISPAttribute, MISPEvent, MISPEventReport, MISPObject
 ]
 _GROUPING_REPORT_TYPING = Union[
-    Grouping, Report_v20, Report_v21
+    Grouping, Report_v20, Report_v21, dict
 ]
 _MARKING_DEFINITION_TYPING = Union[
     MarkingDefinition_v20, MarkingDefinition_v21, dict
@@ -90,16 +95,23 @@ _NOTE_TYPING = Union[
 _OPINION_TYPING = Union[
     Opinion, CustomObject_v20, dict
 ]
+_RELATIONSHIP_TYPING = Union[
+    Relationship_v20, Relationship_v21, dict
+]
 _REPORT_TYPING = Union[
-    Report_v20, Report_v21
+    Report_v20, Report_v21, dict
 ]
 _SDO_TYPING = Union[
-    Campaign_v20, Campaign_v21, CustomObject_v20, CustomObject_v21, Grouping,
-    Indicator_v20, Indicator_v21, ObservedData_v20, ObservedData_v21,
-    Report_v20, Report_v21, Vulnerability_v20, Vulnerability_v21
+    AttackPattern_v20, AttackPattern_v21, Campaign_v20, Campaign_v21,
+    CourseOfAction_v20, CourseOfAction_v21, CustomObject_v20, CustomObject_v21,
+    Grouping, Identity_v20, Identity_v21, Indicator_v20, Indicator_v21,
+    IntrusionSet_v20, IntrusionSet_v21, Location, Malware_v20, Malware_v21,
+    MalwareAnalysis, Note, ObservedData_v20, ObservedData_v21, Opinion,
+    Report_v20, Report_v21, ThreatActor_v20, ThreatActor_v21, Tool_v20,
+    Tool_v21, Vulnerability_v20, Vulnerability_v21, dict
 ]
 _SIGHTING_TYPING = Union[
-    Sighting_v20, Sighting_v21
+    Sighting_v20, Sighting_v21, dict
 ]
 _STIX_OBJECT_TYPING = Union[
     _OBSERVABLE_TYPING, _GROUPING_REPORT_TYPING,
@@ -172,8 +184,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 )
             return
         self._check_duplicate_id(stix_object['id'])
-        if hasattr(stix_object, 'created_by_ref'):
-            self._creators.add(stix_object.created_by_ref)
+        if 'created_by_ref' in stix_object:
+            self._creators.add(stix_object['created_by_ref'])
         try:
             getattr(self, feature)(stix_object)
         except MarkingDefinitionLoadingError as marking_definition_id:
@@ -181,8 +193,16 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 'Error whil parsing the Marking Definition '
                 f'object with id {marking_definition_id}'
             )
-        except AttributeError as exception:
-            self._critical_error(exception)
+        except Exception as exception:
+            # Loading methods read the fields they need with the Mapping
+            # interface every incoming object honours, typed or dict-form.
+            # Anything raised past that point is a field the object does not
+            # carry: drop it, but name the object instead of the exception
+            # alone.
+            self._add_error(
+                'Error while loading the STIX object with id '
+                f'{stix_object["id"]}: {self._parse_traceback(exception)}'
+            )
 
     def _check_duplicate_id(self, object_id: str):
         """Report the ids a bundle gives to more than one loaded object.
@@ -280,85 +300,87 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     ############################################################################
 
     def _load_attack_pattern(
-            self, attack_pattern: AttackPattern_v20 | AttackPattern_v21):
-        self._check_uuid(attack_pattern.id)
+            self,
+            attack_pattern: AttackPattern_v20 | AttackPattern_v21 | dict):
+        self._check_uuid(attack_pattern['id'])
         try:
-            self._attack_pattern[attack_pattern.id] = attack_pattern
+            self._attack_pattern[attack_pattern['id']] = attack_pattern
         except AttributeError:
-            self._attack_pattern = {attack_pattern.id: attack_pattern}
+            self._attack_pattern = {attack_pattern['id']: attack_pattern}
 
-    def _load_campaign(self, campaign: Campaign_v20 | Campaign_v21):
-        self._check_uuid(campaign.id)
+    def _load_campaign(self, campaign: Campaign_v20 | Campaign_v21 | dict):
+        self._check_uuid(campaign['id'])
         try:
-            self._campaign[campaign.id] = campaign
+            self._campaign[campaign['id']] = campaign
         except AttributeError:
-            self._campaign = {campaign.id: campaign}
+            self._campaign = {campaign['id']: campaign}
 
     def _load_course_of_action(
-            self, course_of_action: CourseOfAction_v20 | CourseOfAction_v21):
-        self._check_uuid(course_of_action.id)
+            self,
+            course_of_action: CourseOfAction_v20 | CourseOfAction_v21 | dict):
+        self._check_uuid(course_of_action['id'])
         try:
-            self._course_of_action[course_of_action.id] = course_of_action
+            self._course_of_action[course_of_action['id']] = course_of_action
         except AttributeError:
-            self._course_of_action = {course_of_action.id: course_of_action}
+            self._course_of_action = {course_of_action['id']: course_of_action}
 
-    def _load_grouping(self, grouping: Grouping):
-        self._check_uuid(grouping.id)
+    def _load_grouping(self, grouping: Grouping | dict):
+        self._check_uuid(grouping['id'])
         try:
-            self._grouping[grouping.id] = grouping
+            self._grouping[grouping['id']] = grouping
         except AttributeError:
-            self._grouping = {grouping.id: grouping}
+            self._grouping = {grouping['id']: grouping}
 
-    def _load_identity(self, identity: Identity_v20 | Identity_v21):
-        self._check_uuid(identity.id)
+    def _load_identity(self, identity: Identity_v20 | Identity_v21 | dict):
+        self._check_uuid(identity['id'])
         try:
-            self._identity[identity.id] = identity
+            self._identity[identity['id']] = identity
         except AttributeError:
-            self._identity = {identity.id: identity}
+            self._identity = {identity['id']: identity}
 
-    def _load_indicator(self, indicator: Indicator_v20 | Indicator_v21):
-        self._check_uuid(indicator.id)
+    def _load_indicator(self, indicator: Indicator_v20 | Indicator_v21 | dict):
+        self._check_uuid(indicator['id'])
         try:
-            self._indicator[indicator.id] = indicator
+            self._indicator[indicator['id']] = indicator
         except AttributeError:
-            self._indicator = {indicator.id: indicator}
+            self._indicator = {indicator['id']: indicator}
 
     def _load_intrusion_set(
-            self, intrusion_set: IntrusionSet_v20 | IntrusionSet_v21):
-        self._check_uuid(intrusion_set.id)
+            self, intrusion_set: IntrusionSet_v20 | IntrusionSet_v21 | dict):
+        self._check_uuid(intrusion_set['id'])
         try:
-            self._intrusion_set[intrusion_set.id] = intrusion_set
+            self._intrusion_set[intrusion_set['id']] = intrusion_set
         except AttributeError:
-            self._intrusion_set = {intrusion_set.id: intrusion_set}
+            self._intrusion_set = {intrusion_set['id']: intrusion_set}
 
-    def _load_location(self, location: Location):
+    def _load_location(self, location: Location | dict):
         self._check_uuid(location['id'])
         try:
             self._location[location['id']] = location
         except AttributeError:
             self._location = {location['id']: location}
 
-    def _load_malware(self, malware: Malware_v20 | Malware_v21):
-        self._check_uuid(malware.id)
+    def _load_malware(self, malware: Malware_v20 | Malware_v21 | dict):
+        self._check_uuid(malware['id'])
         try:
-            self._malware[malware.id] = malware
+            self._malware[malware['id']] = malware
         except AttributeError:
-            self._malware = {malware.id: malware}
+            self._malware = {malware['id']: malware}
 
-    def _load_malware_analysis(self, malware_analysis: MalwareAnalysis):
-        self._check_uuid(malware_analysis.id)
+    def _load_malware_analysis(self, malware_analysis: MalwareAnalysis | dict):
+        self._check_uuid(malware_analysis['id'])
         try:
-            self._malware_analysis[malware_analysis.id] = malware_analysis
+            self._malware_analysis[malware_analysis['id']] = malware_analysis
         except AttributeError:
-            self._malware_analysis = {malware_analysis.id: malware_analysis}
+            self._malware_analysis = {malware_analysis['id']: malware_analysis}
 
     def _load_marking_definition(
             self, marking_definition: _MARKING_DEFINITION_TYPING):
         tag = self._parse_marking_definition(marking_definition)
         try:
-            self._marking_definition[marking_definition.id] = tag
+            self._marking_definition[marking_definition['id']] = tag
         except AttributeError:
-            self._marking_definition = {marking_definition.id: tag}
+            self._marking_definition = {marking_definition['id']: tag}
 
     def _load_note(self, note_ref: str, note: _NOTE_TYPING):
         try:
@@ -367,12 +389,12 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             self._note = {note_ref: note}
 
     def _load_observed_data(
-            self, observed_data: ObservedData_v20 | ObservedData_v21):
-        self._check_uuid(observed_data.id)
+            self, observed_data: ObservedData_v20 | ObservedData_v21 | dict):
+        self._check_uuid(observed_data['id'])
         try:
-            self._observed_data[observed_data.id] = observed_data
+            self._observed_data[observed_data['id']] = observed_data
         except AttributeError:
-            self._observed_data = {observed_data.id: observed_data}
+            self._observed_data = {observed_data['id']: observed_data}
 
     def _load_opinion(self, opinion_ref: str, opinion_dict: _OPINION_TYPING):
         try:
@@ -380,10 +402,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         except AttributeError:
             self._opinion = {opinion_ref: opinion_dict}
 
-    def _load_relationship(
-            self, relationship: Relationship_v20 | Relationship_v21):
-        reference = (relationship.target_ref, relationship.relationship_type)
-        source_uuid = self._sanitise_uuid(relationship.source_ref)
+    def _load_relationship(self, relationship: _RELATIONSHIP_TYPING):
+        reference = (
+            relationship['target_ref'], relationship['relationship_type']
+        )
+        source_uuid = self._sanitise_uuid(relationship['source_ref'])
         try:
             self._relationship[source_uuid].add(reference)
         except AttributeError:
@@ -391,34 +414,35 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             self._relationship[source_uuid].add(reference)
 
     def _load_report(self, report: _REPORT_TYPING):
-        self._check_uuid(report.id)
+        self._check_uuid(report['id'])
         try:
-            self._report[report.id] = report
+            self._report[report['id']] = report
         except AttributeError:
-            self._report = {report.id: report}
+            self._report = {report['id']: report}
 
     def _load_threat_actor(
-            self, threat_actor: ThreatActor_v20 | ThreatActor_v21):
-        self._check_uuid(threat_actor.id)
+            self, threat_actor: ThreatActor_v20 | ThreatActor_v21 | dict):
+        self._check_uuid(threat_actor['id'])
         try:
-            self._threat_actor[threat_actor.id] = threat_actor
+            self._threat_actor[threat_actor['id']] = threat_actor
         except AttributeError:
-            self._threat_actor = {threat_actor.id: threat_actor}
+            self._threat_actor = {threat_actor['id']: threat_actor}
 
-    def _load_tool(self, tool: Tool_v20 | Tool_v21):
-        self._check_uuid(tool.id)
+    def _load_tool(self, tool: Tool_v20 | Tool_v21 | dict):
+        self._check_uuid(tool['id'])
         try:
-            self._tool[tool.id] = tool
+            self._tool[tool['id']] = tool
         except AttributeError:
-            self._tool = {tool.id: tool}
+            self._tool = {tool['id']: tool}
 
     def _load_vulnerability(
-            self, vulnerability: Vulnerability_v20 | Vulnerability_v21):
-        self._check_uuid(vulnerability.id)
+            self,
+            vulnerability: Vulnerability_v20 | Vulnerability_v21 | dict):
+        self._check_uuid(vulnerability['id'])
         try:
-            self._vulnerability[vulnerability.id] = vulnerability
+            self._vulnerability[vulnerability['id']] = vulnerability
         except AttributeError:
-            self._vulnerability = {vulnerability.id: vulnerability}
+            self._vulnerability = {vulnerability['id']: vulnerability}
 
     ############################################################################
     #                    MAIN STIX OBJECTS PARSING METHODS.                    #
@@ -510,11 +534,10 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _misp_event_from_report(self, report: _REPORT_TYPING) -> MISPEvent:
         misp_event = self._create_misp_event(report)
-        if report.published != report.modified:
+        published = self._stix_date(report['published'])
+        if published != self._stix_date(report['modified']):
             misp_event.published = True
-            misp_event.publish_timestamp = self._timestamp_from_date(
-                report.published
-            )
+            misp_event.publish_timestamp = self._timestamp_from_date(published)
         else:
             misp_event.published = False
         return misp_event
@@ -524,17 +547,17 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             self._set_misp_event(self._create_generic_event())
             if getattr(self, '_report', None):
                 for report in self._report.values():
-                    self._handle_object_refs(report.object_refs)
+                    self._handle_object_refs(report['object_refs'])
             if getattr(self, '_grouping', None):
                 for grouping in self._grouping.values():
-                    self._handle_object_refs(grouping.object_refs)
+                    self._handle_object_refs(grouping['object_refs'])
             self._handle_unparsed_content()
         else:
             self._set_misp_events()
             if getattr(self, '_report', None):
                 for report in self._report.values():
                     self._set_misp_event(self._misp_event_from_report(report))
-                    self._handle_object_refs(report.object_refs)
+                    self._handle_object_refs(report['object_refs'])
                     self._handle_unparsed_content()
                     self._populate_misp_event()
             if getattr(self, '_grouping', None):
@@ -542,7 +565,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                     self._set_misp_event(
                         self._misp_event_from_grouping(grouping)
                     )
-                    self._handle_object_refs(grouping.object_refs)
+                    self._handle_object_refs(grouping['object_refs'])
                     self._handle_unparsed_content()
                     self._populate_misp_event()
 
@@ -557,11 +580,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         if getattr(self, '_report', None):
             for report in self._report.values():
                 self._set_misp_event(self._misp_event_from_report(report))
-                self._handle_object_refs(report.object_refs)
+                self._handle_object_refs(report['object_refs'])
         elif getattr(self, '_grouping', None):
             for grouping in self._grouping.values():
                 self._set_misp_event(self._misp_event_from_grouping(grouping))
-                self._handle_object_refs(grouping.object_refs)
+                self._handle_object_refs(grouping['object_refs'])
         else:
             self._parse_bundle_with_no_report()
         self._handle_unparsed_content()
@@ -610,28 +633,30 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     #                       ANALYST DATA PARSING METHODS                       #
     ############################################################################
 
-    @staticmethod
-    def _parse_analyst_note(note: Note) -> dict:
+    @classmethod
+    def _parse_analyst_note(cls, note: _NOTE_TYPING) -> dict:
         note_dict = {
-            'created': note.created, 'modified': note.modified,
-            'note': note.content
+            'created': cls._stix_date(note['created']),
+            'modified': cls._stix_date(note['modified']),
+            'note': note['content']
         }
-        if hasattr(note, 'abstract'):
-            note_dict['comment'] = note.abstract
-        if hasattr(note, 'authors'):
-            note_dict['authors'] = ', '.join(note.authors)
-        if hasattr(note, 'lang'):
-            note_dict['language'] = note.lang
+        if 'abstract' in note:
+            note_dict['comment'] = note['abstract']
+        if 'authors' in note:
+            note_dict['authors'] = ', '.join(note['authors'])
+        if 'lang' in note:
+            note_dict['language'] = note['lang']
         return note_dict
 
-    @staticmethod
-    def _parse_analyst_opinion(opinion: Opinion) -> dict:
+    @classmethod
+    def _parse_analyst_opinion(cls, opinion: _OPINION_TYPING) -> dict:
         opinion_dict = {
-            'comment': getattr(opinion, 'explanation', ''),
-            'created': opinion.created, 'modified': opinion.modified
+            'comment': opinion.get('explanation', ''),
+            'created': cls._stix_date(opinion['created']),
+            'modified': cls._stix_date(opinion['modified'])
         }
-        if hasattr(opinion, 'authors'):
-            opinion_dict['authors'] = ', '.join(opinion.authors)
+        if 'authors' in opinion:
+            opinion_dict['authors'] = ', '.join(opinion['authors'])
         return opinion_dict
 
     ############################################################################
@@ -713,11 +738,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def _handle_tags_from_stix_fields(
             self, misp_layer: MISPAttribute | MISPEvent | MISPObject,
             stix_object: _SDO_TYPING) -> Iterator[str]:
-        if hasattr(stix_object, 'confidence'):
-            yield self._parse_confidence_level(stix_object.confidence)
-        if hasattr(stix_object, 'object_marking_refs'):
+        if 'confidence' in stix_object:
+            yield self._parse_confidence_level(stix_object['confidence'])
+        if 'object_marking_refs' in stix_object:
             cluster_ids = []
-            for marking_ref in stix_object.object_marking_refs:
+            for marking_ref in stix_object['object_marking_refs']:
                 try:
                     marking_definition = self._get_stix_object(marking_ref)
                     if marking_ref in self._clusters:
@@ -825,36 +850,36 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             collection_uuid=self._create_v5_uuid(name),
             meta=meta, type=f'stix-{version}-acs-marking',
             version=''.join(version.split('.')),
-            uuid=marking_definition.id.split('--')[1],
+            uuid=marking_definition['id'].split('--')[1],
             value=extension.get(
                 'name',
                 extension.get(
-                    'identifier', marking_definition.id.split('--')[1]
+                    'identifier', marking_definition['id'].split('--')[1]
                 )
             ),
             source=(
-                self._handle_creator(marking_definition.created_by_ref)
-                if hasattr(marking_definition, 'created_by_ref') else
+                self._handle_creator(marking_definition['created_by_ref'])
+                if 'created_by_ref' in marking_definition else
                 extension.get('responsible_entity_custodian')
             )
         )
 
     def _parse_marking_definition(
             self, marking_definition: _MARKING_DEFINITION_TYPING) -> Union[dict, str]:
-        if hasattr(marking_definition, 'definition_type'):
-            definition_type = marking_definition.definition_type
-            definition = marking_definition.definition[definition_type]
+        if 'definition_type' in marking_definition:
+            definition_type = marking_definition['definition_type']
+            definition = marking_definition['definition'][definition_type]
             if definition.startswith(f'{definition_type}:'):
                 return definition
             return f"{definition_type}:{definition}"
-        if hasattr(marking_definition, 'name'):
+        if 'name' in marking_definition:
             # should be TLP 2.0 definition
-            return marking_definition.name.lower()
-        if hasattr(marking_definition, 'extensions'):
+            return marking_definition['name'].lower()
+        if 'extensions' in marking_definition:
             clusters = []
             tags = []
-            version = getattr(marking_definition, 'spec_version', '2.0')
-            for identifier in marking_definition.extensions.keys():
+            version = marking_definition.get('spec_version', '2.0')
+            for identifier in marking_definition['extensions'].keys():
                 feature = self._mapping.marking_extension_mapping(identifier)
                 if feature is None:
                     self._unknown_marking_definition_extension_error(identifier)
@@ -866,7 +891,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                     )
                 )
             if clusters:
-                self._clusters[marking_definition.id] = {
+                self._clusters[marking_definition['id']] = {
                     'used': {}, 'cluster': clusters
                 }
                 # A marking that yielded clusters was loaded successfully, even
@@ -875,7 +900,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 return tags
             if tags:
                 return tags
-        raise MarkingDefinitionLoadingError(marking_definition.id)
+        raise MarkingDefinitionLoadingError(marking_definition['id'])
 
     ############################################################################
     #                 MISP GALAXIES & CLUSTERS PARSING METHODS                 #
@@ -1028,19 +1053,21 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def _parse_sighting(self, sighting: _SIGHTING_TYPING) -> MISPSighting:
         misp_sighting = MISPSighting()
         sighting_args = {
-            'date_sighting': self._timestamp_from_date(sighting.modified),
+            'date_sighting': self._timestamp_from_stix_date(
+                sighting['modified']
+            ),
             'type': '0'
         }
-        if hasattr(sighting, 'description'):
-            sighting_args['source'] = sighting.description
-        if hasattr(sighting, 'where_sighted_refs'):
-            for reference in sighting.where_sighted_refs:
+        if 'description' in sighting:
+            sighting_args['source'] = sighting['description']
+        if 'where_sighted_refs' in sighting:
+            for reference in sighting['where_sighted_refs']:
                 identity = self._identity.get(reference)
                 if identity is None:
                     continue
                 sighting_args['Organisation'] = {
-                    'uuid': self._sanitise_uuid(identity.id),
-                    'name': identity.name
+                    'uuid': self._sanitise_uuid(identity['id']),
+                    'name': identity['name']
                 }
                 misp_sighting.from_dict(**sighting_args)
                 return misp_sighting
@@ -1086,16 +1113,16 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def _add_misp_attribute(
             self, attribute: dict, stix_object: _SDO_TYPING) -> MISPAttribute:
         misp_attribute = self.misp_event.add_attribute(**attribute)
-        if stix_object.id in self._analyst_data:
-            for reference in self._analyst_data[stix_object.id]:
+        if stix_object['id'] in self._analyst_data:
+            for reference in self._analyst_data[stix_object['id']]:
                 self._add_analyst_data(misp_attribute, reference)
         self._add_markings_to_misp_attribute(misp_attribute, stix_object)
         return misp_attribute
 
     def _add_misp_object(self, misp_object: MISPObject,
                          stix_object: _SDO_TYPING) -> MISPObject:
-        if stix_object.id in self._analyst_data:
-            for reference in self._analyst_data[stix_object.id]:
+        if stix_object['id'] in self._analyst_data:
+            for reference in self._analyst_data[stix_object['id']]:
                 self._add_analyst_data(misp_object, reference)
         self._add_markings_to_misp_object(misp_object, stix_object)
         return self.misp_event.add_object(misp_object)
@@ -1120,8 +1147,8 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def _create_misp_event(
             self, stix_object: _GROUPING_REPORT_TYPING) -> MISPEvent:
         misp_event = MISPEvent(force_timestamps=True)
-        self._sanitise_object_uuid(misp_event, stix_object.id)
-        timestamp = self._timestamp_from_date(stix_object.modified)
+        self._sanitise_object_uuid(misp_event, stix_object['id'])
+        timestamp = self._timestamp_from_stix_date(stix_object['modified'])
         event_args = {
             'info': self._generate_info_field(stix_object),
             'distribution': self.distribution, 'timestamp': timestamp
@@ -1129,27 +1156,32 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         if self.distribution == 4 and self.sharing_group_id is not None:
             event_args['sharing_group_id'] = self.sharing_group_id
         misp_event.from_dict(**event_args)
-        if hasattr(stix_object, 'description'):
+        if 'description' in stix_object:
             event_report = MISPEventReport()
             event_report.from_dict(
-                content=stix_object.description, timestamp=timestamp,
-                name=f'STIX {self.stix_version} {stix_object.type} description',
-                uuid=self._create_v5_uuid(f'description - {stix_object.id}')
+                content=stix_object['description'], timestamp=timestamp,
+                name=(
+                    f'STIX {self.stix_version} '
+                    f'{stix_object["type"]} description'
+                ),
+                uuid=self._create_v5_uuid(
+                    f'description - {stix_object["id"]}'
+                )
             )
             misp_event.add_event_report(**event_report)
-        if stix_object.id in self._analyst_data:
-            for reference in self._analyst_data[stix_object.id]:
+        if stix_object['id'] in self._analyst_data:
+            for reference in self._analyst_data[stix_object['id']]:
                 self._add_analyst_data(misp_event, reference)
         if self.producer is not None:
             misp_event.add_tag(f'misp-galaxy:producer="{self.producer}"')
-        elif hasattr(stix_object, 'created_by_ref'):
-            producer = self._handle_creator(stix_object.created_by_ref)
+        elif 'created_by_ref' in stix_object:
+            producer = self._handle_creator(stix_object['created_by_ref'])
             misp_event.add_tag(f'misp-galaxy:producer="{producer}"')
         self._event_tags = set()
         self._add_markings_to_misp_event(misp_event, stix_object)
-        if hasattr(stix_object, 'labels'):
+        if 'labels' in stix_object:
             labels = (
-                label for label in stix_object.labels
+                label for label in stix_object['labels']
                 if label.lower() != 'threat-report'
             )
             for label in labels:
@@ -1171,9 +1203,25 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def _extract_uuid(object_id: str) -> str:
         return object_id.split('--')[-1]
 
+    @staticmethod
+    def _stix_date(date: datetime | str) -> datetime:
+        """Read a date field whatever form the object carrying it takes.
+
+        Typed STIX objects expose their dates as `datetime` values, while the
+        dict-form ones keep the string the document carried. Both reach the
+        same MISP-side code, which only knows what to do with a `datetime`.
+        """
+        if isinstance(date, str):
+            return parse_into_datetime(date)
+        return date
+
+    @classmethod
+    def _timestamp_from_stix_date(cls, date: datetime | str) -> int:
+        return cls._timestamp_from_date(cls._stix_date(date))
+
     def _generate_info_field(self, stix_object: _GROUPING_REPORT_TYPING) -> str:
-        if hasattr(stix_object, 'name'):
-            title = stix_object.name
+        if 'name' in stix_object:
+            title = stix_object['name']
             if self.event_title is not None:
                 title = f'{self.event_title} {title}'
             return title
@@ -1181,7 +1229,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _handle_creator(self, reference: str) -> str:
         if reference in getattr(self, '_identity', {}):
-            return self._identity[reference].name
+            return self._identity[reference]['name']
         return self._mapping.identity_references(reference) or 'misp-stix'
 
     def _is_tlp_marking(self, marking_ref: str) -> bool:
@@ -1190,7 +1238,7 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             self._load_marking_definition(tlp_2_marking)
             return True
         for marking in (TLP_WHITE, TLP_GREEN, TLP_AMBER, TLP_RED):
-            if marking_ref == marking.id:
+            if marking_ref == marking['id']:
                 self._load_marking_definition(marking)
                 return True
         return False
@@ -1210,9 +1258,6 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     ############################################################################
     #                   ERRORS AND WARNINGS HANDLING METHODS                   #
     ############################################################################
-
-    def _critical_error(self, exception: Exception):
-        self._add_error(f'The following exception was raised: {exception}')
 
     def _object_ref_loading_error(self, object_ref: str):
         self._add_error(f'Error loading the STIX object with id {object_ref}')

--- a/misp_stix_converter/tools/misp_object_templates.py
+++ b/misp_stix_converter/tools/misp_object_templates.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional, Tuple
+
+# A MISP object template is a directory named after the template, so a template
+# name is a single path component. pymisp resolves a template by joining the
+# name into a filesystem path (`misp_objects_path / name / 'definition.json'`),
+# which means a name carrying separators or `..` segments reads a file outside
+# the template directory and copies its fields onto the object. The character
+# set below is the one the misp-objects repository actually uses: letters,
+# digits, `-` and `_`, upper case included (`ADS`, `ftm-Airplane`,
+# `regripper-NTUser`, `intelmq_event`).
+_TEMPLATE_NAME_REGEX = re.compile(r'[A-Za-z0-9][A-Za-z0-9_-]*')
+
+# Stands in for a name that cannot be a template name: the object is then built
+# as a generic, template-less one, and the rejected name is kept as data.
+_UNKNOWN_TEMPLATE_NAME = 'unknown-template'
+
+
+def _is_template_name(name: Any) -> bool:
+    """Tell whether a name is safe to hand to pymisp's template resolution.
+
+    :param name: candidate MISP object template name, from any source
+    :return: whether the name is a single, plain template name component
+    """
+    return (
+        isinstance(name, str)
+        and _TEMPLATE_NAME_REGEX.fullmatch(name) is not None
+    )
+
+
+def _rejected_name_note(name: Any) -> str:
+    """Word the rejected name so it survives as data, in either direction.
+
+    :param name: the name that could not be used as a template name
+    :return: the note to keep alongside the object
+    """
+    return f'Original MISP object name: {name}'
+
+
+def _sanitise_template_name(name: Any) -> Tuple[str, Optional[Any]]:
+    """Pick the name to use for template resolution, and report a rejection.
+
+    :param name: candidate MISP object template name, from any source
+    :return: the name safe to resolve, and the rejected name if there is one
+    """
+    if _is_template_name(name):
+        return name, None
+    return _UNKNOWN_TEMPLATE_NAME, name

--- a/tests/_test_stix.py
+++ b/tests/_test_stix.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import json
 import unittest
 from datetime import datetime
+
+# Stands in for any `definition.json` a traversing object name could reach:
+# the values are recognisable so a leak into the converted data is obvious.
+PLANTED_TEMPLATE = {
+    'name': 'planted',
+    'uuid': 'deadbeef-0000-4000-8000-000000000000',
+    'meta-category': 'LEAKED-CATEGORY',
+    'description': 'CONTENTS OF A FILE OUTSIDE THE TEMPLATE DIRECTORY',
+    'version': 99,
+    'attributes': {}
+}
 
 
 class TestSTIX(unittest.TestCase):
@@ -10,6 +22,22 @@ class TestSTIX(unittest.TestCase):
     def _assert_multiple_equal(self, reference, *elements):
         for element in elements:
             self.assertEqual(reference, element)
+
+    @staticmethod
+    def _plant_template_definition(directory):
+        """Plant a template definition outside the MISP objects directory.
+
+        :param directory: a directory outside the template tree
+        :return: the object name that reaches it from the templates path
+        """
+        from os.path import relpath
+        from pathlib import Path
+        from pymisp import AbstractMISP
+        planted = Path(directory) / 'planted'
+        planted.mkdir()
+        with open(planted / 'definition.json', 'wt', encoding='utf-8') as f:
+            json.dump(PLANTED_TEMPLATE, f)
+        return relpath(planted, AbstractMISP().misp_objects_path)
 
     @staticmethod
     def _datetime_from_str(timestamp):

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from pymisp import MISPAttribute
 from stix.core import STIXPackage
 from uuid import uuid5, UUID
-from ._test_stix import TestSTIX
+from ._test_stix import PLANTED_TEMPLATE, TestSTIX
 
 _DEFAULT_ORGNAME = 'MISP'
 _ATTRIBUTE_EXCLUSION_LIST = ('disable_correlation', 'to_ids')
@@ -897,6 +897,43 @@ class TestSTIX2Export(TestSTIX):
         if attribute.get('comment'):
             self.assertEqual(custom_object.x_misp_comment, attribute['comment'])
         self.assertEqual(custom_object.x_misp_value, attribute['value'])
+
+    def _run_invalid_object_name_tests(self, event, rejected_name):
+        self.parser.parse_misp_event(event)
+        misp_object = self.parser._misp_event.objects[0]
+        custom_object = self.parser.stix_objects[-1]
+        # The name never reached template resolution: the object is generic,
+        # and carries no field that could only come from a template file.
+        self.assertEqual(misp_object.name, 'unknown-template')
+        self.assertFalse(misp_object._known_template)
+        self.assertNotEqual(
+            getattr(misp_object, 'meta-category', None),
+            PLANTED_TEMPLATE['meta-category']
+        )
+        self.assertEqual(custom_object.x_misp_name, 'unknown-template')
+        self.assertEqual(
+            custom_object.labels[0], 'misp:name="unknown-template"'
+        )
+        # Nothing is lost: the rejected name is kept as data.
+        self.assertIn(rejected_name, custom_object.x_misp_comment)
+        self.assertIn(event['uuid'], self.parser.warnings)
+        name_warnings = [
+            warning for warning in self.parser.warnings[event['uuid']]
+            if 'Invalid MISP object template name' in warning
+        ]
+        self.assertEqual(len(name_warnings), 1)
+        self.assertIn(rejected_name, name_warnings[0])
+
+    def _check_invalid_object_name_collection(self, parser, rejected_name):
+        custom_object = parser.stix_objects[-1]
+        self.assertEqual(custom_object.x_misp_name, 'unknown-template')
+        self.assertIn(rejected_name, custom_object.x_misp_comment)
+        name_warnings = [
+            warning for warning in parser.warnings['objects collection']
+            if 'Invalid MISP object template name' in warning
+        ]
+        self.assertEqual(len(name_warnings), 1)
+        self.assertIn(rejected_name, name_warnings[0])
 
     def _run_custom_object_tests(self, misp_object, custom_object, object_ref, identity_id):
         name = misp_object['name']

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -9,7 +9,7 @@ from misp_stix_converter import (
     ExternalSTIX2Mapping, ExternalSTIX2toMISPParser, InternalSTIX2toMISPParser,
     MISP_org_uuid)
 from uuid import UUID, uuid5
-from ._test_stix import TestSTIX
+from ._test_stix import PLANTED_TEMPLATE, TestSTIX
 from .update_documentation import (
     AttributesDocumentationUpdater, GalaxiesDocumentationUpdater,
     ObjectsDocumentationUpdater)
@@ -3242,6 +3242,40 @@ class TestInternalSTIX2Import(TestSTIX2Import):
                     self._get_data_value(attribute.data),
                     custom_attribute['data']
                 )
+
+    def _check_custom_object_invalid_name(
+            self, misp_object, custom_object, warnings):
+        rejected_name = custom_object.x_misp_name
+        # The name never reached template resolution: the object is generic,
+        # and carries no field that could only come from a template file.
+        self.assertEqual(misp_object.name, 'unknown-template')
+        self.assertFalse(misp_object._known_template)
+        object_fields = misp_object.to_dict()
+        for template_field in ('template_uuid', 'template_version',
+                               'description'):
+            self.assertNotIn(
+                template_field, object_fields,
+                f'`{template_field}` should not be read from a file'
+            )
+        self.assertNotEqual(
+            getattr(misp_object, 'meta-category', None),
+            PLANTED_TEMPLATE['meta-category']
+        )
+        # The meta-category still comes from the STIX content itself.
+        self.assertEqual(
+            misp_object.category, custom_object.x_misp_meta_category
+        )
+        # Nothing is lost: the rejected name is kept as data.
+        self.assertIn(rejected_name, misp_object.comment)
+        name_warnings = [
+            warning for parser_warnings in warnings.values()
+            for warning in parser_warnings
+            if 'Invalid MISP object template name' in warning
+        ]
+        self.assertEqual(len(name_warnings), 1)
+        self.assertIn(custom_object.id, name_warnings[0])
+        self.assertIn(rejected_name, name_warnings[0])
+        return misp_object
 
     def _check_custom_object_injected_fields(
             self, misp_object, custom_object, warnings):

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -93,6 +93,14 @@ class TestSTIX2Bundles:
 class TestSTIX2Import(TestSTIX):
     _UUIDv4 = UUID('76beed5f-7251-457e-8c2a-b45f7b589d3d')
 
+    @staticmethod
+    def _reported_messages(reports: dict) -> list:
+        """Flatten the errors or warnings of every parsed identifier."""
+        return [
+            message for identifier_reports in reports.values()
+            for message in identifier_reports
+        ]
+
     def _check_object_attribute_uuid(self, attr, object_id, value=None):
         self.assertEqual(
             attr.uuid,
@@ -2937,6 +2945,26 @@ class TestInternalSTIX2Import(TestSTIX2Import):
             )
         self.assertEqual(cluster.description, stix_object.description)
         return cluster.meta
+
+    def _check_galaxy_with_undefined_labels(self, event, stix_object, errors):
+        """A galaxy object no label can dispatch is dropped, never silently."""
+        self.assertFalse(event.galaxies)
+        self.assertTrue(
+            any(
+                stix_object.id in error
+                for error in self._reported_messages(errors)
+            ),
+            f'{stix_object.id} was dropped without any error reported'
+        )
+
+    def _check_galaxy_without_name_label(self, stix_object, warnings):
+        """The galaxy type label alone is enough to convert the object."""
+        label_warnings = [
+            warning for warning in self._reported_messages(warnings)
+            if 'Missing MISP galaxy name label' in warning
+        ]
+        self.assertEqual(len(label_warnings), 1)
+        self.assertIn(stix_object.id, label_warnings[0])
 
     def _check_generic_malware_galaxy(self, galaxy, malware):
         meta = self._check_galaxy_fields_with_external_id(

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -91,6 +91,19 @@ class TestSTIX2Bundles:
 
 
 class TestSTIX2Import(TestSTIX):
+    # Opinion is a STIX 2.1 object type, but one in a 2.0 Bundle reaches the
+    # import as a Dict-Form Object, so both versions need the mapping.
+    __opinion_mapping = {
+        'strongly-disagree': 0,
+        'disagree': 25,
+        'neutral': 50,
+        'agree': 75,
+        'strongly-agree': 100
+    }
+
+    def opinion_mapping(self, field):
+        return self.__opinion_mapping.get(field)
+
     _UUIDv4 = UUID('76beed5f-7251-457e-8c2a-b45f7b589d3d')
 
     @staticmethod
@@ -100,6 +113,49 @@ class TestSTIX2Import(TestSTIX):
             message for identifier_reports in reports.values()
             for message in identifier_reports
         ]
+
+    @staticmethod
+    def _dict_form_timestamp(timestamp: str):
+        """The `datetime` a dict-form object's timestamp string stands for.
+
+        Only typed STIX objects parse their timestamps: the ones left as plain
+        dicts keep the string the document carried.
+        """
+        return datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+
+    def _check_dict_form_analyst_note(self, misp_note, stix_note):
+        """A Note the STIX version does not know arrives as a plain dict."""
+        self.assertIsInstance(stix_note, dict)
+        self.assertEqual(misp_note.uuid, stix_note['id'].split('--')[1])
+        self.assertEqual(misp_note.note, stix_note['content'])
+        self.assertEqual(misp_note.authors, stix_note['authors'][0])
+        self.assertEqual(misp_note.language, stix_note['lang'])
+        for field in ('created', 'modified'):
+            self.assertEqual(
+                getattr(misp_note, field),
+                self._dict_form_timestamp(stix_note[field])
+            )
+
+    def _check_dict_form_analyst_opinion(self, misp_opinion, stix_opinion):
+        """An Opinion the STIX version does not know arrives as a plain dict."""
+        self.assertIsInstance(stix_opinion, dict)
+        self.assertEqual(misp_opinion.uuid, stix_opinion['id'].split('--')[1])
+        if 'x_misp_opinion' in stix_opinion:
+            self.assertEqual(
+                misp_opinion.opinion, stix_opinion['x_misp_opinion']
+            )
+        else:
+            self.assertEqual(
+                misp_opinion.opinion,
+                self.opinion_mapping(stix_opinion['opinion'])
+            )
+        self.assertEqual(misp_opinion.comment, stix_opinion['explanation'])
+        self.assertEqual(misp_opinion.authors, stix_opinion['authors'][0])
+        for field in ('created', 'modified'):
+            self.assertEqual(
+                getattr(misp_opinion, field),
+                self._dict_form_timestamp(stix_opinion[field])
+            )
 
     def _check_duplicate_object_id_warning(self, object_id, warnings):
         """The last occurrence wins, but the shadowing is never silent."""
@@ -478,17 +534,6 @@ class TestSTIX21Import(TestSTIX2Import):
     _ext_galaxies_v21 = defaultdict(dict)
     _ext_attributes_v21 = defaultdict(dict)
     _ext_objects_v21 = defaultdict(dict)
-
-    __opinion_mapping = {
-        'strongly-disagree': 0,
-        'disagree': 25,
-        'neutral': 50,
-        'agree': 75,
-        'strongly-agree': 100
-    }
-
-    def opinion_mapping(self, field):
-        return self.__opinion_mapping.get(field)
 
     @classmethod
     def tearDownClass(self):

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -101,6 +101,15 @@ class TestSTIX2Import(TestSTIX):
             for message in identifier_reports
         ]
 
+    def _check_duplicate_object_id_warning(self, object_id, warnings):
+        """The last occurrence wins, but the shadowing is never silent."""
+        duplicate_warnings = [
+            warning for warning in self._reported_messages(warnings)
+            if 'Duplicate STIX object id' in warning
+        ]
+        self.assertEqual(len(duplicate_warnings), 1)
+        self.assertIn(object_id, duplicate_warnings[0])
+
     def _check_object_attribute_uuid(self, attr, object_id, value=None):
         self.assertEqual(
             attr.uuid,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5875,6 +5875,14 @@ def get_event_with_credential_object():
     return event
 
 
+def get_event_with_object_with_invalid_name(name):
+    event = deepcopy(_BASE_EVENT)
+    misp_object = dict(_populate_object(_TEST_BANK_ACCOUNT_OBJECT))
+    misp_object['name'] = name
+    event['Event']['Object'] = [misp_object]
+    return event
+
+
 def get_event_with_custom_objects():
     event = deepcopy(_BASE_EVENT)
     event['Event']['Object'] = [

--- a/tests/test_external_stix20_bundles.py
+++ b/tests/test_external_stix20_bundles.py
@@ -2113,6 +2113,19 @@ class TestExternalSTIX20Bundles(TestSTIX2Bundles):
     ############################################################################
 
     @classmethod
+    def get_bundle_with_duplicate_object_ids(cls):
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        shadowed = deepcopy(cls.__indicator)
+        indicator = deepcopy(cls.__indicator)
+        shadowed['pattern'] = "[ipv4-addr:value = '198.51.100.0/24']"
+        report.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [
+            deepcopy(cls.__identity), report, shadowed, indicator
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_report_description(cls):
         bundle = deepcopy(cls.__bundle)
         indicator = deepcopy(cls.__indicator)

--- a/tests/test_external_stix20_bundles.py
+++ b/tests/test_external_stix20_bundles.py
@@ -815,6 +815,32 @@ _SECTOR_GALAXY = [
         ]
     }
 ]
+_DICT_FORM_OBJECTS = [
+    # STIX 2.0 has neither a Note nor an Opinion object type: parsed with
+    # `allow_custom`, both reach the loaders as plain dicts rather than typed
+    # objects.
+    {
+        "type": "note",
+        "id": "note--31fc7048-9ede-4db9-a423-ef97670ed4c6",
+        "created": "2024-06-12T12:52:45.000Z",
+        "modified": "2024-06-12T12:52:45.000Z",
+        "abstract": "Analyst note in a STIX 2.0 Bundle",
+        "content": "Hop point observed in the same campaign",
+        "authors": ["john.doe@foo.bar"],
+        "lang": "en",
+        "object_refs": ["indicator--031778a4-057f-48e6-9db9-c8d72b81ccd5"]
+    },
+    {
+        "type": "opinion",
+        "id": "opinion--e6039f2f-d705-41d0-859d-89845546cd7b",
+        "created": "2024-06-12T12:49:45.000Z",
+        "modified": "2024-06-12T12:51:41.000Z",
+        "explanation": "Fully agree with the malicious nature of the range",
+        "authors": ["opinion@foo.bar"],
+        "opinion": "strongly-agree",
+        "object_refs": ["indicator--031778a4-057f-48e6-9db9-c8d72b81ccd5"]
+    }
+]
 _IP_ADDRESS_ATTRIBUTES = [
     {
         "type": "observed-data",
@@ -2111,6 +2137,12 @@ class TestExternalSTIX20Bundles(TestSTIX2Bundles):
     ############################################################################
     #                              EVENTS SAMPLES                              #
     ############################################################################
+
+    @classmethod
+    def get_bundle_with_dict_form_objects(cls):
+        return cls.__assemble_bundle(
+            deepcopy(cls.__indicator), *deepcopy(_DICT_FORM_OBJECTS)
+        )
 
     @classmethod
     def get_bundle_with_duplicate_object_ids(cls):

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -62,6 +62,19 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         event = self.parser.misp_event
         self._check_tlp_marking_tags(event.attributes, TLP_1_0_EXPECTED_TAGS)
 
+    def test_stix20_bundle_with_dict_form_objects(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_dict_form_objects()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, indicator, note, opinion = bundle.objects
+        self._check_misp_event_features(event, report)
+        self.assertEqual(self.parser.errors, {})
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self._check_dict_form_analyst_note(attribute.notes[0], note)
+        self._check_dict_form_analyst_opinion(attribute.opinions[0], opinion)
+
     def test_stix20_bundle_with_duplicate_object_ids(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -19,12 +19,7 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path
         from tempfile import TemporaryDirectory
-        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
-        empty_bundle = (
-            '{"type": "bundle", '
-            '"id": "bundle--5b8e0f9a-0000-4000-8000-0000000000e2", '
-            '"spec_version": "2.0", "objects": []}'
-        )
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_campaign_galaxy()
         with TemporaryDirectory() as tmp_dir:
             filename = Path(tmp_dir) / 'external.stix20.json'
             with open(filename, 'wt', encoding='utf-8') as f:
@@ -37,14 +32,13 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
-            # Forcing the Internal parser on genuinely external SDOs may crash
-            # converters that dispatch on MISP labels, so the mismatch warning
-            # is checked with a bundle both parsers survive.
-            filename = Path(tmp_dir) / 'empty.stix20.json'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(empty_bundle)
+            # Forcing the Internal parser on genuinely external SDOs used to
+            # crash the converters dispatching on MISP labels: the objects are
+            # dropped one by one, each of them reported, and no exception
+            # escapes the entry function.
             results = stix_2_to_misp(
-                filename, classification='internal', output_dir=Path(tmp_dir)
+                filename, classification='internal', debug=True,
+                output_dir=Path(tmp_dir)
             )
             self.assertEqual(results['success'], 1)
             self.assertTrue(
@@ -54,6 +48,12 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
                     for warning in warnings
                 )
             )
+            # The Campaign converter has no local error handling and the
+            # Indicator has no MISP label to dispatch on: both used to escape.
+            reported = '\n'.join(self._reported_messages(results['errors']))
+            _, _, campaign, indicator, attribute_campaign, _ = bundle.objects
+            for stix_object in (campaign, indicator, attribute_campaign):
+                self.assertIn(stix_object.id, reported)
 
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -62,6 +62,38 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         event = self.parser.misp_event
         self._check_tlp_marking_tags(event.attributes, TLP_1_0_EXPECTED_TAGS)
 
+    def test_stix20_bundle_with_duplicate_object_ids(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, shadowed, indicator = bundle.objects
+        self._check_misp_event_features(event, report)
+        # Last occurrence wins: the first Indicator sharing the id is gone.
+        self.assertEqual(len(event.attributes), 1)
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self.assertEqual(attribute.value, '223.166.0.0/15')
+        self._check_duplicate_object_id_warning(
+            shadowed.id, self.parser.warnings
+        )
+
+    def test_stix20_duplicate_object_ids_reported_in_result(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'duplicate_ids.stix20.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            results = stix_2_to_misp(filename, output_dir=Path(tmp_dir))
+        self.assertEqual(results['success'], 1)
+        shadowed = bundle.objects[2]
+        self._check_duplicate_object_id_warning(
+            shadowed.id, results['warnings']
+        )
+
     def test_stix20_bundle_with_event_title_and_producer(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_without_report()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -2910,6 +2910,19 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(*deepcopy(_ANALYST_DATA_SAMPLES))
 
     @classmethod
+    def get_bundle_with_duplicate_object_ids(cls):
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        shadowed = deepcopy(cls.__indicator)
+        indicator = deepcopy(cls.__indicator)
+        shadowed['pattern'] = "[ipv4-addr:value = '198.51.100.0/24']"
+        grouping.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [
+            deepcopy(cls.__identity), grouping, shadowed, indicator
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_grouping_description(cls):
         bundle = deepcopy(cls.__bundle)
         indicator = deepcopy(cls.__indicator)

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -70,12 +70,7 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path
         from tempfile import TemporaryDirectory
-        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
-        empty_bundle = (
-            '{"type": "bundle", '
-            '"id": "bundle--5b8e0f9a-0000-4000-8000-0000000000e1", '
-            '"spec_version": "2.1", "objects": []}'
-        )
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_campaign_galaxy()
         with TemporaryDirectory() as tmp_dir:
             filename = Path(tmp_dir) / 'external.stix21.json'
             with open(filename, 'wt', encoding='utf-8') as f:
@@ -88,14 +83,13 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
-            # Forcing the Internal parser on genuinely external SDOs may crash
-            # converters that dispatch on MISP labels, so the mismatch warning
-            # is checked with a bundle both parsers survive.
-            filename = Path(tmp_dir) / 'empty.stix21.json'
-            with open(filename, 'wt', encoding='utf-8') as f:
-                f.write(empty_bundle)
+            # Forcing the Internal parser on genuinely external SDOs used to
+            # crash the converters dispatching on MISP labels: the objects are
+            # dropped one by one, each of them reported, and no exception
+            # escapes the entry function.
             results = stix_2_to_misp(
-                filename, classification='internal', output_dir=Path(tmp_dir)
+                filename, classification='internal', debug=True,
+                output_dir=Path(tmp_dir)
             )
             self.assertEqual(results['success'], 1)
             self.assertTrue(
@@ -105,6 +99,12 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
                     for warning in warnings
                 )
             )
+            # The Campaign converter has no local error handling and the
+            # Indicator has no MISP label to dispatch on: both used to escape.
+            reported = '\n'.join(self._reported_messages(results['errors']))
+            _, _, campaign, indicator, attribute_campaign, _ = bundle.objects
+            for stix_object in (campaign, indicator, attribute_campaign):
+                self.assertIn(stix_object.id, reported)
 
     def test_stix21_bundle_with_acs_marking(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_acs_marking()

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -177,6 +177,38 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             f'misp-galaxy:producer="{self.parser.producer}"'
         )
 
+    def test_stix21_bundle_with_duplicate_object_ids(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_duplicate_object_ids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, shadowed, indicator = bundle.objects
+        self._check_misp_event_features_from_grouping(event, grouping)
+        # Last occurrence wins: the first Indicator sharing the id is gone.
+        self.assertEqual(len(event.attributes), 1)
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self.assertEqual(attribute.value, '223.166.0.0/15')
+        self._check_duplicate_object_id_warning(
+            shadowed.id, self.parser.warnings
+        )
+
+    def test_stix21_duplicate_object_ids_reported_in_result(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_duplicate_object_ids()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'duplicate_ids.stix21.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            results = stix_2_to_misp(filename, output_dir=Path(tmp_dir))
+        self.assertEqual(results['success'], 1)
+        shadowed = bundle.objects[2]
+        self._check_duplicate_object_id_warning(
+            shadowed.id, results['warnings']
+        )
+
     def test_stix21_bundle_with_grouping_description(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_grouping_description()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -8287,6 +8287,19 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(indicator, observed_data)
 
     @classmethod
+    def get_bundle_with_duplicate_object_ids(cls):
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        shadowed = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        indicator = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        shadowed['pattern'] = "[domain-name:value = 'shadowed.example.com']"
+        report.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [
+            deepcopy(cls.__identity), report, shadowed, indicator
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_event_report(cls):
         return cls.__assemble_bundle(*_EVENT_REPORT)
 

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -1995,6 +1995,24 @@ _CUSTOM_OBJECTS = [
         "x_misp_name": "report"
     }
 ]
+_CUSTOM_OBJECT_WITH_INVALID_NAME = {
+    "type": "x-misp-object",
+    "id": "x-misp-object--0e9f0ad0-2f16-4bdb-a1a0-2f1a4bfd0b0e",
+    "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+    "created": "2020-10-25T16:22:00.000Z",
+    "modified": "2020-10-25T16:22:00.000Z",
+    "labels": ['misp:name="bank-account"', 'misp:meta-category="financial"'],
+    "x_misp_attributes": [
+        {
+            "type": "iban",
+            "object_relation": "iban",
+            "value": "LU1234567890ABCDEF1234567890",
+            "uuid": "8acaad62-227a-4988-96e7-4586847421a3"
+        }
+    ],
+    "x_misp_meta_category": "financial",
+    "x_misp_name": "../../../../../../../../planted"
+}
 _CUSTOM_OBJECT_WITH_INJECTED_FIELDS = {
     "type": "x-misp-object",
     "id": "x-misp-object--695e7924-2518-4054-9cea-f82853d37410",
@@ -8498,6 +8516,13 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_custom_object_with_injected_fields(cls):
         return cls.__assemble_bundle(_CUSTOM_OBJECT_WITH_INJECTED_FIELDS)
+
+    @classmethod
+    def get_bundle_with_custom_object_with_invalid_name(cls, name=None):
+        custom_object = _CUSTOM_OBJECT_WITH_INVALID_NAME
+        if name is not None:
+            custom_object = {**custom_object, 'x_misp_name': name}
+        return cls.__assemble_bundle(custom_object)
 
     @classmethod
     def get_bundle_with_custom_objects(cls):

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -2039,6 +2039,45 @@ _CUSTOM_OBJECT_WITH_INJECTED_FIELDS = {
     "x_misp_meta_category": "financial",
     "x_misp_name": "bank-account"
 }
+_DICT_FORM_OBJECTS = [
+    # STIX 2.0 has neither a Note nor an Opinion object type: parsed with
+    # `allow_custom`, both reach the loaders as plain dicts rather than typed
+    # objects.
+    {
+        "type": "note",
+        "id": "note--31fc7048-9ede-4db9-a423-ef97670ed4c6",
+        "created": "2024-06-12T12:52:45.000Z",
+        "modified": "2024-06-12T12:52:45.000Z",
+        "abstract": "Analyst note in a STIX 2.0 Bundle",
+        "content": "Domain used by the threat actor to host its payloads",
+        "authors": ["john.doe@foo.bar"],
+        "lang": "en",
+        "object_refs": ["indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f"],
+        "labels": ['misp:context-layer="Analyst Note"']
+    },
+    {
+        "type": "opinion",
+        "id": "opinion--e6039f2f-d705-41d0-859d-89845546cd7b",
+        "created": "2024-06-12T12:49:45.000Z",
+        "modified": "2024-06-12T12:51:41.000Z",
+        "explanation": "Fully agree with the malicious nature of the domain",
+        "authors": ["opinion@foo.bar"],
+        "opinion": "strongly-agree",
+        "object_refs": ["indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f"],
+        "labels": ['misp:context-layer="Analyst Opinion"'],
+        "x_misp_opinion": 90
+    },
+    {
+        "type": "note",
+        "id": "note--44ceb474-6493-48de-b753-bbd0470e0e54",
+        "created": "2024-06-11T11:34:42.000Z",
+        "modified": "2024-06-11T11:34:42.000Z",
+        "abstract": "Summary of the case",
+        "content": "A victim reported a malicious domain",
+        "object_refs": ["indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f"],
+        "labels": ['misp:data-layer="Event Report"']
+    }
+]
 _DOMAIN_INDICATOR_ATTRIBUTE = {
     "type": "indicator",
     "id": "indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
@@ -8285,6 +8324,21 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
         observed_data = deepcopy(_DOMAIN_IP_OBSERVABLE_OBJECTS[0])
         observed_data['labels'].append('Object tag')
         return cls.__assemble_bundle(indicator, observed_data)
+
+    @classmethod
+    def get_bundle_with_dict_form_objects(cls):
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        indicator = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        note, opinion, event_report = deepcopy(_DICT_FORM_OBJECTS)
+        report.update(
+            cls._populate_references(indicator['id'], event_report['id'])
+        )
+        bundle['objects'] = [
+            deepcopy(cls.__identity), report, indicator, note, opinion,
+            event_report
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
 
     @classmethod
     def get_bundle_with_duplicate_object_ids(cls):

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -8358,6 +8358,12 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(_INTRUSION_SET_GALAXY)
 
     @classmethod
+    def get_bundle_with_malformed_galaxy_labels(cls, labels):
+        malware = deepcopy(_MALWARE_GALAXY)
+        malware['labels'] = labels
+        return cls.__assemble_bundle(malware)
+
+    @classmethod
     def get_bundle_with_malware_galaxy(cls):
         return cls.__assemble_bundle(_MALWARE_GALAXY)
 

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -1644,6 +1644,22 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         self.assertEqual(port.value, observables["0"].x_misp_port)
         self.assertEqual(free_tag, port.tags[0].name)
 
+    def test_stix20_bundle_with_duplicate_object_ids(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, shadowed, indicator = bundle.objects
+        self._check_misp_event_features(event, report)
+        # Last occurrence wins: the first Indicator sharing the id is gone.
+        self.assertEqual(len(event.attributes), 1)
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self.assertEqual(attribute.value, 'circl.lu')
+        self._check_duplicate_object_id_warning(
+            shadowed.id, self.parser.warnings
+        )
+
     def test_stix20_bundle_with_event_report(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_event_report()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -111,6 +111,30 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         with self.assertRaises(ValueError):
             stix_2_to_misp('unused.json', classification='banana')
 
+    def test_stix20_object_template_name_validation(self):
+        from misp_stix_converter.tools.misp_object_templates import (
+            _is_template_name)
+        from pymisp import AbstractMISP
+        for name in ('../../../../etc', 'foo/bar', 'foo\\bar', '..', '.',
+                     'bank account', 'bank\taccount', '', '-dash-first',
+                     None, 42):
+            self.assertFalse(
+                _is_template_name(name),
+                f'{name!r} must not reach template resolution'
+            )
+        # Every template pymisp ships keeps resolving as before, upper case
+        # and underscores included.
+        templates = [
+            path.name for path in AbstractMISP().misp_objects_path.iterdir()
+            if path.is_dir()
+        ]
+        self.assertTrue(templates)
+        for template in templates:
+            self.assertTrue(
+                _is_template_name(template),
+                f'{template} is a template name pymisp ships'
+            )
+
     ############################################################################
     #                       MISP ATTRIBUTES IMPORT TESTS                       #
     ############################################################################
@@ -2317,6 +2341,33 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         self._check_custom_object_injected_fields(
             misp_object, custom_object, self.parser.warnings
         )
+
+    def test_stix20_bundle_with_custom_object_with_invalid_name(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_custom_object_with_invalid_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, custom_object = bundle.objects
+        misp_object = self._check_misp_event_features(event, report)[0]
+        self._check_custom_object_invalid_name(
+            misp_object, custom_object, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_custom_object_name_traversing_out_of_the_templates(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            traversal = self._plant_template_definition(tmp_dir)
+            bundle = TestInternalSTIX20Bundles.get_bundle_with_custom_object_with_invalid_name(
+                traversal
+            )
+            self.parser.load_stix_bundle(bundle)
+            self.parser.parse_stix_bundle()
+            event = self.parser.misp_event
+            _, report, custom_object = bundle.objects
+            misp_object = self._check_misp_event_features(event, report)[0]
+            self._check_custom_object_invalid_name(
+                misp_object, custom_object, self.parser.warnings
+            )
 
     def test_stix20_bundle_with_custom_objects(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_custom_objects()

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -1644,6 +1644,25 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         self.assertEqual(port.value, observables["0"].x_misp_port)
         self.assertEqual(free_tag, port.tags[0].name)
 
+    def test_stix20_bundle_with_dict_form_objects(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_dict_form_objects()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, indicator, note, opinion, event_report = bundle.objects
+        self._check_misp_event_features(event, report)
+        self.assertEqual(self.parser.errors, {})
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self._check_dict_form_analyst_note(attribute.notes[0], note)
+        self._check_dict_form_analyst_opinion(attribute.opinions[0], opinion)
+        misp_event_report = event.event_reports[0]
+        self.assertEqual(
+            misp_event_report.uuid, event_report['id'].split('--')[1]
+        )
+        self.assertEqual(misp_event_report.name, event_report['abstract'])
+        self.assertEqual(misp_event_report.content, event_report['content'])
+
     def test_stix20_bundle_with_duplicate_object_ids(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -1947,6 +1947,46 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
             galaxy=event.galaxies[0], intrusion_set=intrusion_set
         )
 
+    def test_stix20_bundle_with_malformed_galaxy_labels(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_malformed_galaxy_labels(
+            ['misp:galaxy-type="mitre-malware"']
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, malware = bundle.objects
+        self._check_misp_event_features(event, report)
+        # The galaxy is the one the type label names, name label or not.
+        self._check_malware_galaxy(event.galaxies[0], malware)
+        self._check_galaxy_without_name_label(malware, self.parser.warnings)
+
+    def test_stix20_bundle_with_malformed_galaxy_labels_as_tags(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_malformed_galaxy_labels(
+            ['misp:galaxy-type="mitre-malware"']
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        malware = bundle.objects[-1]
+        self.assertIn(
+            f'misp-galaxy:mitre-malware="{malware.name}"',
+            {tag.name for tag in event.tags}
+        )
+
+    def test_stix20_bundle_with_undefined_galaxy_labels(self):
+        bundles = TestInternalSTIX20Bundles
+        for labels in (['misp:galaxy-name="Malware"'],
+                       ['misp:galaxy-type=""']):
+            with self.subTest(labels=labels):
+                self.setUp()
+                bundle = bundles.get_bundle_with_malformed_galaxy_labels(labels)
+                self.parser.load_stix_bundle(bundle)
+                self.parser.parse_stix_bundle()
+                self._check_galaxy_with_undefined_labels(
+                    self.parser.misp_event, bundle.objects[-1],
+                    self.parser.errors
+                )
+
     def test_stix20_bundle_with_malware_galaxy(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_malware_galaxy()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -2429,6 +2429,35 @@ _CUSTOM_OBJECT_WITH_INJECTED_FIELDS = {
     "x_misp_meta_category": "financial",
     "x_misp_name": "bank-account"
 }
+_DICT_FORM_OBJECTS = [
+    # `x-misp-analyst-note` and `x-misp-analyst-opinion` are custom object
+    # types the converter only declares for STIX 2.0 - MISP writes Analyst
+    # Data as Note and Opinion objects in 2.1. Parsed with `allow_custom`, one
+    # of them in a 2.1 Bundle reaches the loaders as a plain dict rather than
+    # a typed object.
+    {
+        "type": "x-misp-analyst-note",
+        "spec_version": "2.1",
+        "id": "x-misp-analyst-note--31fc7048-9ede-4db9-a423-ef97670ed4c6",
+        "created": "2024-06-12T12:52:45.000Z",
+        "modified": "2024-06-12T12:52:45.000Z",
+        "object_ref": "indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+        "x_misp_author": "john.doe@foo.bar",
+        "x_misp_language": "en",
+        "x_misp_note": "Domain used by the threat actor to host its payloads"
+    },
+    {
+        "type": "x-misp-analyst-opinion",
+        "spec_version": "2.1",
+        "id": "x-misp-analyst-opinion--e6039f2f-d705-41d0-859d-89845546cd7b",
+        "created": "2024-06-12T12:49:45.000Z",
+        "modified": "2024-06-12T12:51:41.000Z",
+        "object_ref": "indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+        "x_misp_author": "opinion@foo.bar",
+        "x_misp_comment": "Fully agree with the malicious nature of the domain",
+        "x_misp_opinion": 90
+    }
+]
 _DOMAIN_INDICATOR_ATTRIBUTE = {
     "type": "indicator",
     "spec_version": "2.1",
@@ -10406,6 +10435,18 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
         observed_data, domain, ip = deepcopy(_DOMAIN_IP_OBSERVABLE_ATTRIBUTE[:-2])
         observed_data['labels'].append('Attribute tag')
         return cls.__assemble_bundle(indicator, observed_data, domain, ip)
+
+    @classmethod
+    def get_bundle_with_dict_form_objects(cls):
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        indicator = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        grouping.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [
+            deepcopy(cls.__identity), grouping, indicator,
+            *deepcopy(_DICT_FORM_OBJECTS)
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
 
     @classmethod
     def get_bundle_with_duplicate_object_ids(cls):

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -10408,6 +10408,19 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(indicator, observed_data, domain, ip)
 
     @classmethod
+    def get_bundle_with_duplicate_object_ids(cls):
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        shadowed = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        indicator = deepcopy(_DOMAIN_INDICATOR_ATTRIBUTE)
+        shadowed['pattern'] = "[domain-name:value = 'shadowed.example.com']"
+        grouping.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [
+            deepcopy(cls.__identity), grouping, shadowed, indicator
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_event_report(cls):
         return cls.__assemble_bundle(*_EVENT_REPORT)
 

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -2383,6 +2383,25 @@ _CUSTOM_OBJECTS = [
         "x_misp_name": "report"
     }
 ]
+_CUSTOM_OBJECT_WITH_INVALID_NAME = {
+    "type": "x-misp-object",
+    "spec_version": "2.1",
+    "id": "x-misp-object--0e9f0ad0-2f16-4bdb-a1a0-2f1a4bfd0b0e",
+    "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+    "created": "2020-10-25T16:22:00.000Z",
+    "modified": "2020-10-25T16:22:00.000Z",
+    "labels": ['misp:name="bank-account"', 'misp:meta-category="financial"'],
+    "x_misp_attributes": [
+        {
+            "type": "iban",
+            "object_relation": "iban",
+            "value": "LU1234567890ABCDEF1234567890",
+            "uuid": "8acaad62-227a-4988-96e7-4586847421a3"
+        }
+    ],
+    "x_misp_meta_category": "financial",
+    "x_misp_name": "../../../../../../../../planted"
+}
 _CUSTOM_OBJECT_WITH_INJECTED_FIELDS = {
     "type": "x-misp-object",
     "spec_version": "2.1",
@@ -10626,6 +10645,13 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_custom_object_with_injected_fields(cls):
         return cls.__assemble_bundle(_CUSTOM_OBJECT_WITH_INJECTED_FIELDS)
+
+    @classmethod
+    def get_bundle_with_custom_object_with_invalid_name(cls, name=None):
+        custom_object = _CUSTOM_OBJECT_WITH_INVALID_NAME
+        if name is not None:
+            custom_object = {**custom_object, 'x_misp_name': name}
+        return cls.__assemble_bundle(custom_object)
 
     @classmethod
     def get_bundle_with_custom_objects(cls):

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -10483,6 +10483,12 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(*_LOCATION_GALAXIES)
 
     @classmethod
+    def get_bundle_with_malformed_galaxy_labels(cls, labels):
+        malware = deepcopy(_MALWARE_GALAXY)
+        malware['labels'] = labels
+        return cls.__assemble_bundle(malware)
+
+    @classmethod
     def get_bundle_with_malware_galaxy(cls):
         return cls.__assemble_bundle(_MALWARE_GALAXY)
 

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -104,6 +104,30 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         with self.assertRaises(ValueError):
             stix_2_to_misp('unused.json', classification='banana')
 
+    def test_stix21_object_template_name_validation(self):
+        from misp_stix_converter.tools.misp_object_templates import (
+            _is_template_name)
+        from pymisp import AbstractMISP
+        for name in ('../../../../etc', 'foo/bar', 'foo\\bar', '..', '.',
+                     'bank account', 'bank\taccount', '', '-dash-first',
+                     None, 42):
+            self.assertFalse(
+                _is_template_name(name),
+                f'{name!r} must not reach template resolution'
+            )
+        # Every template pymisp ships keeps resolving as before, upper case
+        # and underscores included.
+        templates = [
+            path.name for path in AbstractMISP().misp_objects_path.iterdir()
+            if path.is_dir()
+        ]
+        self.assertTrue(templates)
+        for template in templates:
+            self.assertTrue(
+                _is_template_name(template),
+                f'{template} is a template name pymisp ships'
+            )
+
     ############################################################################
     #                       MISP ATTRIBUTES IMPORT TESTS                       #
     ############################################################################
@@ -2768,6 +2792,33 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self._check_custom_object_injected_fields(
             misp_object, custom_object, self.parser.warnings
         )
+
+    def test_stix21_bundle_with_custom_object_with_invalid_name(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_custom_object_with_invalid_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, custom_object = bundle.objects
+        misp_object = self._check_misp_event_features_from_grouping(event, grouping)[0]
+        self._check_custom_object_invalid_name(
+            misp_object, custom_object, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_custom_object_name_traversing_out_of_the_templates(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            traversal = self._plant_template_definition(tmp_dir)
+            bundle = TestInternalSTIX21Bundles.get_bundle_with_custom_object_with_invalid_name(
+                traversal
+            )
+            self.parser.load_stix_bundle(bundle)
+            self.parser.parse_stix_bundle()
+            event = self.parser.misp_event
+            _, grouping, custom_object = bundle.objects
+            misp_object = self._check_misp_event_features_from_grouping(event, grouping)[0]
+            self._check_custom_object_invalid_name(
+                misp_object, custom_object, self.parser.warnings
+            )
 
     def test_stix21_bundle_with_custom_objects(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_custom_objects()

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -1969,6 +1969,22 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self.assertEqual(attribute.value, f'{domain.value}|{address.value}')
         self.assertEqual(attribute.tags[0].name, free_tag)
 
+    def test_stix21_bundle_with_duplicate_object_ids(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_duplicate_object_ids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, shadowed, indicator = bundle.objects
+        self._check_misp_event_features_from_grouping(event, grouping)
+        # Last occurrence wins: the first Indicator sharing the id is gone.
+        self.assertEqual(len(event.attributes), 1)
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self.assertEqual(attribute.value, 'circl.lu')
+        self._check_duplicate_object_id_warning(
+            shadowed.id, self.parser.warnings
+        )
+
     def test_stix21_bundle_with_event_report(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_event_report()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -1969,6 +1969,36 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self.assertEqual(attribute.value, f'{domain.value}|{address.value}')
         self.assertEqual(attribute.tags[0].name, free_tag)
 
+    def test_stix21_bundle_with_dict_form_objects(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_dict_form_objects()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, indicator, note, opinion = bundle.objects
+        self._check_misp_event_features_from_grouping(event, grouping)
+        self.assertEqual(self.parser.errors, {})
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.uuid, indicator.id.split('--')[1])
+        self.assertIsInstance(note, dict)
+        misp_note = attribute.notes[0]
+        self.assertEqual(misp_note.uuid, note['id'].split('--')[1])
+        self.assertEqual(misp_note.note, note['x_misp_note'])
+        self.assertEqual(misp_note.authors, note['x_misp_author'])
+        self.assertEqual(misp_note.language, note['x_misp_language'])
+        self.assertIsInstance(opinion, dict)
+        misp_opinion = attribute.opinions[0]
+        self.assertEqual(misp_opinion.uuid, opinion['id'].split('--')[1])
+        self.assertEqual(misp_opinion.opinion, opinion['x_misp_opinion'])
+        self.assertEqual(misp_opinion.comment, opinion['x_misp_comment'])
+        self.assertEqual(misp_opinion.authors, opinion['x_misp_author'])
+        for analyst_data, stix_object in (
+                (misp_note, note), (misp_opinion, opinion)):
+            for field in ('created', 'modified'):
+                self.assertEqual(
+                    getattr(analyst_data, field),
+                    self._dict_form_timestamp(stix_object[field])
+                )
+
     def test_stix21_bundle_with_duplicate_object_ids(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_duplicate_object_ids()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -2318,6 +2318,46 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
             cluster = galaxy.clusters[0]
             self.assertIn(f'misp-galaxy:{cluster.type}="{cluster.value}"', tag_names)
 
+    def test_stix21_bundle_with_malformed_galaxy_labels(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_malformed_galaxy_labels(
+            ['misp:galaxy-type="mitre-malware"']
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, malware = bundle.objects
+        self._check_misp_event_features_from_grouping(event, grouping)
+        # The galaxy is the one the type label names, name label or not.
+        self._check_malware_galaxy(event.galaxies[0], malware)
+        self._check_galaxy_without_name_label(malware, self.parser.warnings)
+
+    def test_stix21_bundle_with_malformed_galaxy_labels_as_tags(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_malformed_galaxy_labels(
+            ['misp:galaxy-type="mitre-malware"']
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        malware = bundle.objects[-1]
+        self.assertIn(
+            f'misp-galaxy:mitre-malware="{malware.name}"',
+            {tag.name for tag in event.tags}
+        )
+
+    def test_stix21_bundle_with_undefined_galaxy_labels(self):
+        bundles = TestInternalSTIX21Bundles
+        for labels in (['misp:galaxy-name="Malware"'],
+                       ['misp:galaxy-type=""']):
+            with self.subTest(labels=labels):
+                self.setUp()
+                bundle = bundles.get_bundle_with_malformed_galaxy_labels(labels)
+                self.parser.load_stix_bundle(bundle)
+                self.parser.parse_stix_bundle()
+                self._check_galaxy_with_undefined_labels(
+                    self.parser.misp_event, bundle.objects[-1],
+                    self.parser.errors
+                )
+
     def test_stix21_bundle_with_malware_galaxy(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_malware_galaxy()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -3863,6 +3863,33 @@ class TestSTIX20JSONObjectsExport(TestSTIX20ObjectsExport):
         )
         objects_documentation.check_export_mapping()
 
+    # Only the JSON input path: with a MISPEvent, pymisp resolves the template
+    # while the caller builds the event, before misp-stix sees any of it.
+    def test_event_with_object_with_invalid_name(self):
+        name = '../../../../../../../../planted'
+        event = get_event_with_object_with_invalid_name(name)
+        self._run_invalid_object_name_tests(event['Event'], name)
+
+    def test_event_with_object_name_traversing_out_of_the_templates(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            traversal = self._plant_template_definition(tmp_dir)
+            event = get_event_with_object_with_invalid_name(traversal)
+            self._run_invalid_object_name_tests(event['Event'], traversal)
+
+    def test_objects_collection_with_invalid_name(self):
+        name = '../../../../../../../../planted'
+        event = get_event_with_object_with_invalid_name(name)
+        misp_object = event['Event']['Object'][0]
+        for argument in (misp_object, {'Object': [misp_object]}):
+            parser = MISPtoSTIX20Parser()
+            parser.parse_misp_object(argument)
+            self._check_invalid_object_name_collection(parser, name)
+        parser = MISPtoSTIX20Parser()
+        parser.parse_misp_objects([misp_object])
+        self._check_invalid_object_name_collection(parser, name)
+        self.assertEqual(misp_object['name'], name)
+
     def test_embedded_indicator_object_galaxy(self):
         event = get_embedded_indicator_object_galaxy()
         self._test_embedded_indicator_object_galaxy(event['Event'])

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -4885,6 +4885,33 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
         )
         objects_documentation.check_export_mapping()
 
+    # Only the JSON input path: with a MISPEvent, pymisp resolves the template
+    # while the caller builds the event, before misp-stix sees any of it.
+    def test_event_with_object_with_invalid_name(self):
+        name = '../../../../../../../../planted'
+        event = get_event_with_object_with_invalid_name(name)
+        self._run_invalid_object_name_tests(event['Event'], name)
+
+    def test_event_with_object_name_traversing_out_of_the_templates(self):
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            traversal = self._plant_template_definition(tmp_dir)
+            event = get_event_with_object_with_invalid_name(traversal)
+            self._run_invalid_object_name_tests(event['Event'], traversal)
+
+    def test_objects_collection_with_invalid_name(self):
+        name = '../../../../../../../../planted'
+        event = get_event_with_object_with_invalid_name(name)
+        misp_object = event['Event']['Object'][0]
+        for argument in (misp_object, {'Object': [misp_object]}):
+            parser = MISPtoSTIX21Parser()
+            parser.parse_misp_object(argument)
+            self._check_invalid_object_name_collection(parser, name)
+        parser = MISPtoSTIX21Parser()
+        parser.parse_misp_objects([misp_object])
+        self._check_invalid_object_name_collection(parser, name)
+        self.assertEqual(misp_object['name'], name)
+
     def test_embedded_indicator_object_galaxy(self):
         event = get_embedded_indicator_object_galaxy()
         self._test_embedded_indicator_object_galaxy(event['Event'])


### PR DESCRIPTION
Fixes #94 — MISP object template names reaching pymisp's template-path
resolution are validated in both directions. A name is one path component, so
anything else is replaced by `unknown-template`, the object converted without a
template, the rejected name kept in its comment and a warning recorded.

Fixes #92 — the Internal path dispatches on `field=value` labels that content is
free not to carry, or to write without the `=` the split needs. Parsing them no
longer crashes, and an object no converter could handle at all is reported with
its id rather than escaping.

Fixes #91 — objects load into a dict keyed by their STIX id, so two objects
sharing one id kept only the last with nothing said about it. The last
occurrence still wins, but a warning now names the id and what it puts at stake.

Fixes #103 — object types the STIX version a bundle is parsed against does not
know are kept as plain dictionaries: a Note, Opinion, Grouping, Location or
Malware Analysis in a 2.0 bundle, an `x-misp-analyst-note` or `x-misp-opinion`
in a 2.1 one. Loading read them with attribute access, so each raised, was
dropped, and dragged a second misleading error out of the report referencing it.
Loading now reads every object through the interface both forms share. The Note
converter came along because it picked its branch the same way — once loading
succeeds, a Note whose labels read as empty takes no branch and vanishes with no
error at all.

Also carries one fix the merge surfaced: #92's catch-all in `_handle_object` was
swallowing `UnknownStixObjectTypeError` before the dispatcher that reports it by
type, which turned #104's per-type error summary into one traceback per object.

Known gaps, deliberately left: the per-type converters under `stix2misp/converters/`
still read incoming objects with attribute access, so a dict-form Location or
Malware Analysis is reported by id and dropped rather than converted — sweeping
them cascades into the helpers every converter shares. No external 2.1 test for
dict-form objects: every type that parser's loading mapping routes is typed at
2.1, so the case is unreachable there.