### PR TITLE
Report the silent losses of the STIX 2 import

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_indicator_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_indicator_converter.py
@@ -9,6 +9,7 @@ from ..exceptions import (
     UndefinedIndicatorError, UndefinedSTIXObjectError,
     UnknownParsingFunctionError, UnknownPatternMappingError)
 from ..stix2_pattern_parser import STIX2PatternParser
+from ..stix2_to_misp import _OBSERVABLE_FIELDS_TO_SKIP
 from .stix2converter import (
     ExternalSTIX2Converter, InternalSTIX2Converter, STIX2Converter,
     _MAIN_PARSER_TYPING)
@@ -16,9 +17,14 @@ from .stix2mapping import (
     ExternalSTIX2Mapping, InternalSTIX2Mapping, STIX2Mapping)
 from abc import ABCMeta
 from collections import defaultdict
+from datetime import datetime
+from itertools import chain
 from pymisp import MISPObject
-from stix2.v20.sdo import Indicator as Indicator_v20
-from stix2.v21.sdo import Indicator as Indicator_v21
+from stix2.utils import format_datetime
+from stix2.v20.sdo import (
+    Indicator as Indicator_v20, ObservedData as ObservedData_v20)
+from stix2.v21.sdo import (
+    Indicator as Indicator_v21, ObservedData as ObservedData_v21)
 from stix2patterns.inspector import _PatternData as PatternData
 from types import GeneratorType
 from typing import Any, Iterator, Optional, TYPE_CHECKING, Union
@@ -28,6 +34,21 @@ if TYPE_CHECKING:
     from ..internal_stix2_to_misp import InternalSTIX2toMISPParser
 
 _INDICATOR_TYPING = Union[Indicator_v20, Indicator_v21]
+_OBSERVED_DATA_TYPING = Union[ObservedData_v20, ObservedData_v21, dict]
+# Pattern fields whose value an observable never repeats as it stands, so a
+# merge dropping them costs nothing: the ones an observable keeps no value
+# for at all - `src_ref.type = 'ipv4-addr'` naming the type of the observable
+# a reference points to; the MIME content disposition, written bare in a
+# pattern where the observable gains the file name `body_raw_ref.name`
+# compares on its own; and the fixed `content_ref` boilerplate an export
+# writes for a malware sample (`application/zip`, `mime-type-indicated`,
+# `infected`), which carries no MISP data and which the observable renders as
+# `x_misp_attachment` / `x_misp_malware_sample` instead - the sample's own
+# filename and hash are compared from the same pattern
+_PATTERN_FIELDS_TO_SKIP = (
+    *_OBSERVABLE_FIELDS_TO_SKIP, 'content_disposition', 'decryption_key',
+    'encryption_algorithm', 'mime_type'
+)
 
 
 class STIX2IndicatorMapping(STIX2Mapping, metaclass=ABCMeta):
@@ -1705,7 +1726,15 @@ class InternalSTIX2IndicatorConverter(
 
     def parse(self, indicator_ref: str):
         object_id = self.main_parser._extract_uuid(indicator_ref)
-        if f'observed-data--{object_id}' in self._observed_data:
+        observed_data_id = f'observed-data--{object_id}'
+        if observed_data_id in self._observed_data:
+            # A `to_ids` MISP record - an attribute, or an object holding at
+            # least 1 such attribute - exports to an Observed Data carrying
+            # its values *and* an Indicator whose pattern says them again,
+            # both under the record uuid: the Observed Data is the complete
+            # carrier, so the Indicator is skipped - but only what it says
+            # again can be dropped in silence.
+            self._check_merged_indicator(indicator_ref, observed_data_id)
             return
         # A standalone registry-key-value exported to STIX 2.0 emits both a
         # custom observable and a values[0] Indicator sharing the object uuid
@@ -1743,6 +1772,129 @@ class InternalSTIX2IndicatorConverter(
     @property
     def _observed_data(self) -> dict:
         return getattr(self.main_parser, '_observed_data', {})
+
+    ############################################################################
+    #                    MERGED INDICATOR HANDLING METHODS                     #
+    ############################################################################
+
+    def _check_merged_indicator(
+            self, indicator_ref: str, observed_data_id: str):
+        """Report what merging an Indicator into an Observed Data takes away.
+
+        The merge is keyed on the uuid the 2 STIX objects share, never on
+        what they carry, so a bundle whose 2 halves disagree - which a MISP
+        export does not write - is merged all the same and the Indicator's
+        pattern goes with it. The merge stays: it is right for the content it
+        was built for. Only the values the Observed Data does not say again
+        are reported, so a faithful round-trip stays quiet
+        """
+        indicator = self.main_parser._get_stix_object(indicator_ref)
+        comparisons = self._fetch_pattern_comparisons(indicator)
+        if comparisons is None:
+            # A yara, sigma or snort rule states no value an observable could
+            # be repeating, and an unparsable pattern never reaches the
+            # standard parsing path that would report it: either way the
+            # merge takes the whole pattern with it
+            self._merged_indicator_warning(
+                indicator_ref, observed_data_id, (indicator.get('pattern'),)
+            )
+            return
+        observed_values = set(
+            self._fetch_observed_data_values(observed_data_id)
+        )
+        discarded = tuple(
+            value for path, value in self._fetch_pattern_values(comparisons)
+            if path[-1] not in _PATTERN_FIELDS_TO_SKIP
+            and not self._pattern_value_is_kept(value, observed_values)
+        )
+        if discarded:
+            self._merged_indicator_warning(
+                indicator_ref, observed_data_id, discarded
+            )
+
+    def _fetch_merged_observables(
+            self, observed_data: _OBSERVED_DATA_TYPING) -> Iterator[dict]:
+        # The Observed Data converter walks its own observables with the
+        # version already known and reports the `object_refs` it cannot
+        # resolve: here the version is whatever the merged pair carries, and
+        # a missing observable is that converter's loss to name, not ours
+        if 'objects' in observed_data:
+            yield from observed_data['objects'].values()
+            return
+        for object_ref in observed_data.get('object_refs', []):
+            observable = self.main_parser._fetch_observable(object_ref)
+            if observable is not None:
+                yield observable
+
+    def _fetch_observed_data_values(
+            self, observed_data_id: str) -> Iterator[str]:
+        """Yield every value the observables of an Observed Data carry.
+
+        Values are lowered because a pattern and the observable saying the
+        same thing may differ in case only - a hash is the usual one - and a
+        case is not the disagreement worth reporting. Timestamps are yielded
+        in both the form `str` gives and the one a pattern is written with
+        """
+        observed_data = self._observed_data[observed_data_id]
+        for observable in self._fetch_merged_observables(observed_data):
+            for value in self.main_parser._fetch_observable_references(
+                    observable):
+                yield str(value).lower()
+                if isinstance(value, datetime):
+                    yield format_datetime(value).lower()
+
+    def _fetch_pattern_comparisons(
+            self, indicator: _INDICATOR_TYPING) -> Optional[dict]:
+        """The comparisons of a pattern, or None when there are none to read."""
+        if indicator.get('pattern_type', 'stix') != 'stix':
+            return None
+        try:
+            return self._compile_stix_pattern(indicator).comparisons
+        except InvalidSTIXPatternError:
+            return None
+        except Exception as exception:
+            # Reporting a merge must never be what breaks a conversion
+            self.main_parser._add_error(
+                'Error while compiling the pattern of the Indicator merged '
+                f'into an Observed Data with id {indicator.id}: '
+                f'{self.main_parser._parse_traceback(exception)}'
+            )
+            return None
+
+    @staticmethod
+    def _fetch_pattern_values(comparisons: dict) -> Iterator[tuple]:
+        for path, _, value in chain(*comparisons.values()):
+            yield path, value
+
+    @staticmethod
+    def _pattern_value_is_kept(value: Any, observed_values: set) -> bool:
+        """Tell whether an Observed Data says a pattern value again.
+
+        The value has to be there whole: a value one of the 2 halves narrows
+        - `circl.lu` against `www.circl.lu` - is a value the merge takes
+        away. Case is not such a narrowing, and a hash is the usual pair
+        differing by it alone, so the comparison is lowered. A registry value
+        is written with its `%` escaped in a pattern and bare in the
+        observable (ADR-0007), so both of its forms are tried
+        """
+        value = str(value).lower()
+        candidates = {value, value.replace('\\%', '%')}
+        return not candidates.isdisjoint(observed_values)
+
+    def _merged_indicator_warning(
+            self, indicator_ref: str, observed_data_id: str,
+            discarded: tuple):
+        record_uuid = self.main_parser._extract_uuid(indicator_ref)
+        reported_uuid = self.main_parser.replacement_uuids.get(
+            record_uuid, record_uuid
+        )
+        values = ', '.join(f"'{value}'" for value in discarded)
+        self.main_parser._add_warning(
+            f'Merged MISP record uuid {reported_uuid} - the STIX objects '
+            f'{indicator_ref} and {observed_data_id} both produce it, so the '
+            f'Observed Data alone is converted and the values only the '
+            f'Indicator carries ({values}) are not'
+        )
 
     ############################################################################
     #                        ATTRIBUTES PARSING METHODS                        #

--- a/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
@@ -68,7 +68,9 @@ class STIX2ObservedDataConverter(metaclass=ABCMeta):
         return self.main_parser.indicator_references
 
     def _get_observed_data(self, object_id: str) -> _OBSERVED_DATA_TYPING:
-        observed_data = self.main_parser._observed_data[object_id]
+        # a reference to an Observed Data the bundle does not carry is the
+        # loading error `_handle_object` reports by id, not a raw KeyError
+        observed_data = self.main_parser._get_stix_object(object_id)
         if isinstance(observed_data, (ObservedData_v20, ObservedData_v21)):
             return observed_data
         return observed_data['observed_data']

--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -394,7 +394,7 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
         would cost it the round-trip, and what MISP core does with a uuid it
         already knows is its own ownership decision. Only the reporting is
         added, and only here - an **Internal** bundle merges such a pair on
-        purpose, a different loss handled on its own
+        purpose, the **Merged Indicator** loss reported on its own
 
         Records are tracked per record type because events, objects and
         attributes each get their uuid namespace: an attribute sharing its

--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -17,7 +17,7 @@ from .stix2_to_misp import (
     STIX2toMISPParser, _BUNDLE_TYPING, _NOTE_TYPING, _OBSERVABLE_TYPING,
     _OPINION_TYPING)
 from collections import defaultdict
-from pymisp import MISPAttribute, MISPObject
+from pymisp import MISPAttribute, MISPEvent, MISPObject
 from stix2.v20.observables import (
     _Extension as Extension_v20, _STIXBase20 as STIXBase_v20)
 from stix2.v20.sro import Sighting as Sighting_v20
@@ -57,6 +57,7 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
     def __init__(self):
         super().__init__()
         self._mapping = ExternalSTIX2toMISPMapping
+        self._record_uuids: dict = defaultdict(dict)
 
     def parse_stix_bundle(
             self, cluster_distribution: Optional[int] = 0,
@@ -83,6 +84,7 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
 
     def _reset_bundle_state(self):
         super()._reset_bundle_state()
+        self._record_uuids = defaultdict(dict)
         try:
             del self.__standalone_object_refs
         except AttributeError:
@@ -409,3 +411,52 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
                         continue
                     for observable_id, refs in indicator_refs.items():
                         observed_data['indicator_refs'][observable_id].update(refs)
+
+    ############################################################################
+    #                     UUID SANITATION HANDLING METHODS                     #
+    ############################################################################
+
+    def _check_uuid_collision(self, record_type: str, object_id: str):
+        """Report the **Colliding Record Uuid** 2 STIX ids both produce.
+
+        The uuid computation is untouched: re-deriving one of the 2 records
+        would cost it the round-trip, and what MISP core does with a uuid it
+        already knows is its own ownership decision. Only the reporting is
+        added, and only here - an **Internal** bundle merges such a pair on
+        purpose, a different loss handled on its own
+
+        Records are tracked per record type because events, objects and
+        attributes each get their uuid namespace: an attribute sharing its
+        uuid with the object holding it costs nothing, and is the shape MISP's
+        own STIX 2.1 export writes for the address an email message comes from
+        """
+        record_uuid = self._extract_uuid(object_id)
+        known_id = self._record_uuids[record_type].setdefault(
+            record_uuid, object_id
+        )
+        if known_id != object_id:
+            # A uuid the RFC does not know is swapped for the v5 replacement
+            # `_sanitise_*` registered: the collision is keyed on what the 2
+            # ids share, but named with the uuid the records end up carrying.
+            reported_uuid = self.replacement_uuids.get(
+                record_uuid, record_uuid
+            )
+            self._add_warning(
+                f'Colliding MISP {record_type} uuid {reported_uuid} - the '
+                f'STIX objects {known_id} and {object_id} both produce it, so '
+                f'the converted content has 2 {record_type}s sharing one uuid'
+            )
+
+    def _sanitise_attribute_uuid(
+            self, object_id: str, comment: Optional[str] = None,
+            **kwargs) -> dict:
+        self._check_uuid_collision('attribute', object_id)
+        return super()._sanitise_attribute_uuid(object_id, comment, **kwargs)
+
+    def _sanitise_object_uuid(
+            self, misp_object: MISPEvent | MISPObject, object_id: str):
+        self._check_uuid_collision(
+            'event' if isinstance(misp_object, MISPEvent) else 'object',
+            object_id
+        )
+        super()._sanitise_object_uuid(misp_object, object_id)

--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -18,19 +18,10 @@ from .stix2_to_misp import (
     _OPINION_TYPING)
 from collections import defaultdict
 from pymisp import MISPAttribute, MISPEvent, MISPObject
-from stix2.v20.observables import (
-    _Extension as Extension_v20, _STIXBase20 as STIXBase_v20)
 from stix2.v20.sro import Sighting as Sighting_v20
-from stix2.v21.observables import (
-    _Extension as Extension_v21, _STIXBase21 as STIXBase_v21)
 from stix2.v21.sro import Sighting as Sighting_v21
 from typing import Iterator, Optional, Union
 
-_EXTENSION_TYPES = (Extension_v20, Extension_v21, STIXBase_v20, STIXBase_v21)
-_OBSERVABLE_FIELDS_TO_SKIP = (
-    'defanged', 'granular_markings', 'id', 'object_marking_refs',
-    'spec_version', 'type'
-)
 _SDO_STORAGE_FIELDS = {'_indicator': 1, '_observable': 2, '_observed_data': 4}
 _SIGHTING_TYPING = Union[Sighting_v20, Sighting_v21, dict]
 
@@ -325,26 +316,6 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
                 if not any(ref in values for ref in observable_references):
                     continue
                 yield indicator_id
-
-    def _fetch_observable_references(
-            self, observable: dict | _OBSERVABLE_TYPING) -> Iterator[str]:
-        for key, values in observable.items():
-            if key in _OBSERVABLE_FIELDS_TO_SKIP:
-                continue
-            if isinstance(values, dict):
-                yield from self._fetch_observable_references(values)
-                continue
-            if isinstance(values, list):
-                for value in values:
-                    if isinstance(value, _EXTENSION_TYPES):
-                        yield from self._fetch_observable_references(value)
-                        continue
-                    yield value
-                continue
-            if isinstance(values, _EXTENSION_TYPES):
-                yield from self._fetch_observable_references(values)
-                continue
-            yield values
 
     def _set_indicator_references(self):
         score = 0

--- a/misp_stix_converter/stix2misp/external_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix2_to_misp.py
@@ -176,15 +176,14 @@ class ExternalSTIX2toMISPParser(STIX2toMISPParser, ExternalSTIXtoMISPParser):
             if object_type in self._mapping.object_type_refs_to_skip():
                 continue
             if object_type in self._mapping.observable_object_types():
-                if (observable := self._fetch_observable(object_ref)) is not None:
-                    if self.misp_event.uuid not in observable['used']:
-                        observable['used'][self.misp_event.uuid] = False
+                if (observable := self._fetch_observable(object_ref)) is None:
+                    self._object_ref_loading_error(object_ref)
+                    continue
+                if self.misp_event.uuid not in observable['used']:
+                    observable['used'][self.misp_event.uuid] = False
                 continue
             if object_type == 'marking-definition':
-                if object_ref in self._clusters:
-                    cluster = self._clusters[object_ref]
-                    if cluster['used'].get(self.misp_event.uuid) is None:
-                        cluster['used'][self.misp_event.uuid] = False
+                self._handle_marking_definition_ref(object_ref)
                 continue
             try:
                 self._handle_object(object_type, object_ref)

--- a/misp_stix_converter/stix2misp/internal_stix2_mapping.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_mapping.py
@@ -7,10 +7,6 @@ from typing import Union
 
 
 class InternalSTIX2toMISPMapping(STIX2toMISPMapping):
-    __object_type_refs_to_skip = (
-        *STIX2toMISPMapping.object_type_refs_to_skip(),
-        *STIX2toMISPMapping.observable_object_types()
-    )
     __stix_object_loading_mapping = Mapping(
         **{
             'note': '_load_note',
@@ -25,10 +21,6 @@ class InternalSTIX2toMISPMapping(STIX2toMISPMapping):
             **STIX2toMISPMapping.stix_object_loading_mapping()
         }
     )
-
-    @classmethod
-    def object_type_refs_to_skip(cls) -> tuple:
-        return cls.__object_type_refs_to_skip
 
     @classmethod
     def stix_object_loading_mapping(cls, field: str) -> Union[str, None]:

--- a/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
@@ -211,7 +211,18 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
     def _handle_object_refs(self, object_refs: list):
         for object_ref in object_refs:
             object_type = object_ref.split('--')[0]
+            if object_type in self._mapping.observable_object_types():
+                # A MISP export lists the observable objects its Observed
+                # Data consumed next to it, and those are converted with
+                # their parent: only a reference to one the bundle never
+                # carried has anything to say.
+                if not self._has_observable(object_ref):
+                    self._object_ref_loading_error(object_ref)
+                continue
             if object_type in self._mapping.object_type_refs_to_skip():
+                continue
+            if object_type == 'marking-definition':
+                self._handle_marking_definition_ref(object_ref)
                 continue
             try:
                 self._handle_object(object_type, object_ref)

--- a/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
@@ -321,6 +321,11 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         if not all(hasattr(self, field) for field in _STORAGE_VARIABLE_NAMES):
             return
         pattern_parser = self._get_converter('indicator')._compile_stix_pattern
+        # Keyed on the bare uuid where the External parser keys the same map
+        # on the whole STIX id: an Internal Indicator and the Observed Data
+        # rendering the same MISP record share that uuid and nothing else, so
+        # it is what makes each of the 2 findable from the other. Only
+        # Indicators feed the map, so no other type can collide with them here
         self._indicator_references = {
             self._extract_uuid(indicator_id): tuple(val[-1] for val in pattern)
             for indicator_id, indicator in self._indicator.items()

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -175,6 +175,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             if invalid_objects is None:
                 invalid_objects = {}
         self.__invalid_objects = invalid_objects
+        # the ids the loader saw more than one invalid object claim - what
+        # `invalid_objects` cannot hold, since it keeps one object per id
+        self._duplicate_invalid_ids = getattr(
+            bundle, '_duplicate_invalid_ids', set()
+        )
         self._set_identifier(bundle.id)
         self.__stix_version = getattr(bundle, 'spec_version', '2.1')
         self._load_stix_bundle(bundle)
@@ -239,6 +244,24 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 'content may be an altered rendering of the bundle'
             )
         self._loaded_object_ids.add(object_id)
+
+    def _check_duplicate_invalid_marking(self, object_id: str):
+        """Report the ids a bundle gives to more than one invalid marking.
+
+        Objects a whole-bundle parsing failure recovers one at a time are
+        kept by id, so the last of the objects sharing one wins - the same
+        shadowing `_check_duplicate_id` names, one layer below the loaded
+        objects it sees. A Marking Definition is the one invalid object that
+        is applied rather than reported as a loading error, which makes the
+        surviving marking a marking the sender may never have sent: the
+        others cost a reference each, and that reference already fails loudly.
+        """
+        if object_id in self._duplicate_invalid_ids:
+            self._add_warning(
+                f'Duplicate invalid Marking Definition id: {object_id} - the '
+                'marking applied to the converted content may not be the one '
+                'that was sent'
+            )
 
     def _parse_stix_bundle(self):
         # `stix_version` is only set by `load_stix_bundle` - without it the
@@ -529,7 +552,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         invalid = self.invalid_objects.get(object_ref)
         if invalid is None:
             return None
+        # loading raises on a marking too broken to read, and a marking that
+        # governs nothing costs nothing: the duplicate is reported once the
+        # survivor is applied, not before
         self._load_marking_definition(InvalidMarkingDefinition(invalid))
+        self._check_duplicate_invalid_marking(object_ref)
         return self._marking_definition[object_ref]
 
     def _handle_object(self, object_type: str, object_ref: str):

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -506,19 +506,31 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         try:
             return getattr(self, feature)[object_ref]
         except AttributeError:
-            if (invalid := self.invalid_objects.get(object_ref)) is not None:
-                if object_type == 'marking-definition':
-                    invalid = InvalidMarkingDefinition(invalid)
-                    getattr(self, f'_load{feature}')(invalid)
-                    return getattr(self, feature)[object_ref]
+            recovered = self._recover_invalid_object(object_ref, object_type)
+            if recovered is not None:
+                return recovered
             raise ObjectTypeLoadingError(object_type)
         except KeyError:
-            if (invalid := self.invalid_objects.get(object_ref)) is not None:
-                if object_type == 'marking-definition':
-                    invalid = InvalidMarkingDefinition(invalid)
-                    getattr(self, f'_load{feature}')(invalid)
-                    return getattr(self, feature)[object_ref]
+            recovered = self._recover_invalid_object(object_ref, object_type)
+            if recovered is not None:
+                return recovered
             raise ObjectRefLoadingError(object_ref)
+
+    def _recover_invalid_object(self, object_ref: str, object_type: str):
+        """Recover a referenced object the loader could not parse.
+
+        Marking Definitions are the only invalid objects recovered rather
+        than reported as a loading error: the fields a marking is read for
+        survive a validation failure, and dropping one would silently widen
+        the sharing of the data it governs.
+        """
+        if object_type != 'marking-definition':
+            return None
+        invalid = self.invalid_objects.get(object_ref)
+        if invalid is None:
+            return None
+        self._load_marking_definition(InvalidMarkingDefinition(invalid))
+        return self._marking_definition[object_ref]
 
     def _handle_object(self, object_type: str, object_ref: str):
         self._parsed_object_refs.add(object_ref)

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -1324,16 +1324,23 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             return self._identity[reference]['name']
         return self._mapping.identity_references(reference) or 'misp-stix'
 
-    def _is_tlp_marking(self, marking_ref: str) -> bool:
+    def _fetch_tlp_marking(
+            self, marking_ref: str) -> Optional[_MARKING_DEFINITION_TYPING]:
+        """Return the TLP marking the specification gives that id, if any."""
         tlp_2_marking = self._mapping.tlp2_marking_definitions(marking_ref)
         if tlp_2_marking is not None:
-            self._load_marking_definition(tlp_2_marking)
-            return True
+            return tlp_2_marking
         for marking in (TLP_WHITE, TLP_GREEN, TLP_AMBER, TLP_RED):
             if marking_ref == marking['id']:
-                self._load_marking_definition(marking)
-                return True
-        return False
+                return marking
+        return None
+
+    def _is_tlp_marking(self, marking_ref: str) -> bool:
+        marking = self._fetch_tlp_marking(marking_ref)
+        if marking is None:
+            return False
+        self._load_marking_definition(marking)
+        return True
 
     @staticmethod
     def _parse_confidence_level(confidence_level: int) -> str:

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -25,6 +25,8 @@ from stix2 import TLP_AMBER, TLP_GREEN, TLP_RED, TLP_WHITE
 from stix2.utils import parse_into_datetime
 from stix2.v20.bundle import Bundle as Bundle_v20
 from stix2.v20.common import MarkingDefinition as MarkingDefinition_v20
+from stix2.v20.observables import (
+    _Extension as Extension_v20, _STIXBase20 as STIXBase_v20)
 from stix2.v20.sdo import (
     AttackPattern as AttackPattern_v20, Campaign as Campaign_v20,
     CourseOfAction as CourseOfAction_v20, CustomObject as CustomObject_v20,
@@ -38,8 +40,9 @@ from stix2.v20.sro import (
 from stix2.v21.bundle import Bundle as Bundle_v21
 from stix2.v21.common import MarkingDefinition as MarkingDefinition_v21
 from stix2.v21.observables import (
-    Artifact, AutonomousSystem, Directory, DomainName, EmailAddress,
-    EmailMessage, File, IPv4Address, IPv6Address, MACAddress, Mutex,
+    _Extension as Extension_v21, _STIXBase21 as STIXBase_v21, Artifact,
+    AutonomousSystem, Directory, DomainName, EmailAddress, EmailMessage, File,
+    IPv4Address, IPv6Address, MACAddress, Mutex,
     NetworkTraffic as NetworkTraffic_v21, Process, Software, URL, UserAccount,
     WindowsRegistryKey, X509Certificate)
 from stix2.v21.sdo import Grouping, Location, MalwareAnalysis, Note, Opinion
@@ -53,9 +56,14 @@ from stix2.v21.sdo import (
     Vulnerability as Vulnerability_v21)
 from stix2.v21.sro import (
     Relationship as Relationship_v21, Sighting as Sighting_v21)
-from typing import Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 
 # Some constants
+_EXTENSION_TYPES = (Extension_v20, Extension_v21, STIXBase_v20, STIXBase_v21)
+_OBSERVABLE_FIELDS_TO_SKIP = (
+    'defanged', 'granular_markings', 'id', 'object_marking_refs',
+    'spec_version', 'type'
+)
 _LOADED_FEATURES = (
     '_attack_pattern', '_campaign', '_course_of_action', '_custom_attribute',
     '_custom_object', '_identity', '_indicator', '_intrusion_set', '_malware',
@@ -275,6 +283,34 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
 
     def _fetch_observable(self, object_ref: str) -> Optional[dict]:
         return self._observable.get(object_ref)
+
+    def _fetch_observable_references(
+            self, observable: dict | _OBSERVABLE_TYPING) -> Iterator[Any]:
+        """Yield every value an observable object carries, at any depth.
+
+        Which field holds the value an SCO is about depends on its type, and
+        extensions nest further fields under it, so the values are collected
+        by walking the object instead of by asking each type where it keeps
+        them. Only the fields naming or qualifying the object rather than
+        describing what it observed are skipped
+        """
+        for key, values in observable.items():
+            if key in _OBSERVABLE_FIELDS_TO_SKIP:
+                continue
+            if isinstance(values, dict):
+                yield from self._fetch_observable_references(values)
+                continue
+            if isinstance(values, list):
+                for value in values:
+                    if isinstance(value, _EXTENSION_TYPES):
+                        yield from self._fetch_observable_references(value)
+                        continue
+                    yield value
+                continue
+            if isinstance(values, _EXTENSION_TYPES):
+                yield from self._fetch_observable_references(values)
+                continue
+            yield values
 
     def _has_observable(self, object_ref: str) -> bool:
         return object_ref in self._observable

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -305,7 +305,9 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         return self._converter_cache[stix_type]
 
     def _fetch_observable(self, object_ref: str) -> Optional[dict]:
-        return self._observable.get(object_ref)
+        # a bundle carrying no observable object at all never creates the
+        # `_observable` mapping: a reference to one is missing, not a crash
+        return getattr(self, '_observable', {}).get(object_ref)
 
     def _fetch_observable_references(
             self, observable: dict | _OBSERVABLE_TYPING) -> Iterator[Any]:
@@ -335,8 +337,26 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 continue
             yield values
 
+    def _has_marking_definition(self, object_ref: str) -> bool:
+        """Tell a Marking Definition reference the bundle carries an object for.
+
+        Loading records the id of every object it reaches before that object
+        is stored, so a marking too broken to read counts as carried all the
+        same: the loading error already names it, and a second message would
+        say the bundle never sent what it did send. A marking the `stix2`
+        library rejected is recovered and applied wherever it is referenced
+        (see `_recover_invalid_object`), and the TLP markings the
+        specification defines are carried by their id alone - a bundle
+        referring to one of those does not have to send it.
+        """
+        return (
+            object_ref in self._loaded_object_ids
+            or object_ref in self.invalid_objects
+            or self._fetch_tlp_marking(object_ref) is not None
+        )
+
     def _has_observable(self, object_ref: str) -> bool:
-        return object_ref in self._observable
+        return object_ref in getattr(self, '_observable', {})
 
     ############################################################################
     #                                PROPERTIES                                #
@@ -558,6 +578,24 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._load_marking_definition(InvalidMarkingDefinition(invalid))
         self._check_duplicate_invalid_marking(object_ref)
         return self._marking_definition[object_ref]
+
+    def _handle_marking_definition_ref(self, object_ref: str):
+        """Handle a Marking Definition a Report or Grouping lists as content.
+
+        A marking that yielded Galaxy Clusters is registered for the event to
+        use; any other marking the bundle carries is applied through the
+        fields referring to it rather than through this list, so listing it
+        costs nothing. What is left is a reference to an object the bundle
+        never carried, reported like the SDO references `_handle_object`
+        fails to resolve.
+        """
+        if object_ref in self._clusters:
+            cluster = self._clusters[object_ref]
+            if cluster['used'].get(self.misp_event.uuid) is None:
+                cluster['used'][self.misp_event.uuid] = False
+            return
+        if not self._has_marking_definition(object_ref):
+            self._object_ref_loading_error(object_ref)
 
     def _handle_object(self, object_type: str, object_ref: str):
         self._parsed_object_refs.add(object_ref)

--- a/misp_stix_converter/tools/stix2_loading_helpers.py
+++ b/misp_stix_converter/tools/stix2_loading_helpers.py
@@ -19,7 +19,11 @@ def _get_stix_content_version(stix_content: dict) -> str:
     return '2.0'
 
 
-def _handle_invalid_stix_content(invalid_objects, *stix_objects):
+def _handle_invalid_stix_content(
+        invalid_objects, duplicate_invalid_ids, *stix_objects):
+    # the ids set aside from this content, so a dict the caller passed in
+    # already populated by an earlier load never reads as a duplicate
+    invalid_ids = set()
     for index, stix_object in enumerate(stix_objects):
         try:
             valid_object = stix2_parser(
@@ -34,16 +38,20 @@ def _handle_invalid_stix_content(invalid_objects, *stix_objects):
                 raise STIXLoadingError(
                     f"STIX object without an 'id' property at index {index}"
                 )
+            # `invalid_objects` keeps its `id -> object` shape: the object
+            # dropped here is never recovered, but the id it shared travels
+            # to the parser, which is where the loss can be reported
+            if object_id in invalid_ids:
+                duplicate_invalid_ids.add(object_id)
+            invalid_ids.add(object_id)
             invalid_objects[object_id] = stix_object
             continue
         yield valid_object
 
 
 def _handle_stix2_loading_error(
-        stix_content: dict,
-        invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
-    if invalid_objects is None:
-        invalid_objects = {}
+        stix_content: dict, invalid_objects: dict,
+        duplicate_invalid_ids: set) -> _BUNDLE_TYPING:
     if 'objects' not in stix_content:
         raise STIXLoadingError(
             "The STIX 2 content has no 'objects' property"
@@ -69,7 +77,9 @@ def _handle_stix2_loading_error(
     bundle_id = stix_content.get('id')
     bundle = Bundle_v21 if version == '2.1' else Bundle_v20
     return bundle(
-        *_handle_invalid_stix_content(invalid_objects, *stix_content['objects']),
+        *_handle_invalid_stix_content(
+            invalid_objects, duplicate_invalid_ids, *stix_content['objects']
+        ),
         id=bundle_id, allow_custom=True, interoperability=True
     )
 
@@ -78,6 +88,7 @@ def load_stix2_content(stix_content: BytesIO | dict | list | str,
                        invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
     if invalid_objects is None:
         invalid_objects = {}
+    duplicate_invalid_ids: set = set()
     if isinstance(stix_content, dict):
         try:
             bundle = dict_to_stix2(
@@ -87,7 +98,7 @@ def load_stix2_content(stix_content: BytesIO | dict | list | str,
             # the 2.1 code path in `stix2` reports an object without a `type`
             # property as a bare KeyError where the 2.0 one uses ParseError
             bundle = _handle_stix2_loading_error(
-                stix_content, invalid_objects
+                stix_content, invalid_objects, duplicate_invalid_ids
             )
     else:
         if isinstance(stix_content, BytesIO):
@@ -98,11 +109,14 @@ def load_stix2_content(stix_content: BytesIO | dict | list | str,
             )
         except (InvalidValueError, KeyError, ParseError, ValueError):
             bundle = _handle_stix2_loading_error(
-                json.loads(stix_content), invalid_objects
+                json.loads(stix_content), invalid_objects, duplicate_invalid_ids
             )
     # keeps the recovered invalid objects with the bundle they came from, so
     # `load_stix_bundle` sees them even when the caller does not pass the dict
     bundle._invalid_objects = invalid_objects
+    # the ids more than one invalid object claimed: the dict above only kept
+    # the last of them, and only the parser can say what that costs
+    bundle._duplicate_invalid_ids = duplicate_invalid_ids
     return bundle
 
 

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -161,12 +161,31 @@ class TestSTIX2Import(TestSTIX):
 
     def _check_duplicate_object_id_warning(self, object_id, warnings):
         """The last occurrence wins, but the shadowing is never silent."""
-        duplicate_warnings = [
-            warning for warning in self._reported_messages(warnings)
-            if 'Duplicate STIX object id' in warning
-        ]
+        duplicate_warnings = self._reports_matching(
+            warnings, 'Duplicate STIX object id'
+        )
         self.assertEqual(len(duplicate_warnings), 1)
         self.assertIn(object_id, duplicate_warnings[0])
+
+    def _check_uuid_collision_warning(self, record_uuid, object_ids, warnings):
+        """Two STIX ids, one MISP uuid: both records stay, the loss is named."""
+        collision_warnings = self._reports_matching(warnings, 'Colliding MISP')
+        self.assertEqual(len(collision_warnings), 1)
+        self.assertIn(record_uuid, collision_warnings[0])
+        for object_id in object_ids:
+            self.assertIn(object_id, collision_warnings[0])
+
+    def _check_uuid_collision_warning_absence(self, warnings):
+        """STIX ids sharing a uuid part the conversion does not collide on."""
+        self.assertEqual(
+            self._reports_matching(warnings, 'Colliding MISP'), []
+        )
+
+    def _reports_matching(self, reports: dict, message: str) -> list:
+        return [
+            report for report in self._reported_messages(reports)
+            if message in report
+        ]
 
     def _import_bundle_with_unloadable_objects(
             self, bundle, count: int = 1, distinct_types: bool = True,

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -125,6 +125,20 @@ class TestSTIX2Import(TestSTIX):
         """
         return datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
 
+    def _check_dangling_object_ref_error(self, object_ref, errors):
+        """A reference to an object the bundle does not carry is named."""
+        dangling_errors = self._reports_matching(
+            errors, f'Error loading the STIX object with id {object_ref}'
+        )
+        self.assertEqual(len(dangling_errors), 1)
+
+    def _check_dangling_object_ref_error_absence(self, errors):
+        """References the bundle resolves - including the observable objects
+        an Observed Data consumed - have nothing to report."""
+        self.assertEqual(
+            self._reports_matching(errors, 'Error loading the STIX object'), []
+        )
+
     def _check_dict_form_analyst_note(self, misp_note, stix_note):
         """A Note the STIX version does not know arrives as a plain dict."""
         self.assertIsInstance(stix_note, dict)
@@ -464,6 +478,80 @@ class TestSTIX20Import(TestSTIX2Import):
             )
             ext_objects_documentation.check_import_mapping('stix20')
 
+    def _load_stix20_content_with_object_refs(
+            self, *extra_refs, internal: bool = False, carried: tuple = ()):
+        """A Report listing the given references next to legitimate ones.
+
+        STIX 2.0 keeps its observable objects inside the Observed Data
+        carrying them, so an Observed Data reference is the closest a 2.0
+        Report gets to referencing an observable object. The objects given as
+        `carried` are referenced too, so a reference the bundle does carry an
+        object for can be told from one it does not.
+        """
+        from misp_stix_converter.tools import load_stix2_content
+        identity_id = 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f'
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        observed_data_id = 'observed-data--a12c56ba-5c07-4e0a-90c9-1a1cd7c1e0a4'
+        labels = ['misp:type="domain"', 'misp:category="Network activity"']
+        report_labels = ['Threat-Report']
+        if internal:
+            report_labels.append('misp:tool="MISP-STIX-Converter"')
+        return load_stix2_content(
+            {
+                'type': 'bundle', 'spec_version': '2.0',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'identity', 'id': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL', 'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'report',
+                        'id': 'report--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'published': '2020-10-25T16:22:00Z',
+                        'labels': report_labels,
+                        'object_refs': [
+                            indicator_id, observed_data_id,
+                            *(
+                                stix_object['id'] for stix_object in carried
+                            ),
+                            *extra_refs
+                        ]
+                    },
+                    {
+                        'type': 'indicator', 'id': indicator_id,
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'valid_from': '2020-10-25T16:22:00.000Z',
+                        'labels': labels
+                    },
+                    {
+                        'type': 'observed-data', 'id': observed_data_id,
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'first_observed': '2020-10-25T16:22:00Z',
+                        'last_observed': '2020-10-25T16:22:00Z',
+                        'number_observed': 1, 'labels': labels,
+                        'objects': {
+                            '0': {
+                                'type': 'domain-name', 'value': 'misp-project.org'
+                            }
+                        }
+                    },
+                    *carried
+                ]
+            }
+        )
+
     def _populate_galaxy_documentation(self, **kwargs):
         galaxy = kwargs.pop('galaxy')
         stix_name, stix_object = next(iter(kwargs.items()))
@@ -671,6 +759,91 @@ class TestSTIX21Import(TestSTIX2Import):
                 'import'
             )
             ext_objects_documentation.check_import_mapping('stix21')
+
+    def _load_stix21_content_with_object_refs(
+            self, *extra_refs, internal: bool = False,
+            observables: bool = True, carried: tuple = ()):
+        """A Grouping listing the given references next to legitimate ones.
+
+        The observable object is listed next to the Observed Data consuming
+        it, which is how a MISP export writes both. Dropping the pair with
+        `observables` leaves a bundle carrying no observable object at all -
+        the shape an observable reference has nothing to be looked up in.
+        The objects given as `carried` are referenced too, so a reference the
+        bundle does carry an object for can be told from one it does not.
+        """
+        from misp_stix_converter.tools import load_stix2_content
+        identity_id = 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f'
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        observed_data_id = 'observed-data--a12c56ba-5c07-4e0a-90c9-1a1cd7c1e0a4'
+        domain_id = 'domain-name--e5d2e1f0-9b2e-4a9e-8d2e-1f09b2e4a9e8'
+        labels = ['misp:type="domain"', 'misp:category="Network activity"']
+        grouping_labels = ['Threat-Report']
+        if internal:
+            grouping_labels.append('misp:tool="MISP-STIX-Converter"')
+        observed_data = [
+            {
+                'type': 'observed-data', 'spec_version': '2.1',
+                'id': observed_data_id, 'created_by_ref': identity_id,
+                'created': '2020-10-25T16:22:00.000Z',
+                'modified': '2020-10-25T16:22:00.000Z',
+                'first_observed': '2020-10-25T16:22:00Z',
+                'last_observed': '2020-10-25T16:22:00Z',
+                'number_observed': 1, 'labels': labels,
+                'object_refs': [domain_id]
+            },
+            {
+                'type': 'domain-name', 'spec_version': '2.1',
+                'id': domain_id, 'value': 'misp-project.org'
+            }
+        ] if observables else []
+        return load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'identity', 'spec_version': '2.1',
+                        'id': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL', 'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'grouping', 'spec_version': '2.1',
+                        'id': 'grouping--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'context': 'suspicious-activity',
+                        'labels': grouping_labels,
+                        'object_refs': [
+                            indicator_id,
+                            *(
+                                observable['id']
+                                for observable in observed_data
+                            ),
+                            *(
+                                stix_object['id'] for stix_object in carried
+                            ),
+                            *extra_refs
+                        ]
+                    },
+                    {
+                        'type': 'indicator', 'spec_version': '2.1',
+                        'id': indicator_id, 'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'pattern_type': 'stix',
+                        'valid_from': '2020-10-25T16:22:00.000Z',
+                        'labels': labels
+                    },
+                    *observed_data, *carried
+                ]
+            }
+        )
 
     def _populate_galaxy_documentation(self, **kwargs):
         galaxy = kwargs.pop('galaxy')

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -167,6 +167,21 @@ class TestSTIX2Import(TestSTIX):
         self.assertEqual(len(duplicate_warnings), 1)
         self.assertIn(object_id, duplicate_warnings[0])
 
+    def _check_merged_indicator_warning(
+            self, record_uuid, object_ids, discarded, warnings):
+        """An Indicator merged into an Observed Data names what it took away."""
+        merge_warnings = self._reports_matching(warnings, 'Merged MISP record')
+        self.assertEqual(len(merge_warnings), 1)
+        self.assertIn(record_uuid, merge_warnings[0])
+        for object_id in (*object_ids, *discarded):
+            self.assertIn(object_id, merge_warnings[0])
+
+    def _check_merged_indicator_warning_absence(self, warnings):
+        """An Indicator the Observed Data merging it says again in full."""
+        self.assertEqual(
+            self._reports_matching(warnings, 'Merged MISP record'), []
+        )
+
     def _check_uuid_collision_warning(self, record_uuid, object_ids, warnings):
         """Two STIX ids, one MISP uuid: both records stay, the loss is named."""
         collision_warnings = self._reports_matching(warnings, 'Colliding MISP')

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -167,6 +167,39 @@ class TestSTIX2Import(TestSTIX):
         self.assertEqual(len(duplicate_warnings), 1)
         self.assertIn(object_id, duplicate_warnings[0])
 
+    @staticmethod
+    def _invalid_tlp_markings(marking_id: str, *tlp_values) -> list:
+        """The Marking Definitions a bundle carries under a single id.
+
+        A TLP marking under an id the specification does not give it fails
+        `stix2` validation in both versions, which is what puts the objects
+        below on the invalid objects path - the shape a sender minting its
+        own TLP markings writes, with one id reused.
+        """
+        return [
+            {
+                'type': 'marking-definition', 'id': marking_id,
+                'created': '2017-01-20T00:00:00.000Z',
+                'definition_type': 'tlp', 'definition': {'tlp': tlp_value}
+            } for tlp_value in tlp_values
+        ]
+
+    def _check_duplicate_invalid_marking_warning(self, marking_id, warnings):
+        """The marking governing the data may not be the one that was sent."""
+        duplicate_warnings = self._reports_matching(
+            warnings, 'Duplicate invalid Marking Definition id'
+        )
+        self.assertEqual(len(duplicate_warnings), 1)
+        self.assertIn(marking_id, duplicate_warnings[0])
+
+    def _check_duplicate_invalid_marking_warning_absence(self, warnings):
+        """Invalid objects a bundle keeps apart, or does not apply."""
+        self.assertEqual(
+            self._reports_matching(
+                warnings, 'Duplicate invalid Marking Definition id'
+            ), []
+        )
+
     def _check_merged_indicator_warning(
             self, record_uuid, object_ids, discarded, warnings):
         """An Indicator merged into an Observed Data names what it took away."""

--- a/tests/test_external_stix20_bundles.py
+++ b/tests/test_external_stix20_bundles.py
@@ -2145,6 +2145,86 @@ class TestExternalSTIX20Bundles(TestSTIX2Bundles):
         )
 
     @classmethod
+    def __assemble_colliding_uuids_bundle(
+            cls, indicated: str, observed: str, record_uuid=None,
+            interoperability=False):
+        """An Indicator and an Observed Data whose ids share their uuid part.
+
+        `indicator--X` and `observed-data--X` are 2 STIX objects, but the MISP
+        records they produce keep only the part after `--`, so both claim X.
+        STIX 2.0 carries no top-level Observable, hence the pair the 2.1 file
+        builds from an Indicator and an SCO.
+        """
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        indicator = deepcopy(cls.__indicator)
+        if record_uuid is None:
+            record_uuid = indicator['id'].split('--')[1]
+        indicator['id'] = f'indicator--{record_uuid}'
+        indicator['pattern'] = f"[domain-name:value = '{indicated}']"
+        observed_data = {
+            "type": "observed-data",
+            "id": f"observed-data--{record_uuid}",
+            "created_by_ref": cls.__identity['id'],
+            "created": "2020-10-25T16:22:00.000Z",
+            "modified": "2020-10-25T16:22:00.000Z",
+            "first_observed": "2020-10-25T16:22:00Z",
+            "last_observed": "2020-10-25T16:22:00Z",
+            "number_observed": 1,
+            "objects": {"0": {"type": "domain-name", "value": observed}}
+        }
+        report.update(
+            cls._populate_references(indicator['id'], observed_data['id'])
+        )
+        bundle['objects'] = [
+            deepcopy(cls.__identity), report, indicator, observed_data
+        ]
+        return dict_to_stix2(
+            bundle, allow_custom=True, interoperability=interoperability
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_record_uuids(cls):
+        return cls.__assemble_colliding_uuids_bundle(
+            'first.example.com', 'second.example.com'
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_non_rfc_record_uuids(cls):
+        # A uuid no RFC version knows is replaced by a v5 one on both sides of
+        # the collision, so the warning has to name the replacement. Only the
+        # interoperability mode lets such an id through the STIX validation.
+        return cls.__assemble_colliding_uuids_bundle(
+            'first.example.com', 'second.example.com',
+            record_uuid='91ae0a21-c7ae-0c7f-b84b-b84a7ce53d1f',
+            interoperability=True
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_uuids_on_matching_values(cls):
+        return cls.__assemble_colliding_uuids_bundle(
+            'same.example.com', 'same.example.com'
+        )
+
+    @classmethod
+    def get_bundle_with_vulnerability_sharing_an_indicator_uuid(cls):
+        """A Galaxy Cluster and an attribute claiming the same uuid part."""
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        indicator = deepcopy(cls.__indicator)
+        vulnerability = deepcopy(_VULNERABILITY_OBJECTS[0])
+        vulnerability['id'] = (
+            f"vulnerability--{indicator['id'].split('--')[1]}"
+        )
+        report.update(
+            cls._populate_references(indicator['id'], vulnerability['id'])
+        )
+        bundle['objects'] = [
+            deepcopy(cls.__identity), report, indicator, vulnerability
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_duplicate_object_ids(cls):
         bundle = deepcopy(cls.__bundle)
         report = deepcopy(cls.__report)

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -302,6 +302,182 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         load_stix2_content(stix_content)
         self.assertEqual(stix_content, original)
 
+    def _load_stix20_content_with_invalid_markings(self, *markings):
+        from misp_stix_converter.tools import load_stix2_content
+        return load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'identity',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'report',
+                        'id': 'report--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'published': '2020-10-25T16:22:00Z',
+                        'labels': ['Threat-Report'],
+                        'object_refs': [
+                            'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+                        ]
+                    },
+                    {
+                        'type': 'indicator',
+                        'id': 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'labels': ['malicious-activity'],
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'valid_from': '2020-10-25T16:22:00.000Z',
+                        'object_marking_refs': [markings[0]['id']]
+                    },
+                    *markings
+                ]
+            }
+        )
+
+    def test_stix20_duplicate_invalid_marking_definitions_are_reported(self):
+        # A Marking Definition is the one invalid object applied rather than
+        # reported as a loading error: with 2 of them under one id, the last
+        # one wins and the data ends up governed by a marking the sender may
+        # never have sent.
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix20_content_with_invalid_markings(
+            *self._invalid_tlp_markings(marking_id, 'white', 'red')
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        # `invalid_objects` keeps its `id -> object` shape: the marking the
+        # bundle lost travels as an id, not as a second object.
+        self.assertEqual(list(self.parser.invalid_objects), [marking_id])
+        self._check_duplicate_invalid_marking_warning(
+            marking_id, self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual(
+            [tag.name for tag in attribute.tags], ['tlp:red']
+        )
+
+    def test_stix20_unapplied_invalid_marking_definitions_are_not_reported(self):
+        # A marking too broken to read governs nothing: loading it raises,
+        # the object referring to it is reported as an error and lands with
+        # no marking, and a duplicate that changed no marking has no stake to
+        # warn about.
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix20_content_with_invalid_markings(
+            *(
+                {
+                    'type': 'marking-definition', 'id': marking_id,
+                    'created': '2017-01-20T00:00:00.000Z',
+                    'definition_type': 'tlp'
+                } for _ in range(2)
+            )
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], [])
+        self.assertIn(
+            attribute.uuid,
+            '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
+    def test_stix20_distinct_invalid_marking_definitions_are_not_reported(self):
+        # Invalid markings the bundle keeps apart shadow nothing: both are
+        # recovered, and each governs what refers to it.
+        markings = self._invalid_tlp_markings(
+            'marking-definition--11111111-1111-4111-8111-111111111111', 'white'
+        ) + self._invalid_tlp_markings(
+            'marking-definition--22222222-2222-4222-8222-222222222222', 'red'
+        )
+        bundle = self._load_stix20_content_with_invalid_markings(*markings)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(len(self.parser.invalid_objects), 2)
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], ['tlp:white'])
+
+    def test_stix20_duplicate_invalid_objects_are_reported_by_type(self):
+        # Any other invalid object is fetched, dropped and named by the error
+        # its reference produces: 1 id, 1 reference, 1 error, duplicate or
+        # not - nothing a second warning would add.
+        from misp_stix_converter.tools import load_stix2_content
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        bundle = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'identity',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'report',
+                        'id': 'report--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'published': '2020-10-25T16:22:00Z',
+                        'labels': ['Threat-Report'],
+                        'object_refs': [
+                            'indicator--91ae0a21-4b7c-4c1d-9d18-b8b4e2f4a1e2',
+                            indicator_id
+                        ]
+                    },
+                    {
+                        'type': 'indicator',
+                        'id': 'indicator--91ae0a21-4b7c-4c1d-9d18-b8b4e2f4a1e2',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'labels': ['malicious-activity'],
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'valid_from': '2020-10-25T16:22:00.000Z'
+                    },
+                    *(
+                        {
+                            'type': 'indicator', 'id': indicator_id,
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'labels': ['malicious-activity'],
+                            'pattern': pattern,
+                            'valid_from': '2020-10-25T16:22:00.000Z'
+                        } for pattern in ('FIRST pattern', 'SECOND pattern')
+                    )
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        self.assertIn(
+            indicator_id, '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -322,6 +322,69 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         self._check_dict_form_analyst_note(attribute.notes[0], note)
         self._check_dict_form_analyst_opinion(attribute.opinions[0], opinion)
 
+    def test_stix20_bundle_with_colliding_record_uuids(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_colliding_record_uuids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, indicator, observed_data = bundle.objects
+        self._check_misp_event_features(event, report)
+        indicated, observed = event.attributes
+        record_uuid = indicator.id.split('--')[1]
+        # Both attributes keep the uuid their STIX id yields: re-deriving one
+        # of them would cost it the round-trip ADR-0006 guarantees.
+        self.assertEqual(indicated.value, 'first.example.com')
+        self.assertEqual(indicated.uuid, record_uuid)
+        self.assertEqual(observed.value, 'second.example.com')
+        self.assertEqual(observed.uuid, record_uuid)
+        self._check_uuid_collision_warning(
+            record_uuid, (indicator.id, observed_data.id), self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_colliding_non_rfc_record_uuids(self):
+        # Both records carry the v5 replacement the sanitation registered, so
+        # the warning names that uuid rather than the one the STIX ids share.
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_colliding_non_rfc_record_uuids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, indicator, observed_data = bundle.objects
+        indicated, observed = event.attributes
+        self.assertEqual(indicated.uuid, observed.uuid)
+        self.assertNotEqual(str(indicated.uuid), indicator.id.split('--')[1])
+        self._check_uuid_collision_warning(
+            str(indicated.uuid), (indicator.id, observed_data.id),
+            self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_colliding_uuids_on_matching_values(self):
+        # The Indicator and the Observed Data describe the same value, so the
+        # linking merges them into one attribute: one record, one uuid.
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_colliding_uuids_on_matching_values()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'same.example.com')
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
+    def test_stix20_bundle_with_vulnerability_sharing_an_indicator_uuid(self):
+        # The Vulnerability becomes a Galaxy Cluster, a namespace of its own:
+        # the attribute is the only record claiming the shared uuid part.
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_vulnerability_sharing_an_indicator_uuid()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        indicator, vulnerability = bundle.objects[2:]
+        record_uuid = indicator.id.split('--')[1]
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].uuid, record_uuid)
+        self.assertEqual(len(event.galaxies), 1)
+        cluster = event.galaxies[0].clusters[0]
+        self.assertEqual(cluster.value, vulnerability.name)
+        self.assertNotEqual(str(cluster.uuid), record_uuid)
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
     def test_stix20_bundle_with_duplicate_object_ids(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_duplicate_object_ids()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -478,6 +478,51 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             indicator_id, '\n'.join(self._reported_messages(self.parser.errors))
         )
 
+    def test_stix20_dangling_object_refs_are_reported(self):
+        # A Report referencing an object the bundle does not carry produces
+        # an event missing it. STIX 2.0 keeps its observable objects inside
+        # their Observed Data, so an Observed Data and a Marking Definition
+        # reference are what a 2.0 Report can leave dangling next to an SDO.
+        dangling_refs = (
+            'indicator--22222222-2222-4222-8222-222222222222',
+            'marking-definition--33333333-3333-4333-8333-333333333333',
+            'observed-data--44444444-4444-4444-8444-444444444444'
+        )
+        bundle = self._load_stix20_content_with_object_refs(*dangling_refs)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        for object_ref in dangling_refs:
+            self._check_dangling_object_ref_error(
+                object_ref, self.parser.errors
+            )
+        # what the bundle does carry is converted all the same
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix20_resolved_object_refs_are_not_reported(self):
+        # Every reference the bundle carries an object for: nothing lost,
+        # nothing to say.
+        bundle = self._load_stix20_content_with_object_refs()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix20_carried_marking_refs_are_not_reported(self):
+        # A Marking Definition reference is dangling only when the bundle
+        # carried no object under that id. STIX 2.0 knows no extension on a
+        # marking, so the shapes a 2.0 Report can carry are an invalid
+        # marking - recovered and applied where it is referenced - and a TLP
+        # marking the specification defines, which it does not have to send.
+        invalid_id = 'marking-definition--66666666-6666-4666-8666-666666666666'
+        bundle = self._load_stix20_content_with_object_refs(
+            'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
+            carried=tuple(self._invalid_tlp_markings(invalid_id, 'white'))
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [invalid_id])
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -2910,6 +2910,109 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(*deepcopy(_ANALYST_DATA_SAMPLES))
 
     @classmethod
+    def __assemble_colliding_uuids_bundle(
+            cls, observed, indicated=None, record_uuid=None,
+            observable_uuid=None, interoperability=False):
+        """An Observable and, optionally, an Indicator sharing a uuid part.
+
+        `indicator--X` and `domain-name--X` are 2 STIX objects, but the MISP
+        records they produce keep only the part after `--`, so both claim X.
+        `observable_uuid` gives the Observable a uuid part of its own, and
+        leaving `indicated` out keeps the Observed Data with the Observable it
+        holds - the 2 shapes that share a uuid without colliding.
+        """
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        if record_uuid is None:
+            record_uuid = cls.__indicator['id'].split('--')[1]
+        observable = {
+            "type": "domain-name", "spec_version": "2.1",
+            "id": f"domain-name--{observable_uuid or record_uuid}",
+            "value": observed
+        }
+        observed_data = {
+            "type": "observed-data", "spec_version": "2.1",
+            "id": f"observed-data--{record_uuid}",
+            "created_by_ref": cls.__identity['id'],
+            "created": "2020-10-25T16:22:00.000Z",
+            "modified": "2020-10-25T16:22:00.000Z",
+            "first_observed": "2020-10-25T16:22:00Z",
+            "last_observed": "2020-10-25T16:22:00Z",
+            "number_observed": 1, "object_refs": [observable['id']]
+        }
+        stix_objects = [observed_data, observable]
+        if indicated is not None:
+            indicator = deepcopy(cls.__indicator)
+            indicator['id'] = f'indicator--{record_uuid}'
+            indicator['pattern'] = f"[domain-name:value = '{indicated}']"
+            stix_objects.insert(0, indicator)
+        grouping.update(
+            cls._populate_references(
+                *(
+                    stix_object['id'] for stix_object in stix_objects
+                    if stix_object['type'] != 'domain-name'
+                )
+            )
+        )
+        bundle['objects'] = [deepcopy(cls.__identity), grouping, *stix_objects]
+        return dict_to_stix2(
+            bundle, allow_custom=True, interoperability=interoperability
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_record_uuids(cls):
+        return cls.__assemble_colliding_uuids_bundle(
+            'second.example.com', indicated='first.example.com'
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_non_rfc_record_uuids(cls):
+        # A uuid no RFC version knows is replaced by a v5 one on both sides of
+        # the collision, so the warning has to name the replacement. Only the
+        # interoperability mode lets such an id through the STIX validation.
+        return cls.__assemble_colliding_uuids_bundle(
+            'second.example.com', indicated='first.example.com',
+            record_uuid='91ae0a21-c7ae-0c7f-b84b-b84a7ce53d1f',
+            interoperability=True
+        )
+
+    @classmethod
+    def get_bundle_with_colliding_uuids_on_matching_values(cls):
+        return cls.__assemble_colliding_uuids_bundle(
+            'same.example.com', indicated='same.example.com'
+        )
+
+    @classmethod
+    def get_bundle_with_indicator_and_observable_uuids(cls):
+        return cls.__assemble_colliding_uuids_bundle(
+            'second.example.com', indicated='first.example.com',
+            observable_uuid='4dbbf3d9-0a3d-45d5-9d5e-8bea0a1a2fef'
+        )
+
+    @classmethod
+    def get_bundle_with_observable_sharing_its_observed_data_uuid(cls):
+        """The shape MISP's own STIX 2.1 export writes for every Observable."""
+        return cls.__assemble_colliding_uuids_bundle('circl.lu')
+
+    @classmethod
+    def get_bundle_with_vulnerability_sharing_an_indicator_uuid(cls):
+        """A Galaxy Cluster and an attribute claiming the same uuid part."""
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        indicator = deepcopy(cls.__indicator)
+        vulnerability = deepcopy(_VULNERABILITY_OBJECTS[0])
+        vulnerability['id'] = (
+            f"vulnerability--{indicator['id'].split('--')[1]}"
+        )
+        grouping.update(
+            cls._populate_references(indicator['id'], vulnerability['id'])
+        )
+        bundle['objects'] = [
+            deepcopy(cls.__identity), grouping, indicator, vulnerability
+        ]
+        return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
     def get_bundle_with_duplicate_object_ids(cls):
         bundle = deepcopy(cls.__bundle)
         grouping = deepcopy(cls.__grouping)

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -520,6 +520,82 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             indicator_id, '\n'.join(self._reported_messages(self.parser.errors))
         )
 
+    def test_stix21_dangling_object_refs_are_reported(self):
+        # A Grouping referencing an object the bundle does not carry produces
+        # an event missing it. Only the SDO references used to say so: the
+        # observable and Marking Definition ones took their own path out.
+        dangling_refs = (
+            'domain-name--11111111-1111-4111-8111-111111111111',
+            'indicator--22222222-2222-4222-8222-222222222222',
+            'marking-definition--33333333-3333-4333-8333-333333333333'
+        )
+        bundle = self._load_stix21_content_with_object_refs(*dangling_refs)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        for object_ref in dangling_refs:
+            self._check_dangling_object_ref_error(
+                object_ref, self.parser.errors
+            )
+        # what the bundle does carry is converted all the same
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix21_resolved_object_refs_are_not_reported(self):
+        # An observable object a Grouping lists next to the Observed Data
+        # consuming it is converted with its parent: the reference resolves,
+        # and has nothing to report.
+        bundle = self._load_stix21_content_with_object_refs()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix21_dangling_observable_ref_without_observable_objects(self):
+        # The observable objects are only mapped once one is loaded, so a
+        # bundle carrying none used to make the lookup an `AttributeError`
+        # escaping `parse_stix_bundle` uncaught.
+        object_ref = 'domain-name--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix21_content_with_object_refs(
+            object_ref, observables=False
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error(object_ref, self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 1)
+
+    def test_stix21_carried_marking_refs_are_not_reported(self):
+        # A Marking Definition reference is dangling only when the bundle
+        # carried no object under that id - whatever became of the object
+        # afterwards. The 3 shapes that are carried: a marking too broken to
+        # read, which its own loading error already names; an invalid one,
+        # recovered and applied where it is referenced; and a TLP marking the
+        # specification defines, which a bundle does not have to send.
+        unreadable_id = 'marking-definition--55555555-5555-4555-8555-555555555555'
+        invalid_id = 'marking-definition--66666666-6666-4666-8666-666666666666'
+        bundle = self._load_stix21_content_with_object_refs(
+            'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
+            carried=(
+                {
+                    'type': 'marking-definition', 'spec_version': '2.1',
+                    'id': unreadable_id,
+                    'created': '2017-01-20T00:00:00.000Z',
+                    'extensions': {
+                        'extension-definition--99999999-9999-4999-8999-999999999999': {
+                            'extension_type': 'property-extension'
+                        }
+                    }
+                },
+                *self._invalid_tlp_markings(invalid_id, 'white')
+            )
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [invalid_id])
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        # the marking that could not be read is named by the loader instead
+        self.assertIn(
+            unreadable_id, '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
     def test_stix21_classification_forced_internal_warns_on_mismatch(self):
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -350,6 +350,176 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         load_stix2_content(stix_content)
         self.assertEqual(stix_content, original)
 
+    def _load_stix21_content_with_invalid_markings(self, *markings):
+        from misp_stix_converter.tools import load_stix2_content
+        return load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'identity', 'spec_version': '2.1',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'grouping', 'spec_version': '2.1',
+                        'id': 'grouping--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'context': 'suspicious-activity',
+                        'object_refs': [
+                            'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+                        ]
+                    },
+                    {
+                        'type': 'indicator', 'spec_version': '2.1',
+                        'id': 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'pattern_type': 'stix',
+                        'valid_from': '2020-10-25T16:22:00.000Z',
+                        'object_marking_refs': [markings[0]['id']]
+                    },
+                    *markings
+                ]
+            }
+        )
+
+    def test_stix21_duplicate_invalid_marking_definitions_are_reported(self):
+        # A Marking Definition is the one invalid object applied rather than
+        # reported as a loading error: with 2 of them under one id, the last
+        # one wins and the data ends up governed by a marking the sender may
+        # never have sent.
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix21_content_with_invalid_markings(
+            *self._invalid_tlp_markings(marking_id, 'white', 'red')
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        # `invalid_objects` keeps its `id -> object` shape: the marking the
+        # bundle lost travels as an id, not as a second object.
+        self.assertEqual(list(self.parser.invalid_objects), [marking_id])
+        self._check_duplicate_invalid_marking_warning(
+            marking_id, self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], ['tlp:red'])
+
+    def test_stix21_unapplied_invalid_marking_definitions_are_not_reported(self):
+        # A marking too broken to read governs nothing: loading it raises,
+        # the object referring to it is reported as an error and lands with
+        # no marking, and a duplicate that changed no marking has no stake to
+        # warn about.
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix21_content_with_invalid_markings(
+            *(
+                {
+                    'type': 'marking-definition', 'id': marking_id,
+                    'created': '2017-01-20T00:00:00.000Z',
+                    'definition_type': 'tlp'
+                } for _ in range(2)
+            )
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], [])
+        self.assertIn(
+            attribute.uuid,
+            '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
+    def test_stix21_distinct_invalid_marking_definitions_are_not_reported(self):
+        # Invalid markings the bundle keeps apart shadow nothing: both are
+        # recovered, and each governs what refers to it.
+        markings = self._invalid_tlp_markings(
+            'marking-definition--11111111-1111-4111-8111-111111111111', 'white'
+        ) + self._invalid_tlp_markings(
+            'marking-definition--22222222-2222-4222-8222-222222222222', 'red'
+        )
+        bundle = self._load_stix21_content_with_invalid_markings(*markings)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(len(self.parser.invalid_objects), 2)
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], ['tlp:white'])
+
+    def test_stix21_duplicate_invalid_objects_are_reported_by_type(self):
+        # Any other invalid object is fetched, dropped and named by the error
+        # its reference produces: 1 id, 1 reference, 1 error, duplicate or
+        # not - nothing a second warning would add.
+        from misp_stix_converter.tools import load_stix2_content
+        indicator_id = 'indicator--10440d97-42bb-4b17-a439-9dd5e17dd93e'
+        bundle = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'identity', 'spec_version': '2.1',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'grouping', 'spec_version': '2.1',
+                        'id': 'grouping--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'context': 'suspicious-activity',
+                        'object_refs': [
+                            'indicator--91ae0a21-4b7c-4c1d-9d18-b8b4e2f4a1e2',
+                            indicator_id
+                        ]
+                    },
+                    {
+                        'type': 'indicator', 'spec_version': '2.1',
+                        'id': 'indicator--91ae0a21-4b7c-4c1d-9d18-b8b4e2f4a1e2',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'pattern_type': 'stix',
+                        'valid_from': '2020-10-25T16:22:00.000Z'
+                    },
+                    *(
+                        {
+                            'type': 'indicator', 'spec_version': '2.1',
+                            'id': indicator_id,
+                            'created': '2020-10-25T16:22:00.000Z',
+                            'modified': '2020-10-25T16:22:00.000Z',
+                            'pattern': pattern, 'pattern_type': 'stix',
+                            'valid_from': '2020-10-25T16:22:00.000Z'
+                        } for pattern in ('FIRST pattern', 'SECOND pattern')
+                    )
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_duplicate_invalid_marking_warning_absence(
+            self.parser.warnings
+        )
+        self.assertIn(
+            indicator_id, '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
     def test_stix21_classification_forced_internal_warns_on_mismatch(self):
         from misp_stix_converter import stix_2_to_misp
         from pathlib import Path

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -461,6 +461,96 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             f'misp-galaxy:producer="{self.parser.producer}"'
         )
 
+    def test_stix21_bundle_with_colliding_record_uuids(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_colliding_record_uuids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, indicator, _, observable = bundle.objects
+        self._check_misp_event_features_from_grouping(event, grouping)
+        indicated, observed = event.attributes
+        record_uuid = indicator.id.split('--')[1]
+        # Both attributes keep the uuid their STIX id yields: re-deriving one
+        # of them would cost it the round-trip ADR-0006 guarantees.
+        self.assertEqual(indicated.value, 'first.example.com')
+        self.assertEqual(indicated.uuid, record_uuid)
+        self.assertEqual(observed.value, 'second.example.com')
+        self.assertEqual(observed.uuid, record_uuid)
+        self._check_uuid_collision_warning(
+            record_uuid, (indicator.id, observable.id), self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_colliding_non_rfc_record_uuids(self):
+        # Both records carry the v5 replacement the sanitation registered, so
+        # the warning names that uuid rather than the one the STIX ids share.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_colliding_non_rfc_record_uuids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, indicator, _, observable = bundle.objects
+        indicated, observed = event.attributes
+        self.assertEqual(indicated.uuid, observed.uuid)
+        self.assertNotEqual(str(indicated.uuid), indicator.id.split('--')[1])
+        self._check_uuid_collision_warning(
+            str(indicated.uuid), (indicator.id, observable.id),
+            self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_colliding_uuids_on_matching_values(self):
+        # The Indicator and the Observable describe the same value, so the
+        # linking merges them into one attribute: one record, one uuid.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_colliding_uuids_on_matching_values()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'same.example.com')
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
+    def test_stix21_bundle_with_observable_sharing_its_observed_data_uuid(self):
+        # MISP's own export gives an Observable the uuid of the Observed Data
+        # holding it - 21 times in `test_misp_events.stix21.json`. Only the
+        # Observable becomes a record, so nothing collides.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_observable_sharing_its_observed_data_uuid()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(len(event.attributes), 1)
+        attribute = event.attributes[0]
+        self.assertEqual(attribute.value, 'circl.lu')
+        self.assertEqual(attribute.uuid, bundle.objects[3].id.split('--')[1])
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
+    def test_stix21_bundle_with_indicator_and_observable_uuids(self):
+        # The Observable carries an id of its own, so the attribute it becomes
+        # takes that uuid instead of the Observed Data's: nothing collides.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_indicator_and_observable_uuids()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, indicator, _, observable = bundle.objects
+        indicated, observed = event.attributes
+        self.assertEqual(indicated.uuid, indicator.id.split('--')[1])
+        self.assertEqual(observed.uuid, observable.id.split('--')[1])
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
+    def test_stix21_bundle_with_vulnerability_sharing_an_indicator_uuid(self):
+        # The Vulnerability becomes a Galaxy Cluster, a namespace of its own:
+        # the attribute is the only record claiming the shared uuid part.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_vulnerability_sharing_an_indicator_uuid()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        indicator, vulnerability = bundle.objects[2:]
+        record_uuid = indicator.id.split('--')[1]
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].uuid, record_uuid)
+        self.assertEqual(len(event.galaxies), 1)
+        cluster = event.galaxies[0].clusters[0]
+        self.assertEqual(cluster.value, vulnerability.name)
+        self.assertNotEqual(str(cluster.uuid), record_uuid)
+        self._check_uuid_collision_warning_absence(self.parser.warnings)
+
     def test_stix21_bundle_with_duplicate_object_ids(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_duplicate_object_ids()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -8370,6 +8370,47 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
         )
 
     @classmethod
+    def __assemble_merged_indicator_bundle(cls, **indicator_fields):
+        """An Indicator and an Observed Data sharing the uuid they merge on.
+
+        `indicator--X` and `observed-data--X` are the 2 renderings a MISP
+        object with a `to_ids` attribute exports, and the import merges them
+        back into the single record X: what the Indicator says the Observed
+        Data does not is what such a merge takes away.
+        """
+        observed_data, indicator, relationship = deepcopy(
+            _DOMAIN_OBSERVABLE_ATTRIBUTE
+        )
+        indicator.update(indicator_fields)
+        return cls.__assemble_bundle(observed_data, indicator, relationship)
+
+    @classmethod
+    def get_bundle_with_merged_indicator_on_different_values(cls):
+        return cls.__assemble_merged_indicator_bundle(
+            pattern="[domain-name:value = 'misp-project.org']"
+        )
+
+    @classmethod
+    def get_bundle_with_merged_indicator_on_narrowed_value(cls):
+        # The Observed Data narrows what the pattern states rather than
+        # contradicting it: still a value the merge does not keep.
+        observed_data, indicator, relationship = deepcopy(
+            _DOMAIN_OBSERVABLE_ATTRIBUTE
+        )
+        observed_data['objects']['0']['value'] = 'www.circl.lu'
+        return cls.__assemble_bundle(observed_data, indicator, relationship)
+
+    @classmethod
+    def get_bundle_with_merged_indicator_without_stix_pattern(cls):
+        # A sigma rule states no value the Observed Data could be repeating.
+        # STIX 2.0 knows no `pattern_type` and validates every pattern as a
+        # STIX one, so the rule reaches the parser as a custom property.
+        return cls.__assemble_merged_indicator_bundle(
+            pattern="[domain-name:value = 'misp-project.org']",
+            pattern_type='sigma'
+        )
+
+    @classmethod
     def get_bundle_with_multiple_reports(cls):
         bundle = deepcopy(cls.__bundle)
         bundle['objects'] = [

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -139,6 +139,72 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
     #                       MISP ATTRIBUTES IMPORT TESTS                       #
     ############################################################################
 
+    def test_stix20_duplicate_invalid_marking_definitions_are_reported(self):
+        # The invalid objects path is the loader's, not a parser's: an
+        # Internal bundle failing `stix2` parsing recovers and applies the
+        # last of the Marking Definitions sharing an id just like an External
+        # one, and pays the same warning for it.
+        from misp_stix_converter.tools import load_stix2_content
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--314e4210-e41a-4952-9f3c-135d7d577112',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'identity',
+                        'id': 'identity--a0c22599-9e58-4da4-96ac-7051603fa951',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-Project',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'report',
+                        'id': 'report--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--a0c22599-9e58-4da4-96ac-7051603fa951',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'published': '2020-10-25T16:22:00Z',
+                        'labels': [
+                            'Threat-Report', 'misp:tool="MISP-STIX-Converter"'
+                        ],
+                        'object_refs': [
+                            'observed-data--11111111-1111-4111-8111-111111111111'
+                        ]
+                    },
+                    {
+                        'type': 'observed-data',
+                        'id': 'observed-data--11111111-1111-4111-8111-111111111111',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'first_observed': '2020-10-25T16:22:00Z',
+                        'last_observed': '2020-10-25T16:22:00Z',
+                        'number_observed': 1,
+                        'objects': {
+                            '0': {'type': 'ipv4-addr', 'value': '10.0.0.1'}
+                        },
+                        'labels': [
+                            'misp:type="ip-src"',
+                            'misp:category="Network activity"'
+                        ],
+                        'object_marking_refs': [marking_id]
+                    },
+                    *self._invalid_tlp_markings(marking_id, 'white', 'red')
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [marking_id])
+        self._check_duplicate_invalid_marking_warning(
+            marking_id, self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], ['tlp:red'])
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -205,6 +205,53 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         attribute = self.parser.misp_event.attributes[0]
         self.assertEqual([tag.name for tag in attribute.tags], ['tlp:red'])
 
+    def test_stix20_dangling_object_refs_are_reported(self):
+        # A Marking Definition reference an Internal Report leaves dangling
+        # used to be reported as an unknown object *type* - the type is known,
+        # the object under that id is what the bundle never carried.
+        dangling_refs = (
+            'indicator--22222222-2222-4222-8222-222222222222',
+            'marking-definition--33333333-3333-4333-8333-333333333333',
+            'observed-data--44444444-4444-4444-8444-444444444444'
+        )
+        bundle = self._load_stix20_content_with_object_refs(
+            *dangling_refs, internal=True
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        for object_ref in dangling_refs:
+            self._check_dangling_object_ref_error(
+                object_ref, self.parser.errors
+            )
+        # what the bundle does carry is converted all the same
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix20_resolved_object_refs_are_not_reported(self):
+        # Every reference the bundle carries an object for: nothing lost,
+        # nothing to say.
+        bundle = self._load_stix20_content_with_object_refs(internal=True)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix20_carried_marking_refs_are_not_reported(self):
+        # A Marking Definition reference is dangling only when the bundle
+        # carried no object under that id. STIX 2.0 knows no extension on a
+        # marking, so the shapes a 2.0 Report can carry are an invalid
+        # marking - recovered and applied where it is referenced - and a TLP
+        # marking the specification defines, which it does not have to send.
+        invalid_id = 'marking-definition--66666666-6666-4666-8666-666666666666'
+        bundle = self._load_stix20_content_with_object_refs(
+            'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
+            internal=True,
+            carried=tuple(self._invalid_tlp_markings(invalid_id, 'white'))
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [invalid_id])
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+
     def test_stix20_bundle_with_tlp_1_0_markings(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -1768,6 +1768,64 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         )
         self.assertIn(f'Original UUID was: {vulnerability_uuid}', vulnerability.comment)
 
+    def test_stix20_bundle_with_merged_indicator_on_different_values(self):
+        # The Observed Data wins the merge, as it does for the content this
+        # was built for, but what only the Indicator carried is now named.
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_merged_indicator_on_different_values()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, observed_data, indicator, _ = bundle.objects
+        attribute = self._check_misp_event_features(event, report)[0]
+        record_uuid = indicator.id.split('--')[1]
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(attribute.uuid, record_uuid)
+        self.assertEqual(attribute.value, 'circl.lu')
+        self._check_merged_indicator_warning(
+            record_uuid, (indicator.id, observed_data.id),
+            ('misp-project.org',), self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_merged_indicator_on_matching_values(self):
+        # The 2 renderings a MISP record exports say the same thing, so the
+        # merge restoring that record takes nothing away.
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_domain_attribute()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'circl.lu')
+        self._check_merged_indicator_warning_absence(self.parser.warnings)
+
+    def test_stix20_bundle_with_merged_indicator_on_narrowed_value(self):
+        # A value the Observed Data narrows is a value the merge takes away,
+        # so the comparison cannot settle for the pattern being contained.
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_merged_indicator_on_narrowed_value()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, observed_data, indicator, _ = bundle.objects
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'www.circl.lu')
+        self._check_merged_indicator_warning(
+            indicator.id.split('--')[1], (indicator.id, observed_data.id),
+            ('circl.lu',), self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_merged_indicator_without_stix_pattern(self):
+        # No comparison to run: the whole pattern goes with the merge.
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_merged_indicator_without_stix_pattern()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, observed_data, indicator, _ = bundle.objects
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'circl.lu')
+        self._check_merged_indicator_warning(
+            indicator.id.split('--')[1], (indicator.id, observed_data.id),
+            (indicator.pattern,), self.parser.warnings
+        )
+
     def test_stix20_bundle_with_multiple_reports_as_multiple_events(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_multiple_reports()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -10478,6 +10478,49 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
         )
 
     @classmethod
+    def __assemble_merged_indicator_bundle(cls, **indicator_fields):
+        """An Indicator and an Observed Data sharing the uuid they merge on.
+
+        `indicator--X` and `observed-data--X` are the 2 renderings a MISP
+        object with a `to_ids` attribute exports, and the import merges them
+        back into the single record X: what the Indicator says the Observed
+        Data does not is what such a merge takes away.
+        """
+        observed_data, domain, indicator, relationship = deepcopy(
+            _DOMAIN_OBSERVABLE_ATTRIBUTE
+        )
+        indicator.update(indicator_fields)
+        return cls.__assemble_bundle(
+            observed_data, domain, indicator, relationship
+        )
+
+    @classmethod
+    def get_bundle_with_merged_indicator_on_different_values(cls):
+        return cls.__assemble_merged_indicator_bundle(
+            pattern="[domain-name:value = 'misp-project.org']"
+        )
+
+    @classmethod
+    def get_bundle_with_merged_indicator_on_narrowed_value(cls):
+        # The Observed Data narrows what the pattern states rather than
+        # contradicting it: still a value the merge does not keep.
+        observed_data, domain, indicator, relationship = deepcopy(
+            _DOMAIN_OBSERVABLE_ATTRIBUTE
+        )
+        domain['value'] = 'www.circl.lu'
+        return cls.__assemble_bundle(
+            observed_data, domain, indicator, relationship
+        )
+
+    @classmethod
+    def get_bundle_with_merged_indicator_without_stix_pattern(cls):
+        # A sigma rule states no value the Observed Data could be repeating,
+        # and the merge drops it before the parsing path reporting it.
+        return cls.__assemble_merged_indicator_bundle(
+            pattern='title: Merged sigma rule', pattern_type='sigma'
+        )
+
+    @classmethod
     def get_bundle_with_multiple_reports(cls):
         bundle = deepcopy(cls.__bundle)
         bundle['objects'] = [

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -2108,6 +2108,64 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         )
         self.assertIn(f'Original UUID was: {vulnerability_uuid}', vulnerability.comment)
 
+    def test_stix21_bundle_with_merged_indicator_on_different_values(self):
+        # The Observed Data wins the merge, as it does for the content this
+        # was built for, but what only the Indicator carried is now named.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_merged_indicator_on_different_values()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, observed_data, _, indicator, _ = bundle.objects
+        attribute = self._check_misp_event_features(event, grouping)[0]
+        record_uuid = indicator.id.split('--')[1]
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(attribute.uuid, record_uuid)
+        self.assertEqual(attribute.value, 'circl.lu')
+        self._check_merged_indicator_warning(
+            record_uuid, (indicator.id, observed_data.id),
+            ('misp-project.org',), self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_merged_indicator_on_matching_values(self):
+        # The 2 renderings a MISP record exports say the same thing, so the
+        # merge restoring that record takes nothing away.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_domain_attribute()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'circl.lu')
+        self._check_merged_indicator_warning_absence(self.parser.warnings)
+
+    def test_stix21_bundle_with_merged_indicator_on_narrowed_value(self):
+        # A value the Observed Data narrows is a value the merge takes away,
+        # so the comparison cannot settle for the pattern being contained.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_merged_indicator_on_narrowed_value()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, observed_data, _, indicator, _ = bundle.objects
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'www.circl.lu')
+        self._check_merged_indicator_warning(
+            indicator.id.split('--')[1], (indicator.id, observed_data.id),
+            ('circl.lu',), self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_merged_indicator_without_stix_pattern(self):
+        # No comparison to run: the whole rule goes with the merge.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_merged_indicator_without_stix_pattern()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, _, observed_data, _, indicator, _ = bundle.objects
+        self.assertEqual(len(event.attributes), 1)
+        self.assertEqual(event.attributes[0].value, 'circl.lu')
+        self._check_merged_indicator_warning(
+            indicator.id.split('--')[1], (indicator.id, observed_data.id),
+            (indicator.pattern,), self.parser.warnings
+        )
+
     def test_stix21_bundle_with_multiple_reports_as_multiple_events(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_multiple_reports()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -204,6 +204,86 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         attribute = self.parser.misp_event.attributes[0]
         self.assertEqual([tag.name for tag in attribute.tags], ['tlp:red'])
 
+    def test_stix21_dangling_object_refs_are_reported(self):
+        # An Internal Grouping lists the observable objects its Observed Data
+        # consumed, which is why observable references are skipped before any
+        # lookup: the skip took the references to objects the bundle never
+        # carried with it.
+        dangling_refs = (
+            'domain-name--11111111-1111-4111-8111-111111111111',
+            'indicator--22222222-2222-4222-8222-222222222222',
+            'marking-definition--33333333-3333-4333-8333-333333333333'
+        )
+        bundle = self._load_stix21_content_with_object_refs(
+            *dangling_refs, internal=True
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        for object_ref in dangling_refs:
+            self._check_dangling_object_ref_error(
+                object_ref, self.parser.errors
+            )
+        # what the bundle does carry is converted all the same
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix21_resolved_object_refs_are_not_reported(self):
+        # The observable objects a MISP export lists next to their Observed
+        # Data are converted with it: references that resolve, reported by
+        # nothing.
+        bundle = self._load_stix21_content_with_object_refs(internal=True)
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 2)
+
+    def test_stix21_dangling_observable_ref_without_observable_objects(self):
+        # The observable objects are only mapped once one is loaded: a bundle
+        # carrying none is the shape the reference has nothing to be looked
+        # up in.
+        object_ref = 'domain-name--11111111-1111-4111-8111-111111111111'
+        bundle = self._load_stix21_content_with_object_refs(
+            object_ref, internal=True, observables=False
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self._check_dangling_object_ref_error(object_ref, self.parser.errors)
+        self.assertEqual(len(self.parser.misp_event.attributes), 1)
+
+    def test_stix21_carried_marking_refs_are_not_reported(self):
+        # A Marking Definition reference is dangling only when the bundle
+        # carried no object under that id - whatever became of the object
+        # afterwards. The 3 shapes that are carried: a marking too broken to
+        # read, which its own loading error already names; an invalid one,
+        # recovered and applied where it is referenced; and a TLP marking the
+        # specification defines, which a bundle does not have to send.
+        unreadable_id = 'marking-definition--55555555-5555-4555-8555-555555555555'
+        invalid_id = 'marking-definition--66666666-6666-4666-8666-666666666666'
+        bundle = self._load_stix21_content_with_object_refs(
+            'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9',
+            internal=True,
+            carried=(
+                {
+                    'type': 'marking-definition', 'spec_version': '2.1',
+                    'id': unreadable_id,
+                    'created': '2017-01-20T00:00:00.000Z',
+                    'extensions': {
+                        'extension-definition--99999999-9999-4999-8999-999999999999': {
+                            'extension_type': 'property-extension'
+                        }
+                    }
+                },
+                *self._invalid_tlp_markings(invalid_id, 'white')
+            )
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [invalid_id])
+        self._check_dangling_object_ref_error_absence(self.parser.errors)
+        # the marking that could not be read is named by the loader instead
+        self.assertIn(
+            unreadable_id, '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
     def test_stix21_bundle_with_tlp_1_0_markings(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -132,6 +132,78 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
     #                       MISP ATTRIBUTES IMPORT TESTS                       #
     ############################################################################
 
+    def test_stix21_duplicate_invalid_marking_definitions_are_reported(self):
+        # The invalid objects path is the loader's, not a parser's: an
+        # Internal bundle failing `stix2` parsing recovers and applies the
+        # last of the Marking Definitions sharing an id just like an External
+        # one, and pays the same warning for it.
+        from misp_stix_converter.tools import load_stix2_content
+        marking_id = 'marking-definition--11111111-1111-4111-8111-111111111111'
+        bundle = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--314e4210-e41a-4952-9f3c-135d7d577112',
+                'objects': [
+                    {
+                        'type': 'identity', 'spec_version': '2.1',
+                        'id': 'identity--a0c22599-9e58-4da4-96ac-7051603fa951',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-Project',
+                        'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'grouping', 'spec_version': '2.1',
+                        'id': 'grouping--a6ef17d6-91cb-4a05-b10b-2f045daf874c',
+                        'created_by_ref': 'identity--a0c22599-9e58-4da4-96ac-7051603fa951',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'context': 'suspicious-activity',
+                        'labels': [
+                            'Threat-Report', 'misp:tool="MISP-STIX-Converter"'
+                        ],
+                        'object_refs': [
+                            'indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f'
+                        ]
+                    },
+                    {
+                        'type': 'indicator', 'spec_version': '2.1',
+                        'id': 'indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f',
+                        'created_by_ref': 'identity--a0c22599-9e58-4da4-96ac-7051603fa951',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[domain-name:value = 'circl.lu']",
+                        'pattern_type': 'stix',
+                        'pattern_version': '2.1',
+                        'valid_from': '2020-10-25T16:22:00Z',
+                        'kill_chain_phases': [
+                            {
+                                'kill_chain_name': 'misp-category',
+                                'phase_name': 'Network activity'
+                            }
+                        ],
+                        'labels': [
+                            'misp:type="domain"',
+                            'misp:category="Network activity"'
+                        ],
+                        'object_marking_refs': [marking_id]
+                    },
+                    *self._invalid_tlp_markings(
+                        marking_id, 'white', 'red'
+                    )
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(list(self.parser.invalid_objects), [marking_id])
+        self._check_duplicate_invalid_marking_warning(
+            marking_id, self.parser.warnings
+        )
+        attribute = self.parser.misp_event.attributes[0]
+        self.assertEqual([tag.name for tag in attribute.tags], ['tlp:red'])
+
     def test_stix21_bundle_with_tlp_1_0_markings(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_tlp_1_0_markings()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
## Description

Four import-side situations where a STIX 2 bundle lost or overrode data without the operator ever being told. In every case the resolution stays what it was — the fix is that the loss is now named, with the id or uuid the records actually carry.

## The four silent losses

**#107 — Two STIX ids collapsing onto one MISP uuid.** A STIX id is `<type>--<uuid>` and the whole id names the object, while a MISP record uuid keeps only the part after `--`: `indicator--X` and `domain-name--X` are two objects the sender kept apart that arrive as two records both claiming `X`. Neither uuid is re-derived — that would cost whichever record loses its bare uuid its round-trip — but the collision is now reported. Events, objects and attributes are tracked apart, since each has its own uuid namespace and an attribute sharing its uuid with the object holding it is what MISP's own STIX 2.1 export writes.

**#108 — Values dropped when an Indicator is merged into an Observed Data.** An Internal export renders a `to_ids` record twice, so folding the pair back into one record is right. The fold read no values though, so a pair whose halves disagree was folded all the same and the pattern went with it. The fold stays; the values the Observed Data does not carry are now named with the uuid.

**#109 — Invalid Marking Definitions sharing an id.** A bundle that fails to parse as a whole is re-parsed object by object, and the objects failing on their own are kept by id — so the last of two invalid Marking Definitions carrying one id wins. Unlike every other invalid object, a marking is not just reported and dropped but applied, which means the data can end up governed by a marking the sender never sent. The last one still wins; it no longer wins in silence.

**#110 — `object_refs` pointing at nothing.** A Report or Grouping referencing an object the bundle never sent produced an event missing it and said nothing: only the SDO references were answered, the observable and Marking Definition ones took their own path out — and a marking was blamed on its type, which was never the problem. Every reference type now names the id it could not reach, and a bundle carrying no observable object at all answers the reference instead of raising.

## Refactors carried along

- The observable value walker moved to the base parser: collecting the values an observable carries is not External-specific, an Internal Indicator merged into an Observed Data has to read them too.
- Recovering a referenced invalid object lives in one method instead of two identical four-line branches, which now differ only in the error they raise.
- Telling whether an id is a specification TLP marking is split from loading that marking, so a caller only needing the question answered no longer pays the answer.

## Tests

Each fix ships with its own coverage commit, symmetric across both versions and both parsers where the behaviour is shared (`test_internal_stix20/21_import.py`, `test_external_stix20/21_import.py`, plus the matching bundle fixtures).