### PR TITLE
Stop a quote in the data from dropping objects, breaking the XML or adding tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ STIX 1 specific arguments:
                         MISP data structure level.
   --format {json,xml}   STIX 1 format.
   -n, --namespace NAMESPACE
-                        Namespace to be used in the STIX 1 header.
+                        Namespace to be used in the STIX 1 header - must be a URI.
   -org ORG              Organisation name to be used in the STIX 1 header.
 ```
 

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -95,7 +95,7 @@ def main():
     )
     stix1_parser.add_argument(
         '-n', '--namespace', default='https://misp-project.org',
-        help='Namespace to be used in the STIX 1 header.'
+        help='Namespace to be used in the STIX 1 header - must be a URI.'
     )
     stix1_parser.add_argument(
         '-org', default='MISP',

--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -1648,12 +1648,12 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
             separator: Optional[str] = ':') -> list:
         pattern = []
         for key, values in attributes.items():
-            key = key.replace('-', '_')
+            segment = self._quote_custom_property(key)
             if not isinstance(values, list):
-                pattern.append(f"{prefix}{separator}x_misp_{key} = '{values}'")
+                pattern.append(f"{prefix}{separator}{segment} = '{values}'")
                 continue
             for value in values:
-                pattern.append(f"{prefix}{separator}x_misp_{key} = '{value}'")
+                pattern.append(f"{prefix}{separator}{segment} = '{value}'")
         return pattern
 
     def _handle_pattern_properties(
@@ -1661,9 +1661,8 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
             separator: Optional[str] = ':') -> list:
         pattern = []
         for key, value in attributes.items():
-            pattern.append(
-                f"{prefix}{separator}x_misp_{key.replace('-', '_')} = '{value}'"
-            )
+            segment = self._quote_custom_property(key)
+            pattern.append(f"{prefix}{separator}{segment} = '{value}'")
         return pattern
 
     def _handle_pe_object_references(
@@ -1737,7 +1736,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                     for value in values:
                         pattern.extend(
                             self._handle_custom_data_pattern(
-                                prefix, key.replace('-', '_'), value
+                                prefix, key, value
                             )
                         )
             indicator = self._handle_object_indicator(misp_object, pattern)
@@ -3200,13 +3199,13 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
                         for value in values:
                             pattern.extend(
                                 self._handle_custom_data_pattern(
-                                    prefix, key.replace('-', '_'), value
+                                    prefix, key, value
                                 )
                             )
                     else:
                         pattern.extend(
                             self._handle_custom_data_pattern(
-                                prefix, key.replace('-', '_'), values
+                                prefix, key, values
                             )
                         )
             indicator = self._handle_object_indicator(misp_object, pattern)
@@ -5202,15 +5201,16 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
     @staticmethod
     def _handle_custom_data_pattern(
             prefix: str, key: str, value: str | tuple) -> list:
+        segment = MISPtoSTIX2Parser._quote_custom_property(key)
         if isinstance(value, tuple):
             value, data = value
             if not isinstance(data, str):
                 data = b64encode(data.getvalue()).decode()
             return [
-                f"{prefix}:x_misp_{key}.data = '{data}'",
-                f"{prefix}:x_misp_{key}.value = '{value}'"
+                f"{prefix}:{segment}.data = '{data}'",
+                f"{prefix}:{segment}.value = '{value}'"
             ]
-        return [f"{prefix}:x_misp_{key} = '{value}'"]
+        return [f"{prefix}:{segment} = '{value}'"]
 
     def _handle_indicator_time_fields(
             self, data_layer: MISPAttribute | MISPObject | dict) -> dict:
@@ -5373,6 +5373,12 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
     @staticmethod
     def _escape_pattern_value(value: str) -> str:
         return str(value).replace('\\', '\\\\').replace("'", "\\'")
+
+    @staticmethod
+    def _quote_custom_property(relation: str) -> str:
+        return MISPtoSTIX2Parser._quote_segment(
+            f"x_misp_{relation.replace('-', '_')}"
+        )
 
     @staticmethod
     def _quote_segment(segment: str) -> str:

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -10,7 +10,8 @@ from .misp2stix.misp_to_stix20 import MISPtoSTIX20Parser
 from .misp2stix.misp_to_stix21 import MISPtoSTIX21Parser
 from .stix2misp.importparser import MISP_org_uuid
 from .tools.stix1_framing import (
-    stix1_attributes_framing, stix1_framing, _create_stix_package)
+    stix1_attributes_framing, stix1_framing, _create_stix_package,
+    _validate_namespace)
 from .tools.stix1_loading_helpers import load_stix1_package
 from .tools.stix1_to_misp_helpers import get_stix1_parser, is_stix1_from_misp
 from .tools.stix1_writing_helpers import (
@@ -111,7 +112,7 @@ class AttributeCollectionHandler:
 def misp_attribute_collection_to_stix1(
         *input_files: List[_files_type], debug: Optional[bool] = False,
         return_format: Optional[str] = _STIX1_default_format,
-        namespace: Optional[str] = _default_namespace,
+        namespace: str = _default_namespace,
         org: Optional[str] = _default_org,
         version: Optional[str] = _STIX1_default_version,
         in_memory: Optional[bool] = False,
@@ -122,6 +123,7 @@ def misp_attribute_collection_to_stix1(
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
+    namespace = _validate_namespace(namespace)
     parser = MISPtoSTIX1AttributesParser(org, version)
     if len(input_files) == 1:
         try:
@@ -236,7 +238,7 @@ def misp_attribute_collection_to_stix1(
 def misp_event_collection_to_stix1(
         *input_files: List[_files_type], debug: Optional[bool] = False,
         return_format: Optional[str] = _STIX1_default_format,
-        namespace: Optional[str] = _default_namespace,
+        namespace: str = _default_namespace,
         org: Optional[str] = _default_org,
         version: Optional[str] = _STIX1_default_version,
         in_memory: Optional[bool] = False,
@@ -247,6 +249,7 @@ def misp_event_collection_to_stix1(
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
+    namespace = _validate_namespace(namespace)
     _write_args = (namespace, org, return_format)
     parser = MISPtoSTIX1EventsParser(org, version)
     if len(input_files) == 1:
@@ -443,7 +446,7 @@ def misp_collection_to_stix2(
 def misp_to_stix1(
         filename: _files_type, debug: Optional[bool] = False,
         return_format: Optional[str] = _STIX1_default_format,
-        namespace: Optional[str] = _default_namespace,
+        namespace: str = _default_namespace,
         org: Optional[str] = _default_org,
         version: Optional[str] = _STIX1_default_version,
         output_dir: Optional[_files_type] = None,
@@ -452,6 +455,7 @@ def misp_to_stix1(
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
+    namespace = _validate_namespace(namespace)
     parser = MISPtoSTIX1EventsParser(org, version)
     try:
         if not isinstance(filename, Path):

--- a/misp_stix_converter/stix2misp/importparser.py
+++ b/misp_stix_converter/stix2misp/importparser.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 
 import json
+import re
 import traceback
 from ..abstract import AbstractParser
 from abc import ABCMeta
 from datetime import datetime
 from pymisp import MISPEvent, MISPObject
 from pymisp.abstract import resources_path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 from uuid import UUID
 
 MISP_org_uuid = '55f6ea65-aa10-4c5a-bf01-4f84950d210f'
@@ -16,6 +17,16 @@ _DEFAULT_DISTRIBUTION = 0
 
 _VALID_DISTRIBUTIONS = (0, 1, 2, 3, 4)
 _RFC_VERSIONS = (1, 3, 4, 5)
+
+# The producer is written into the MISP taxonomy tag
+# `misp-galaxy:producer="<producer>"`, a grammar with no escaping of its own: a
+# `"` in the value closes it, and the rest of the name is then read as further
+# taxonomy entries of the tag - a name a bundle chose for itself deciding what
+# else the event is tagged with. The control characters cannot be written into
+# the XML and CSV exports the tag reaches either. Both are taken out of the
+# value, along with the whitespace around what is left - the rest is kept as it
+# stands, inner spaces and the `:` and `=` a plain name may carry included.
+_TAG_VALUE_METACHARACTERS = re.compile(r'["\x00-\x1f\x7f]')
 
 
 def _load_json_file(path) -> dict:
@@ -61,6 +72,26 @@ class STIXtoMISPParser(AbstractParser):
         self.__title: Union[str, None]
 
         self.__replacement_uuids: dict = {}
+
+    def _add_producer_tag(self, misp_event: MISPEvent, producer: Any):
+        """Tag the event with the producer, as one taxonomy entry at most.
+
+        Sanitised here rather than with the other parameters in
+        `_set_parameters`: a `producer` parameter a tag value cannot be made of
+        has to leave the event without a producer tag, never falling back to
+        the provenance the bundle claims for itself.
+
+        :param misp_event: the event being created
+        :param producer: the producer name, from the `producer` parameter or
+            from the Identity the bundle credits itself to - from any source
+        """
+        name = _TAG_VALUE_METACHARACTERS.sub('', str(producer)).strip()
+        if not name:
+            self._unusable_producer_warning(producer)
+            return
+        if name != producer:
+            self._sanitised_producer_warning(producer, name)
+        misp_event.add_tag(f'misp-galaxy:producer="{name}"')
 
     def _populate_misp_event(self):
         self.misp_events.append(self.misp_event)
@@ -215,9 +246,22 @@ class STIXtoMISPParser(AbstractParser):
         tb = ''.join(traceback.format_tb(exception.__traceback__))
         return f'{tb}{exception.__str__()}'
 
+    def _sanitised_producer_warning(self, producer: Any, sanitised: str):
+        self._add_warning(
+            f'Sanitised producer name: {producer} - what a MISP taxonomy tag '
+            'value cannot carry was taken out, the event is tagged as '
+            f'produced by {sanitised}'
+        )
+
     def _sharing_group_id_error(self, exception: Exception):
         self._add_error(
             f'Wrong sharing group id format: {exception}', 'init'
+        )
+
+    def _unusable_producer_warning(self, producer: Any):
+        self._add_warning(
+            f'Unusable producer name: {producer} - nothing a MISP taxonomy '
+            'tag value can be made of, the event carries no producer tag'
         )
 
     ############################################################################

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -1268,10 +1268,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             event_args['sharing_group_id'] = self.sharing_group_id
         misp_event.from_dict(**event_args)
         if self.producer is not None:
-            misp_event.add_tag(f'misp-galaxy:producer="{self.producer}"')
+            self._add_producer_tag(misp_event, self.producer)
         elif len(self._creators) == 1:
-            producer = self._handle_creator(tuple(self._creators)[0])
-            misp_event.add_tag(f'misp-galaxy:producer="{producer}"')
+            self._add_producer_tag(
+                misp_event, self._handle_creator(tuple(self._creators)[0])
+            )
         return misp_event
 
     def _create_misp_event(
@@ -1303,10 +1304,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             for reference in self._analyst_data[stix_object['id']]:
                 self._add_analyst_data(misp_event, reference)
         if self.producer is not None:
-            misp_event.add_tag(f'misp-galaxy:producer="{self.producer}"')
+            self._add_producer_tag(misp_event, self.producer)
         elif 'created_by_ref' in stix_object:
-            producer = self._handle_creator(stix_object['created_by_ref'])
-            misp_event.add_tag(f'misp-galaxy:producer="{producer}"')
+            self._add_producer_tag(
+                misp_event, self._handle_creator(stix_object['created_by_ref'])
+            )
         self._event_tags = set()
         self._add_markings_to_misp_event(misp_event, stix_object)
         if 'labels' in stix_object:

--- a/misp_stix_converter/tools/stix1_framing.py
+++ b/misp_stix_converter/tools/stix1_framing.py
@@ -119,6 +119,20 @@ SCHEMALOC_DICT = Mapping(
 )
 
 
+# A namespace reaches the STIX Package root element as
+# `xmlns:<org>="<namespace>"` without being escaped: a quote breaks out of the
+# attribute and declares namespace prefixes of its own, `<`, `>` and `&` make
+# the document not well-formed at all. What may get there is an absolute URI -
+# a scheme, then anything but the characters RFC 3986 excludes - with `&` and
+# the quotes taken out as well, since the value is written into markup as it
+# stands. `\s` is not enough to keep the control characters out - it misses
+# most of the C0 range, and a `\x08` in an attribute value is as invalid as
+# a `<`.
+_NAMESPACE_REGEX = re.compile(
+    r'[A-Za-z][A-Za-z0-9+.\-]*:[^\x00-\x20\x7f<>"\'&{}|\\^`]+'
+)
+
+
 def stix1_attributes_framing(namespace: str, orgname: str, return_format: str,
                              version: str) -> tuple:
     stix_package = _create_stix_package(orgname, version)
@@ -158,6 +172,7 @@ def _create_stix_package(
 
 
 def _handle_namespaces(namespace: str, orgname: str) -> tuple:
+    namespace = _validate_namespace(namespace)
     parsed_orgname = re.sub('[\W]+', '', orgname.replace(' ', '_'))
     namespaces = {namespace: parsed_orgname}
     namespaces.update(NS_DICT)
@@ -213,3 +228,21 @@ def _stix_xml_framing(stix_package: STIXPackage, namespaces: dict) -> tuple:
     footer = f"        </{s_related}>\n    </{s_related}s>\n{s_stix}"
     separator = f"        </{s_related}>\n        <{s_related}>\n"
     return header, separator, footer
+
+
+def _validate_namespace(namespace: str) -> str:
+    """Reject a namespace the XML framing cannot write as it stands.
+
+    :param namespace: the caller-supplied STIX 1 namespace
+    :return: the namespace itself, unchanged
+    :raises ValueError: if it does not match `_NAMESPACE_REGEX`
+    """
+    if not isinstance(namespace, str) or (
+            _NAMESPACE_REGEX.fullmatch(namespace) is None):
+        raise ValueError(
+            f'Invalid `namespace` parameter: {namespace!r} - the STIX 1 '
+            'namespace must be an absolute URI: a scheme, followed by `:`, '
+            'then characters a URI allows, minus the `& " \'` a namespace '
+            'declaration cannot carry unescaped.'
+        )
+    return namespace

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from pymisp import MISPAttribute
 from stix.core import STIXPackage
+from stix2patterns.validator import validate
+from unittest.mock import patch
 from uuid import uuid5, UUID
 from ._test_stix import PLANTED_TEMPLATE, TestSTIX
 
@@ -17,6 +19,23 @@ _DEFAULT_ORGNAME = 'MISP'
 _ATTRIBUTE_EXCLUSION_LIST = ('disable_correlation', 'to_ids')
 _MISP_OBJECT_EXCLUSION_LIST = (
     'distribution', 'sharing_group_id', 'template_uuid', 'template_version'
+)
+
+# Object relations reaching a pattern property-name position, paired with the
+# pattern segment each one must produce. An unquoted metacharacter segment
+# either breaks the pattern - the object is then reported instead of converted
+# - or, for a dotted relation, silently turns one property into a path. The
+# last pair is the benign control: a relation needing no quotes keeps the bare
+# segment it always had. Segments are spelled out rather than computed, so the
+# expectations do not restate the escaping they guard.
+_PATTERN_SEGMENT_RELATIONS = (
+    ("rel' OR file:name = 'x", r"'x_misp_rel\' OR file:name = \'x'"),
+    ('rel]', "'x_misp_rel]'"),
+    ('rel=1', "'x_misp_rel=1'"),
+    ('weird relation', "'x_misp_weird relation'"),
+    ("x'", r"'x_misp_x\''"),
+    ('a.b', "'x_misp_a.b'"),
+    ('rel-with-dash', 'x_misp_rel_with_dash')
 )
 
 
@@ -140,6 +159,28 @@ class TestSTIX2Export(TestSTIX):
     def _add_object_ids_flag(event):
         for misp_object in event['Object']:
             misp_object['Attribute'][0]['to_ids'] = True
+
+    def _add_metacharacter_relation(self, event, relation, value):
+        misp_object = event['Event']['Object'][0]
+        misp_object['Attribute'].append(
+            {
+                'type': 'text', 'object_relation': relation,
+                'value': value, 'to_ids': True
+            }
+        )
+        return misp_object
+
+    def _get_indicators(self):
+        return [
+            stix_object for stix_object in self.parser.stix_objects
+            if stix_object['type'] == 'indicator'
+        ]
+
+    def _object_errors(self, misp_object):
+        return [
+            error for errors in self.parser.errors.values()
+            for error in errors if misp_object['uuid'] in error
+        ]
 
     def _check_account_indicator_objects(self, misp_objects, patterns):
         gitlab_object, telegram_object = misp_objects
@@ -649,6 +690,56 @@ class TestSTIX2Export(TestSTIX):
         self.assertEqual(observed_data.modified, timestamp)
         self.assertEqual(observed_data.first_observed, timestamp)
         self.assertEqual(observed_data.last_observed, timestamp)
+
+    def _check_pattern_metacharacter_relations(self, event_getter, prefix):
+        value = 'metacharacter value'
+        for relation, segment in _PATTERN_SEGMENT_RELATIONS:
+            with self.subTest(object_relation=relation):
+                self.setUp()
+                event = event_getter()
+                self._add_object_ids_flag(event['Event'])
+                misp_object = self._add_metacharacter_relation(
+                    event, relation, value
+                )
+                self.parser.parse_misp_event(event['Event'])
+                self.assertEqual(self._object_errors(misp_object), [])
+                indicators = self._get_indicators()
+                self.assertEqual(len(indicators), 1)
+                self.assertIn(
+                    f"{prefix}:{segment} = '{value}'", indicators[0].pattern
+                )
+                self.assertTrue(
+                    validate(
+                        indicators[0].pattern,
+                        stix_version=self.parser._version
+                    )
+                )
+
+    def _check_unquotable_pattern_reported(self, event_getter, name):
+        # The quoting under test is what keeps a metacharacter relation out of
+        # the property-name position; with it neutralised the pattern fails to
+        # parse, and the object must then be *reported* and converted as a
+        # custom object rather than vanishing from the export.
+        event = event_getter()
+        self._add_object_ids_flag(event['Event'])
+        misp_object = self._add_metacharacter_relation(event, 'rel]', 'V')
+        with patch.object(
+                self.parser, '_quote_custom_property',
+                lambda relation: f'x_misp_{relation}'):
+            self.parser.parse_misp_event(event['Event'])
+        self.assertEqual(self._get_indicators(), [])
+        self.assertIn(
+            'x-misp-object',
+            [stix_object['type'] for stix_object in self.parser.stix_objects]
+        )
+        object_errors = self._object_errors(misp_object)
+        self.assertEqual(len(object_errors), 1)
+        self.assertTrue(
+            object_errors[0].startswith(
+                f"Error with the {name} object "
+                f"(uuid: {misp_object['uuid']}):"
+            )
+        )
 
     def _check_pe_and_section_observable(self, extension, pe, section):
         (_type, compilation, entrypoint, original, internal, desc, version,

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -19,6 +19,11 @@ from .update_documentation import (
 PATTERNS = ('_ATTRIBUTES', '_OBJECTS')
 UUIDv4 = UUID('76beed5f-7251-457e-8c2a-b45f7b589d3d')
 
+# A producer name asking for a second taxonomy entry inside the tag it is
+# written into, and what a MISP taxonomy tag value can carry of it.
+SMUGGLING_PRODUCER = 'Evil" tlp:clear misp-galaxy:producer="CIRCL'
+SANITISED_PRODUCER = 'Evil tlp:clear misp-galaxy:producer=CIRCL'
+
 _GALAXY_SUMMARY_MAPPING = {
     'attack-pattern': 'Attack Pattern (mitre-attack-pattern)',
     'course-of-action': 'Course of Action (mitre-course-of-action)',
@@ -228,6 +233,23 @@ class TestSTIX2Import(TestSTIX):
         self.assertEqual(
             self._reports_matching(warnings, 'Merged MISP record'), []
         )
+
+    def _check_unusable_producer_warning(self, producer, warnings):
+        """A producer name a taxonomy tag has nothing left to carry from."""
+        producer_warnings = self._reports_matching(
+            warnings, 'Unusable producer name'
+        )
+        self.assertEqual(len(producer_warnings), 1)
+        self.assertIn(producer, producer_warnings[0])
+
+    def _check_sanitised_producer_warning(self, producer, sanitised, warnings):
+        """A producer name is one taxonomy entry, whatever it carries."""
+        producer_warnings = self._reports_matching(
+            warnings, 'Sanitised producer name'
+        )
+        self.assertEqual(len(producer_warnings), 1)
+        for value in (producer, sanitised):
+            self.assertIn(value, producer_warnings[0])
 
     def _check_uuid_collision_warning(self, record_uuid, object_ids, warnings):
         """Two STIX ids, one MISP uuid: both records stay, the loss is named."""

--- a/tests/test_external_stix20_bundles.py
+++ b/tests/test_external_stix20_bundles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import TestSTIX2Bundles
+from ._test_stix_import import SMUGGLING_PRODUCER, TestSTIX2Bundles
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -2236,6 +2236,34 @@ class TestExternalSTIX20Bundles(TestSTIX2Bundles):
             deepcopy(cls.__identity), report, shadowed, indicator
         ]
         return dict_to_stix2(bundle, allow_custom=True)
+
+    @classmethod
+    def __smuggling_identity(cls):
+        """An Identity naming itself what a taxonomy tag cannot carry."""
+        identity = deepcopy(cls.__identity)
+        identity['name'] = SMUGGLING_PRODUCER
+        return identity
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_identity_name(cls):
+        bundle = deepcopy(cls.__bundle)
+        report = deepcopy(cls.__report)
+        indicator = deepcopy(cls.__indicator)
+        report.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [cls.__smuggling_identity(), report, indicator]
+        return dict_to_stix2(bundle)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_the_only_creator_name(cls):
+        """The same Identity, as the one creator a bundle credits itself to."""
+        bundle = deepcopy(cls.__bundle)
+        identity = cls.__smuggling_identity()
+        observables = deepcopy(_IP_ADDRESS_ATTRIBUTES)
+        for stix_object in observables:
+            if 'created_by_ref' in stix_object:
+                stix_object['created_by_ref'] = identity['id']
+        bundle['objects'] = [identity, *observables]
+        return dict_to_stix2(bundle)
 
     @classmethod
     def get_bundle_with_report_description(cls):

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -5,7 +5,8 @@ from .test_external_stix20_bundles import (
     TestExternalSTIX20Bundles, TLP_1_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX20
 from ._test_stix_import import (
-    TestExternalSTIX2Import, TestSTIX20Import, UUIDv4, MISP_org_uuid)
+    SANITISED_PRODUCER, SMUGGLING_PRODUCER, TestExternalSTIX2Import,
+    TestSTIX20Import, UUIDv4, MISP_org_uuid)
 from uuid import uuid5
 
 
@@ -651,6 +652,59 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             event.tags[0]['name'],
             f'misp-galaxy:producer="{self.parser.producer}"'
         )
+
+    def test_stix20_bundle_with_metacharacters_in_identity_name(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_metacharacters_in_identity_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        identity, _, _ = bundle.objects
+        # The Identity name asks for a second taxonomy entry inside the tag
+        # the producer is written into: what the event gets is one tag.
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            identity.name, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_metacharacters_in_the_only_creator_name(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_metacharacters_in_the_only_creator_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            SMUGGLING_PRODUCER, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_metacharacters_in_producer_parameter(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_without_report()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(producer=SMUGGLING_PRODUCER)
+        event = self.parser.misp_event
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            SMUGGLING_PRODUCER, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_unusable_producer_parameter(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_without_report()
+        self.parser.load_stix_bundle(bundle)
+        producer = '" "'
+        self.parser.parse_stix_bundle(producer=producer)
+        # Nothing a tag value can be made of: the event carries no producer
+        # tag at all, rather than an empty one - and never the provenance the
+        # bundle claims instead of the one the parameter asked for.
+        self.assertEqual(self.parser.misp_event.tags, [])
+        self._check_unusable_producer_warning(producer, self.parser.warnings)
 
     def test_stix21_bundle_with_report_description(self):
         bundle = TestExternalSTIX20Bundles.get_bundle_with_report_description()

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import TestSTIX2Bundles, UUIDv4
+from ._test_stix_import import SMUGGLING_PRODUCER, TestSTIX2Bundles, UUIDv4
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -3033,6 +3033,34 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
             deepcopy(cls.__grouping), indicator['id']
         )
         bundle['objects'] = [deepcopy(cls.__identity), grouping, indicator]
+        return dict_to_stix2(bundle)
+
+    @classmethod
+    def __smuggling_identity(cls):
+        """An Identity naming itself what a taxonomy tag cannot carry."""
+        identity = deepcopy(cls.__identity)
+        identity['name'] = SMUGGLING_PRODUCER
+        return identity
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_identity_name(cls):
+        bundle = deepcopy(cls.__bundle)
+        grouping = deepcopy(cls.__grouping)
+        indicator = deepcopy(cls.__indicator)
+        grouping.update(cls._populate_references(indicator['id']))
+        bundle['objects'] = [cls.__smuggling_identity(), grouping, indicator]
+        return dict_to_stix2(bundle)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_the_only_creator_name(cls):
+        """The same Identity, as the one creator a bundle credits itself to."""
+        bundle = deepcopy(cls.__bundle)
+        identity = cls.__smuggling_identity()
+        observables = deepcopy(_IP_ADDRESS_ATTRIBUTES)
+        for stix_object in observables:
+            if 'created_by_ref' in stix_object:
+                stix_object['created_by_ref'] = identity['id']
+        bundle['objects'] = [identity, *observables]
         return dict_to_stix2(bundle)
 
     @classmethod

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -5,7 +5,8 @@ from .test_external_stix21_bundles import (
     TestExternalSTIX21Bundles, TLP_1_0_EXPECTED_TAGS, TLP_2_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX21
 from ._test_stix_import import (
-    TestExternalSTIX2Import, TestSTIX21Import, UUIDv4, MISP_org_uuid)
+    SANITISED_PRODUCER, SMUGGLING_PRODUCER, TestExternalSTIX2Import,
+    TestSTIX21Import, UUIDv4, MISP_org_uuid)
 from uuid import uuid5
 
 _ACS_EXTENSION_ID = 'extension-definition--3a65884d-005a-4290-8335-cb2d778a83ce'
@@ -706,6 +707,59 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             event.tags[0]['name'],
             f'misp-galaxy:producer="{self.parser.producer}"'
         )
+
+    def test_stix21_bundle_with_metacharacters_in_identity_name(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_metacharacters_in_identity_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        identity, _, _ = bundle.objects
+        # The Identity name asks for a second taxonomy entry inside the tag
+        # the producer is written into: what the event gets is one tag.
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            identity.name, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_metacharacters_in_the_only_creator_name(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_metacharacters_in_the_only_creator_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            SMUGGLING_PRODUCER, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_metacharacters_in_producer_parameter(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_without_grouping()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(producer=SMUGGLING_PRODUCER)
+        event = self.parser.misp_event
+        self.assertEqual(
+            [tag.name for tag in event.tags],
+            [f'misp-galaxy:producer="{SANITISED_PRODUCER}"']
+        )
+        self._check_sanitised_producer_warning(
+            SMUGGLING_PRODUCER, SANITISED_PRODUCER, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_unusable_producer_parameter(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_without_grouping()
+        self.parser.load_stix_bundle(bundle)
+        producer = '" "'
+        self.parser.parse_stix_bundle(producer=producer)
+        # Nothing a tag value can be made of: the event carries no producer
+        # tag at all, rather than an empty one - and never the provenance the
+        # bundle claims instead of the one the parameter asked for.
+        self.assertEqual(self.parser.misp_event.tags, [])
+        self._check_unusable_producer_warning(producer, self.parser.warnings)
 
     def test_stix21_bundle_with_colliding_record_uuids(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_colliding_record_uuids()

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -4,10 +4,14 @@
 import re
 from base64 import b64encode
 from datetime import datetime, timezone
+from lxml import etree
 from misp_stix_converter import (InvalidMISPInputError, MISPtoSTIX1AttributesParser,
                                  MISPtoSTIX1EventsParser, misp_attribute_collection_to_stix1,
                                  misp_event_collection_to_stix1, misp_to_stix1)
+from misp_stix_converter.tools.stix1_framing import _handle_namespaces
 from pymisp import MISPEvent
+from shutil import copyfile
+from tempfile import TemporaryDirectory
 from uuid import uuid5, UUID
 from .test_events import *
 from .test_events import _INDICATOR_ATTRIBUTE
@@ -87,6 +91,113 @@ class TestSTIX1InputContract(TestSTIX):
             {'Attribute': [deepcopy(_INDICATOR_ATTRIBUTE)]}
         )
         self.assertIsNotNone(parser.stix_package)
+
+
+class TestSTIX1NamespaceParameter(TestSTIX):
+    # Every STIX 1 export entry validates the `namespace` parameter - the
+    # framing writes it into the root element as it stands - so a rejected
+    # value produces no output at all.
+    _BREAKOUT_NAMESPACE = 'http://evil.example" xmlns:evil="http://x'
+    _INVALID_NAMESPACES = (
+        _BREAKOUT_NAMESPACE,
+        'http://evil.example/<',
+        'http://evil.example/>',
+        'http://evil.example/?a=1&b=2',
+        'http://evil.example/\x08',  # a control character is as invalid as a `<`
+        'misp-project.org',  # no scheme: not a URI
+        'http://misp project.example',  # whitespace
+        '',
+        None
+    )
+    _DEFAULT_NAMESPACE = 'https://misp-project.org'
+    _VALID_NAMESPACE = 'http://custom.example/misp'
+
+    def setUp(self):
+        self._events_file = Path(__file__).parent / 'test_events_collection_1.json'
+        self._attributes_file = Path(__file__).parent / 'test_attributes_collection_1.json'
+
+    def tearDown(self):
+        # Framing sets the process-global mixbox id namespace: put the default
+        # back, so the exports a custom namespace ran here stay contained
+        _handle_namespaces(self._DEFAULT_NAMESPACE, 'MISP')
+
+    def _copy_input(self, tmp_dir, input_file):
+        filename = Path(tmp_dir) / input_file.name
+        copyfile(input_file, filename)
+        return filename
+
+    def _export_event(self, tmp_dir, **kwargs):
+        filename = self._copy_input(tmp_dir, self._events_file)
+        output_file = Path(f'{filename}.out')
+        self.assertEqual(
+            misp_to_stix1(filename, **kwargs),
+            {'success': 1, 'results': [output_file]}
+        )
+        return output_file
+
+    def test_invalid_namespaces_are_rejected(self):
+        for namespace in self._INVALID_NAMESPACES:
+            with TemporaryDirectory() as tmp_dir:
+                filename = self._copy_input(tmp_dir, self._events_file)
+                with self.assertRaises(ValueError) as context:
+                    misp_to_stix1(filename, namespace=namespace)
+                self.assertIn('namespace', str(context.exception))
+                # The parameter is rejected before any file is written
+                self.assertEqual(list(Path(tmp_dir).iterdir()), [filename])
+
+    def test_json_export_rejects_invalid_namespaces(self):
+        # The JSON framing never writes the namespace, but the value is still
+        # the invalid configuration the operator has to hear about
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._copy_input(tmp_dir, self._events_file)
+            with self.assertRaises(ValueError):
+                misp_to_stix1(
+                    filename, return_format='json',
+                    namespace=self._BREAKOUT_NAMESPACE
+                )
+            self.assertEqual(list(Path(tmp_dir).iterdir()), [filename])
+
+    def test_collection_exports_reject_invalid_namespaces(self):
+        for function, input_file in (
+                (misp_event_collection_to_stix1, self._events_file),
+                (misp_attribute_collection_to_stix1, self._attributes_file)):
+            with TemporaryDirectory() as tmp_dir:
+                filename = self._copy_input(tmp_dir, input_file)
+                with self.assertRaises(ValueError) as context:
+                    function(
+                        filename, filename, single_output=True,
+                        output_dir=tmp_dir,
+                        namespace=self._BREAKOUT_NAMESPACE
+                    )
+                self.assertIn('namespace', str(context.exception))
+                # Not even the temp fragments of the streamed path
+                self.assertEqual(list(Path(tmp_dir).iterdir()), [filename])
+
+    def test_valid_namespace_frames_the_root_element(self):
+        with TemporaryDirectory() as tmp_dir:
+            default_map = etree.parse(
+                str(self._export_event(tmp_dir))
+            ).getroot().nsmap
+        with TemporaryDirectory() as tmp_dir:
+            custom_map = etree.parse(
+                str(self._export_event(tmp_dir, namespace=self._VALID_NAMESPACE))
+            ).getroot().nsmap
+        # The organisation prefix is the only declaration that moved
+        self.assertEqual(default_map.pop('MISP'), self._DEFAULT_NAMESPACE)
+        self.assertEqual(custom_map.pop('MISP'), self._VALID_NAMESPACE)
+        self.assertEqual(default_map, custom_map)
+
+    def test_framing_helper_validates_the_namespace(self):
+        # The framing helpers are the choke point every XML export goes
+        # through, including callers using them directly
+        with self.assertRaises(ValueError):
+            _handle_namespaces(self._BREAKOUT_NAMESPACE, 'MISP')
+        self.assertEqual(
+            _handle_namespaces(self._VALID_NAMESPACE, 'MISP')[
+                self._VALID_NAMESPACE
+            ],
+            'MISP'
+        )
 
 
 class TestStix1Export(TestSTIX):

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -3988,6 +3988,11 @@ class TestSTIX20JSONObjectsExport(TestSTIX20ObjectsExport):
             stix=self.parser.stix_objects[2:]
         )
 
+    def test_event_with_cpe_asset_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_cpe_asset_object, 'software'
+        )
+
     def test_event_with_cpe_asset_observable_object(self):
         event = get_event_with_cpe_asset_object()
         self._test_event_with_cpe_asset_observable_object(event['Event'])
@@ -4137,13 +4142,20 @@ class TestSTIX20JSONObjectsExport(TestSTIX20ObjectsExport):
         )
         filename['value'] = "%USERPROFILE%\\Desktop\\O'Brien\\Styx-Stealer.pdb"
         self.parser.parse_misp_event(event['Event'])
-        indicators = [
-            stix_object for stix_object in self.parser.stix_objects
-            if stix_object['type'] == 'indicator'
-        ]
+        indicators = self._get_indicators()
         self.assertEqual(len(indicators), 1)
         escaped = filename['value'].replace('\\', '\\\\').replace("'", "\\'")
         self.assertIn(f"file:name = '{escaped}'", indicators[0].pattern)
+
+    def test_event_with_file_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_file_object, 'file'
+        )
+
+    def test_event_with_file_indicator_unquotable_pattern_reported(self):
+        self._check_unquotable_pattern_reported(
+            get_event_with_file_object, 'file'
+        )
 
     def test_event_with_file_object_invalid_hash_single_error(self):
         # A file object with a `to_ids` flag is built as both observed-data
@@ -4416,6 +4428,11 @@ class TestSTIX20JSONObjectsExport(TestSTIX20ObjectsExport):
         self._populate_documentation(
             misp_object=self.parser._misp_event.objects[0],
             stix=self.parser.stix_objects[2:]
+        )
+
+    def test_event_with_user_account_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_user_account_object, 'user-account'
         )
 
     def test_event_with_user_account_observable_object(self):

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -5021,6 +5021,11 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
             stix=self.parser.stix_objects[2:]
         )
 
+    def test_event_with_cpe_asset_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_cpe_asset_object, 'software'
+        )
+
     def test_event_with_cpe_asset_observable_object(self):
         event = get_event_with_cpe_asset_object()
         self._test_event_with_cpe_asset_observable_object(event['Event'])
@@ -5170,13 +5175,20 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
         )
         filename['value'] = "%USERPROFILE%\\Desktop\\O'Brien\\Styx-Stealer.pdb"
         self.parser.parse_misp_event(event['Event'])
-        indicators = [
-            stix_object for stix_object in self.parser.stix_objects
-            if stix_object['type'] == 'indicator'
-        ]
+        indicators = self._get_indicators()
         self.assertEqual(len(indicators), 1)
         escaped = filename['value'].replace('\\', '\\\\').replace("'", "\\'")
         self.assertIn(f"file:name = '{escaped}'", indicators[0].pattern)
+
+    def test_event_with_file_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_file_object, 'file'
+        )
+
+    def test_event_with_file_indicator_unquotable_pattern_reported(self):
+        self._check_unquotable_pattern_reported(
+            get_event_with_file_object, 'file'
+        )
 
     def test_event_with_file_object_invalid_hash_single_error(self):
         # A file object with a `to_ids` flag is built as both observed-data
@@ -5305,10 +5317,7 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
         )
         filename['value'] = "C:\\Users\\O'Brien\\shortcut.lnk"
         self.parser.parse_misp_event(event['Event'])
-        indicators = [
-            stix_object for stix_object in self.parser.stix_objects
-            if stix_object['type'] == 'indicator'
-        ]
+        indicators = self._get_indicators()
         self.assertEqual(len(indicators), 1)
         escaped = filename['value'].replace('\\', '\\\\').replace("'", "\\'")
         self.assertIn(f"file:name = '{escaped}'", indicators[0].pattern)
@@ -5481,6 +5490,11 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
         self._populate_documentation(
             misp_object=self.parser._misp_event.objects[0],
             stix=self.parser.stix_objects[2:]
+        )
+
+    def test_event_with_user_account_indicator_metacharacter_relation(self):
+        self._check_pattern_metacharacter_relations(
+            get_event_with_user_account_object, 'user-account'
         )
 
     def test_event_with_user_account_observable_object(self):

--- a/tests/test_stix2_patterning.py
+++ b/tests/test_stix2_patterning.py
@@ -3,6 +3,7 @@ import unittest
 from misp_stix_converter.misp2stix.misp_to_stix2 import MISPtoSTIX2Parser
 
 _qs = MISPtoSTIX2Parser._quote_segment
+_qcp = MISPtoSTIX2Parser._quote_custom_property
 _ev = MISPtoSTIX2Parser._escape_pattern_value
 
 
@@ -49,6 +50,30 @@ class TestQuoteSegment(unittest.TestCase):
 
     def test_embedded_backslash_escaped(self):
         self.assertEqual(_qs('a\\b'), r"'a\\b'")
+
+
+class TestQuoteCustomProperty(unittest.TestCase):
+
+    def test_hyphen_becomes_underscore_and_stays_bare(self):
+        self.assertEqual(_qcp('rel-with-dash'), 'x_misp_rel_with_dash')
+        self.assertEqual(_qcp('user-avatar'), 'x_misp_user_avatar')
+        self.assertEqual(_qcp('filename'), 'x_misp_filename')
+
+    def test_metacharacters_quoted_as_one_segment(self):
+        self.assertEqual(_qcp('a.b'), "'x_misp_a.b'")
+        self.assertEqual(_qcp('rel]'), "'x_misp_rel]'")
+        self.assertEqual(_qcp('rel=1'), "'x_misp_rel=1'")
+        self.assertEqual(_qcp('weird relation'), "'x_misp_weird relation'")
+
+    def test_apostrophe_escaped_inside_the_quoted_segment(self):
+        self.assertEqual(_qcp("x'"), r"'x_misp_x\''")
+        self.assertEqual(
+            _qcp("rel' OR file:name = 'x"),
+            r"'x_misp_rel\' OR file:name = \'x'"
+        )
+
+    def test_empty_relation_stays_bare(self):
+        self.assertEqual(_qcp(''), 'x_misp_')
 
 
 class TestCanonicalHashPatternName(unittest.TestCase):


### PR DESCRIPTION
## Description

Three places where a value was written straight into a string that has its own syntax, so a `"` in that value ended the field and let the rest of it become fields of its own: a STIX pattern property name, the `xmlns:<org>` declaration of a STIX 1 Package root element, and the `misp-galaxy:producer` tag an import puts on the event. Two on export, one on import.

## The three fixes

**#95 — `x_misp_<relation>` in a pattern.** A MISP object relation went into the property name as it stands, so a relation carrying `'`, `]`, `=` or a space produced a pattern the specification rejects: the Indicator was lost and the object was recorded as an error. The payload no error channel can catch is `a.b` — it stays valid and asserts an object path instead of one property name, quietly changing what the pattern means. The relation is quoted now, at the three helpers that put one in that position, so both cases keep the data the MISP object had.

**#96 — the `-n/--namespace` value in the root element.** The namespace the caller passes went verbatim into `xmlns:<org>="<namespace>"`: a value carrying a `"` declared namespace prefixes of its own, and one carrying `<`, `>`, `&` or a control character produced a file no XML parser accepts while the export reported success. Only an absolute URI reaches the framing now, checked at every STIX 1 entry before any output exists — so a rejected value leaves no file and no temp fragment — and again in the framing helpers every XML path goes through. The CLI help for `-n` and the README line say what is accepted.

**#93 — the value of the `misp-galaxy:producer` tag.** The producer name — the `producer` parameter, or the name of the Identity a bundle credits itself to — went into `misp-galaxy:producer="..."`, and a MISP tag has no escape sequence: a name carrying a `"` closed the value and had the rest of itself read as more taxonomy entries, so a bundle could tag the event it created with the `tlp:`, `PAP:` or `workflow:` values of its choosing. The `"` and the control characters no XML or CSV export can write are taken out now, and the change to the name is reported. A name nothing survives from leaves the event with no producer tag rather than an empty one, and an unusable `producer` parameter never falls back to the provenance the bundle claims for itself.

## Two conventions this settles

Quote where the syntax allows quoting, remove where it does not: a pattern property name has a quoted form, so the relation keeps every character it had; a MISP tag value has none, so what it cannot carry is removed and the loss is named.

Parameter checking differs by direction, on purpose: on export a bad parameter raises `ValueError` before any work, which is what the export already did elsewhere; on import it is recorded and falls back, which is what `distribution` and `sharing_group_id` already did and what the result dict exists to report.

## Tests

Each fix has its own coverage commit: the pattern payloads across 2.0 and 2.1 export, `TestSTIX1NamespaceParameter` over the invalid values plus the JSON path and both collection entries, and 8 producer tests across 2.0 and 2.1 import — the Identity name, the bundle's only creator, the parameter, and a parameter nothing can be made of. All were measured failing before their fix.
