### PR TITLE
Fix where a conversion writes its output, and how it writes it

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ options:
   -f, --file FILE [FILE ...]
                         Path to the file(s) to convert.
   -v, --version {1,2}   STIX major version - default is 2
-  -s, --single-event    Produce only one MISP event per STIX file(in case of multiple Report, Grouping or Incident objects).
+  -s, --single-event    Produce only one MISP event per STIX file, in case of multiple Report or Grouping objects. STIX 1 always produces one, whether this is set or not.
   -o, --output-name OUTPUT_NAME
                         Output file name - used in the case of a single input file or when the `single_event` argument is used.
   --output-dir OUTPUT_DIR

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ options:
   -s, --single-output   Produce only one result file (in case of multiple input file).
   -m, --in-memory       Store result in memory (in case of multiple result files) instead of storing it in tmp files.
   --output-dir OUTPUT_DIR
-                        Output path - used in the case of multiple input files when the `single_output` argument is not used.
+                        Output directory - default is the directory the input files come from. Created if it does not exist.
   -o, --output-name OUTPUT_NAME
                         Output file name - used in the case of a single input file or when the `single_output` argument is used.
 
@@ -174,7 +174,7 @@ options:
   -o, --output-name OUTPUT_NAME
                         Output file name - used in the case of a single input file or when the `single_event` argument is used.
   --output-dir OUTPUT_DIR
-                        Output path - used in the case of multiple input files when the `single_event` argument is not used.
+                        Output directory - default is the directory the input files come from. It has to exist when more than one MISP event comes out of a file.
   -d, --distribution {0,1,2,3,4}
                         Distribution level for the imported MISP content (default is 0) - 0: Your organisation only - 1: This community only - 2: Connected communities - 3: All communities - 4: Sharing Group
   -sg, --sharing-group SHARING_GROUP

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ options:
   -o, --output-name OUTPUT_NAME
                         Output file name - used in the case of a single input file or when the `single_event` argument is used.
   --output-dir OUTPUT_DIR
-                        Output directory - default is the directory the input files come from. It has to exist when more than one MISP event comes out of a file.
+                        Output directory - default is the directory the input files come from. Created if it does not exist.
   --overwrite           Replace an output file that already exists - without it a conversion writing onto an existing file fails and leaves it as it is.
   -d, --distribution {0,1,2,3,4}
                         Distribution level for the imported MISP content (default is 0) - 0: Your organisation only - 1: This community only - 2: Connected communities - 3: All communities - 4: Sharing Group

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Main feature:
 ##### Export parameters
 
 ```bash
-usage: misp_stix_converter export [-h] -f FILE [FILE ...] -v {1.1.1,1.2,2.0,2.1} [-s] [-m] [--output-dir OUTPUT_DIR] [-o OUTPUT_NAME] [--level {attribute,event}] [--format {json,xml}] [-n NAMESPACE] [-org ORG]
+usage: misp_stix_converter export [-h] -f FILE [FILE ...] -v {1.1.1,1.2,2.0,2.1} [-s] [-m] [--output-dir OUTPUT_DIR] [-o OUTPUT_NAME] [--overwrite] [--level {attribute,event}] [--format {json,xml}]
+                                  [-n NAMESPACE] [-org ORG]
 
 options:
   -h, --help            show this help message and exit
@@ -149,6 +150,7 @@ options:
                         Output directory - default is the directory the input files come from. Created if it does not exist.
   -o, --output-name OUTPUT_NAME
                         Output file name - used in the case of a single input file or when the `single_output` argument is used.
+  --overwrite           Replace an output file that already exists - without it a conversion writing onto an existing file fails and leaves it as it is.
 
 STIX 1 specific arguments:
   --level {attribute,event}
@@ -162,7 +164,8 @@ STIX 1 specific arguments:
 ##### Import parameters
 
 ```bash
-usage: misp_stix_converter import [-h] -f FILE [FILE ...] [-v {1,2}] [-s] [-o OUTPUT_NAME] [--output-dir OUTPUT_DIR] [-d {0,1,2,3,4}] [-sg SHARING_GROUP] [--galaxies-as-tags] [--no-force-galaxy-cluster]
+usage: misp_stix_converter import [-h] -f FILE [FILE ...] [-v {1,2}] [-s] [-o OUTPUT_NAME] [--output-dir OUTPUT_DIR] [--overwrite] [-d {0,1,2,3,4}] [-sg SHARING_GROUP] [--galaxies-as-tags]
+                                  [--no-force-galaxy-cluster]
                                   [--org-uuid ORG_UUID] [-cd {0,1,2,3,4}] [-csg CLUSTER_SHARING_GROUP] [-t TITLE] [-p PRODUCER] [-c CONFIG] [-u URL] [-a API_KEY] [--skip-ssl]
 
 options:
@@ -175,6 +178,7 @@ options:
                         Output file name - used in the case of a single input file or when the `single_event` argument is used.
   --output-dir OUTPUT_DIR
                         Output directory - default is the directory the input files come from. It has to exist when more than one MISP event comes out of a file.
+  --overwrite           Replace an output file that already exists - without it a conversion writing onto an existing file fails and leaves it as it is.
   -d, --distribution {0,1,2,3,4}
                         Distribution level for the imported MISP content (default is 0) - 0: Your organisation only - 1: This community only - 2: Connected communities - 3: All communities - 4: Sharing Group
   -sg, --sharing-group SHARING_GROUP

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -75,8 +75,8 @@ def main():
     )
     export_parser.add_argument(
         '--output-dir', type=Path,
-        help='Output path - used in the case of multiple input files when the '
-             '`single_output` argument is not used.'
+        help='Output directory - default is the directory the input files '
+             'come from. Created if it does not exist.'
     )
     export_parser.add_argument(
         '-o', '--output-name', type=Path,
@@ -127,8 +127,9 @@ def main():
     )
     import_parser.add_argument(
         '--output-dir', type=Path,
-        help='Output path - used in the case of multiple input files when the '
-             '`single_event` argument is not used.'
+        help='Output directory - default is the directory the input files '
+             'come from. It has to exist when more than one MISP event comes '
+             'out of a file.'
     )
     import_parser.add_argument(
         '--classification', choices=['internal', 'external'], default=None,
@@ -208,12 +209,9 @@ def main():
     import_parser.set_defaults(func=_stix_to_misp)
 
     stix_args = parser.parse_args()
-    single = (
-        stix_args.single_output if stix_args.feature == 'export'
-        else stix_args.single_event
-    )
-    if len(stix_args.file) > 1 and single and stix_args.output_dir is None:
-        stix_args.output_dir = Path(__file__).parents[1] / 'tmp'
+    # No default output location is set here: the conversion functions write
+    # next to their input files when the operator named none, so nothing lands
+    # in the installed package tree
     feature = 'MISP to STIX' if stix_args.feature == 'export' else 'STIX to MISP'
     try:
         traceback = stix_args.func(stix_args)

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -83,6 +83,12 @@ def main():
         help='Output file name - used in the case of a single input file or '
              'when the `single_output` argument is used.'
     )
+    export_parser.add_argument(
+        '--overwrite', action='store_true',
+        help='Replace an output file that already exists - without it a '
+             'conversion writing onto an existing file fails and leaves it '
+             'as it is.'
+    )
     # STIX 1 EXPORT SPECIFIC ARGUMENTS
     stix1_parser = export_parser.add_argument_group('STIX 1 specific arguments')
     stix1_parser.add_argument(
@@ -130,6 +136,12 @@ def main():
         help='Output directory - default is the directory the input files '
              'come from. It has to exist when more than one MISP event comes '
              'out of a file.'
+    )
+    import_parser.add_argument(
+        '--overwrite', action='store_true',
+        help='Replace an output file that already exists - without it a '
+             'conversion writing onto an existing file fails and leaves it '
+             'as it is.'
     )
     import_parser.add_argument(
         '--classification', choices=['internal', 'external'], default=None,

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -134,8 +134,7 @@ def main():
     import_parser.add_argument(
         '--output-dir', type=Path,
         help='Output directory - default is the directory the input files '
-             'come from. It has to exist when more than one MISP event comes '
-             'out of a file.'
+             'come from. Created if it does not exist.'
     )
     import_parser.add_argument(
         '--overwrite', action='store_true',

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -123,8 +123,9 @@ def main():
     )
     import_parser.add_argument(
         '-s', '--single-event', action='store_true',
-        help='Produce only one MISP event per STIX file'
-             '(in case of multiple Report, Grouping or Incident objects).'
+        help='Produce only one MISP event per STIX file, in case of '
+             'multiple Report or Grouping objects. STIX 1 always produces '
+             'one, whether this is set or not.'
     )
     import_parser.add_argument(
         '-o', '--output-name', type=Path,

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -570,8 +570,6 @@ def stix_1_to_misp(filename: _files_type,
         stix_parser.parse_stix_package(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    if output_dir is None:
-        output_dir = filename.parent
     if stix_parser.single_event:
         name = _check_filename(
             filename.parent, f'{filename.name}.out', output_dir, output_name
@@ -581,9 +579,10 @@ def stix_1_to_misp(filename: _files_type,
             overwrite=overwrite
         )
         return _generate_traceback(debug, stix_parser, name)
+    directory = _check_output_dir(filename.parent, output_dir)
     output_names = []
     for misp_event in stix_parser.misp_events:
-        output = output_dir / f'{filename.name}.{misp_event.uuid}.misp.out'
+        output = directory / f'{filename.name}.{misp_event.uuid}.misp.out'
         _write_output(
             output, misp_event.to_json(indent=4), overwrite=overwrite
         )
@@ -678,8 +677,6 @@ def stix_2_to_misp(filename: _files_type,
         stix_parser.parse_stix_bundle(**args)
     except Exception as error:
         return {'errors': [f'{filename} -  {error.__str__()}']}
-    if output_dir is None:
-        output_dir = filename.parent
     if stix_parser.single_event:
         name = _check_filename(
             filename.parent, f'{filename.name}.out', output_dir, output_name
@@ -689,9 +686,10 @@ def stix_2_to_misp(filename: _files_type,
             overwrite=overwrite
         )
         return _generate_traceback(debug, stix_parser, name)
+    directory = _check_output_dir(filename.parent, output_dir)
     output_names = []
     for misp_event in stix_parser.misp_events:
-        output = output_dir / f'{filename.name}.{misp_event.uuid}.misp.out'
+        output = directory / f'{filename.name}.{misp_event.uuid}.misp.out'
         _write_output(
             output, misp_event.to_json(indent=4), overwrite=overwrite
         )
@@ -915,12 +913,17 @@ def _process_stix_to_misp_instance(misp: PyMISP, args) -> dict:
 #                              UTILITY FUNCTIONS.                              #
 ################################################################################
 
+def _as_path(location: _files_type) -> Path:
+    # Every funnel takes the `Path` or the `str` the parameters document, so
+    # none of them can leave a `str` for a caller to join a name onto
+    return location if isinstance(location, Path) else Path(location).resolve()
+
+
 def _check_filename(default_dir: Path, default_name: str,
                     output_dir: _files_type, output_name: _files_type) -> Path:
     if output_name is None:
         return _check_output(default_dir, default_name, output_dir)
-    if not isinstance(output_name, Path):
-        output_name = Path(output_name).resolve()
+    output_name = _as_path(output_name)
     if output_name.is_dir():
         return output_name / default_name
     return _ensure_directory(output_name.parent) / output_name.name
@@ -930,11 +933,22 @@ def _check_output(
         default_dir: Path, default_name: str, output_dir: _files_type) -> Path:
     if output_dir is None:
         return default_dir / default_name
-    if not isinstance(output_dir, Path):
-        output_dir = Path(output_dir).resolve()
+    output_dir = _as_path(output_dir)
     if output_dir.is_file():
         return output_dir
     return _ensure_directory(output_dir) / default_name
+
+
+def _check_output_dir(default_dir: Path, output_dir: _files_type) -> Path:
+    # Where the import entries write one file per MISP event. Unlike
+    # `_check_output` the destination can only be a directory - a single file
+    # cannot hold several events - so a location the caller named is created
+    # rather than read as an output file, and how many events a document
+    # yields is its own shape rather than a caller parameter, so it cannot
+    # decide whether a documented parameter type works
+    if output_dir is None:
+        return default_dir
+    return _ensure_directory(_as_path(output_dir))
 
 
 def _default_output_dir(*input_files: _files_type) -> Path:

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -2,7 +2,6 @@
 #!/usr/bin/env python3
 
 import json
-import os
 import urllib3
 from .misp2stix.misp_to_stix1 import (
     MISPtoSTIX1AttributesParser, MISPtoSTIX1EventsParser)
@@ -25,6 +24,7 @@ from pymisp import MISPEvent, PyMISP, PyMISPError
 from stix2.base import STIXJSONEncoder
 from stix2.v20 import Bundle as Bundle_v20
 from stix2.v21 import Bundle as Bundle_v21
+from tempfile import TemporaryDirectory
 from typing import List, Optional, Union
 from uuid import uuid4
 
@@ -177,43 +177,45 @@ def misp_attribute_collection_to_stix1(
                 traceback.update(_generate_traceback(debug, parser, name))
             return traceback
         handler = AttributeCollectionHandler(return_format)
-        tmp_path = name.parent
-        for filename in input_files:
-            try:
-                parser.parse_json_file(filename)
-                package = parser.stix_package
-                for feature in _STIX1_features:
-                    values = getattr(package, feature)
-                    if values:
-                        content = globals()[f'write_{feature}'](values, return_format)
-                        if not content.strip():
-                            continue
-                        filename = handler.get_filename(feature)
-                        if filename is None:
-                            filename = handler.set_feature(feature, uuid4())
-                            with open(tmp_path / filename, 'wt', encoding='utf-8') as f:
-                                f.write(f'{handler.header(feature)}{content}')
-                            continue
-                        with open(tmp_path / filename, 'at', encoding='utf-8') as f:
-                            f.write(content)
-            except Exception as exception:
-                traceback['fails'].append(f'{filename} - {exception.__str__()}')
-        if any(filename not in traceback.get('fails', []) for filename in input_files):
-            header, _, footer = stix1_attributes_framing(
-                namespace, org, return_format, stix_package.version
-            )
-            with open(name, 'wt', encoding='utf-8') as result:
-                result.write(header)
-                for feature, filename in handler.features.items():
-                    with open(tmp_path / filename, 'rt', encoding='utf-8') as current:
-                        content = current.read() if return_format == 'xml' else current.read()[:-2]
-                    current_footer = handler.footer(feature)
-                    if return_format == 'json' and feature == list(handler.features)[-1]:
-                        current_footer = current_footer[:-2]
-                    result.write(f'{content}{current_footer}')
-                    os.remove(tmp_path / filename)
-                result.write(footer)
-            traceback.update(_generate_traceback(debug, parser, name))
+        # The per-feature fragments hold converted content: they live in a
+        # scratch directory of their own, removed however the assembly ends
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            for filename in input_files:
+                try:
+                    parser.parse_json_file(filename)
+                    package = parser.stix_package
+                    for feature in _STIX1_features:
+                        values = getattr(package, feature)
+                        if values:
+                            content = globals()[f'write_{feature}'](values, return_format)
+                            if not content.strip():
+                                continue
+                            fragment = handler.get_filename(feature)
+                            if fragment is None:
+                                fragment = handler.set_feature(feature, uuid4())
+                                with open(tmp_path / fragment, 'wt', encoding='utf-8') as f:
+                                    f.write(f'{handler.header(feature)}{content}')
+                                continue
+                            with open(tmp_path / fragment, 'at', encoding='utf-8') as f:
+                                f.write(content)
+                except Exception as exception:
+                    traceback['fails'].append(f'{filename} - {exception.__str__()}')
+            if any(filename not in traceback.get('fails', []) for filename in input_files):
+                header, _, footer = stix1_attributes_framing(
+                    namespace, org, return_format, stix_package.version
+                )
+                with open(name, 'wt', encoding='utf-8') as result:
+                    result.write(header)
+                    for feature, fragment in handler.features.items():
+                        with open(tmp_path / fragment, 'rt', encoding='utf-8') as current:
+                            content = current.read() if return_format == 'xml' else current.read()[:-2]
+                        current_footer = handler.footer(feature)
+                        if return_format == 'json' and feature == list(handler.features)[-1]:
+                            current_footer = current_footer[:-2]
+                        result.write(f'{content}{current_footer}')
+                    result.write(footer)
+                traceback.update(_generate_traceback(debug, parser, name))
         return traceback
     output_names = []
     for filename in input_files:

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -8,6 +8,8 @@ from .misp2stix.misp_to_stix1 import (
 from .misp2stix.misp_to_stix20 import MISPtoSTIX20Parser
 from .misp2stix.misp_to_stix21 import MISPtoSTIX21Parser
 from .stix2misp.importparser import MISP_org_uuid
+from .tools.output_writing_helpers import (
+    _open_output, _private_opener, _write_output)
 from .tools.stix1_framing import (
     stix1_attributes_framing, stix1_framing, _create_stix_package,
     _validate_namespace)
@@ -118,7 +120,8 @@ def misp_attribute_collection_to_stix1(
         in_memory: Optional[bool] = False,
         single_output: Optional[bool] = False,
         output_dir: Optional[_files_type] = None,
-        output_name: Optional[_files_type] = None) -> dict:
+        output_name: Optional[_files_type] = None,
+        overwrite: Optional[bool] = False) -> dict:
     if return_format not in _STIX1_valid_formats:
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
@@ -135,7 +138,8 @@ def misp_attribute_collection_to_stix1(
                 filename.parent, f'{filename.name}.out', output_dir, output_name
             )
             _write_raw_stix(
-                parser.stix_package, name, namespace, org, return_format
+                parser.stix_package, name, namespace, org, return_format,
+                overwrite
             )
             return _generate_traceback(debug, parser, name)
         except Exception as exception:
@@ -172,7 +176,8 @@ def misp_attribute_collection_to_stix1(
                     traceback['fails'].append(f'{filename} - {exception.__str__()}')
             if any(filename not in traceback.get('fails', []) for filename in input_files):
                 _write_raw_stix(
-                    stix_package, name, namespace, org, return_format
+                    stix_package, name, namespace, org, return_format,
+                    overwrite
                 )
                 traceback.update(_generate_traceback(debug, parser, name))
             return traceback
@@ -194,10 +199,16 @@ def misp_attribute_collection_to_stix1(
                             fragment = handler.get_filename(feature)
                             if fragment is None:
                                 fragment = handler.set_feature(feature, uuid4())
-                                with open(tmp_path / fragment, 'wt', encoding='utf-8') as f:
+                                with open(
+                                        tmp_path / fragment, 'wt',
+                                        encoding='utf-8',
+                                        opener=_private_opener) as f:
                                     f.write(f'{handler.header(feature)}{content}')
                                 continue
-                            with open(tmp_path / fragment, 'at', encoding='utf-8') as f:
+                            with open(
+                                    tmp_path / fragment, 'at',
+                                    encoding='utf-8',
+                                    opener=_private_opener) as f:
                                 f.write(content)
                 except Exception as exception:
                     traceback['fails'].append(f'{filename} - {exception.__str__()}')
@@ -205,16 +216,16 @@ def misp_attribute_collection_to_stix1(
                 header, _, footer = stix1_attributes_framing(
                     namespace, org, return_format, stix_package.version
                 )
-                with open(name, 'wt', encoding='utf-8') as result:
-                    result.write(header)
+                with _open_output(name, overwrite=overwrite) as output:
+                    output.write(header)
                     for feature, fragment in handler.features.items():
                         with open(tmp_path / fragment, 'rt', encoding='utf-8') as current:
                             content = current.read() if return_format == 'xml' else current.read()[:-2]
                         current_footer = handler.footer(feature)
                         if return_format == 'json' and feature == list(handler.features)[-1]:
                             current_footer = current_footer[:-2]
-                        result.write(f'{content}{current_footer}')
-                    result.write(footer)
+                        output.write(f'{content}{current_footer}')
+                    output.write(footer)
                 traceback.update(_generate_traceback(debug, parser, name))
         return traceback
     output_names = []
@@ -227,7 +238,8 @@ def misp_attribute_collection_to_stix1(
                 filename.parent, f'{filename.name}.out', output_dir
             )
             _write_raw_stix(
-                parser.stix_package, name, namespace, org, return_format
+                parser.stix_package, name, namespace, org, return_format,
+                overwrite
             )
             output_names.append(name)
         except Exception as exception:
@@ -246,13 +258,14 @@ def misp_event_collection_to_stix1(
         in_memory: Optional[bool] = False,
         single_output: Optional[bool] = False,
         output_dir: Optional[_files_type] = None,
-        output_name: Optional[_files_type] = None) -> dict:
+        output_name: Optional[_files_type] = None,
+        overwrite: Optional[bool] = False) -> dict:
     if return_format not in _STIX1_valid_formats:
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
     namespace = _validate_namespace(namespace)
-    _write_args = (namespace, org, return_format)
+    _write_args = (namespace, org, return_format, overwrite)
     parser = MISPtoSTIX1EventsParser(org, version)
     if len(input_files) == 1:
         filename = input_files[0]
@@ -295,29 +308,40 @@ def misp_event_collection_to_stix1(
         header, separator, footer = stix1_framing(
             namespace, org, return_format, stix_package.version
         )
-        filename = input_files[0]
-        try:
-            if not isinstance(filename, Path):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            content = write_events(parser.stix_package, return_format)
-            with open(name, 'wt', encoding='utf-8') as f:
-                f.write(f'{header}{content}')
-        except Exception as exception:
-            traceback['fails'].append(filename)
-        for filename in input_files[1:]:
+        written = False
+        with _open_output(name, overwrite=overwrite) as output:
+            filename = input_files[0]
             try:
                 if not isinstance(filename, Path):
                     filename = Path(filename).resolve()
                 parser.parse_json_file(filename)
                 content = write_events(parser.stix_package, return_format)
-                with open(name, 'at', encoding='utf-8') as f:
-                    f.write(f'{separator}{content}')
+                output.write(f'{header}{content}')
+                written = True
             except Exception as exception:
-                traceback['fails'].append(f'{filename} - {exception.__str__()}')
-        with open(name, 'at', encoding='utf-8') as f:
-            f.write(footer)
-        traceback.update(_generate_traceback(debug, parser, name))
+                traceback['fails'].append(filename)
+            for filename in input_files[1:]:
+                try:
+                    if not isinstance(filename, Path):
+                        filename = Path(filename).resolve()
+                    parser.parse_json_file(filename)
+                    content = write_events(parser.stix_package, return_format)
+                    output.write(
+                        f'{separator}{content}' if written else content
+                    )
+                    written = True
+                except Exception as exception:
+                    traceback['fails'].append(
+                        f'{filename} - {exception.__str__()}'
+                    )
+            if written:
+                output.write(footer)
+            else:
+                # No input file converted: the destination keeps whatever it
+                # held rather than taking a header and a footer alone
+                output.discard()
+        if written:
+            traceback.update(_generate_traceback(debug, parser, name))
         return traceback
     output_names = []
     for filename in input_files:
@@ -343,7 +367,8 @@ def misp_collection_to_stix2(
         in_memory: Optional[bool] = False,
         single_output: Optional[bool] = False,
         output_dir: Optional[_files_type] = None,
-        output_name: Optional[_files_type] = None) -> dict:
+        output_name: Optional[_files_type] = None,
+        overwrite: Optional[bool] = False) -> dict:
     if version not in _STIX2_valid_versions:
         version = _STIX2_default_version
     parser = MISPtoSTIX21Parser() if version == '2.1' else MISPtoSTIX20Parser()
@@ -356,8 +381,9 @@ def misp_collection_to_stix2(
             name = _check_filename(
                 filename.parent, f'{filename.name}.out', output_dir, output_name
             )
-            with open(name, 'wt', encoding='utf-8') as f:
-                f.write(parser.bundle.serialize(indent=4))
+            _write_output(
+                name, parser.bundle.serialize(indent=4), overwrite=overwrite
+            )
             return _generate_traceback(debug, parser, name)
         except Exception as exception:
             return {'fails': [f'{filename} - {exception.__str__()}']}
@@ -379,8 +405,9 @@ def misp_collection_to_stix2(
                     f"{version.replace('.', '')}.json",
                     output_dir, output_name
                 )
-                with open(name, 'wt', encoding='utf-8') as f:
-                    f.write(bundle.serialize(indent=4))
+                _write_output(
+                    name, bundle.serialize(indent=4), overwrite=overwrite
+                )
                 traceback.update(_generate_traceback(debug, parser, name))
             return traceback
         bundle = Bundle_v21() if version == '2.1' else Bundle_v20()
@@ -389,42 +416,47 @@ def misp_collection_to_stix2(
             f"{bundle.id.split('--')[1]}.stix{version.replace('.', '')}.json",
             output_dir, output_name
         )
-        with open(name, 'wt', encoding='utf-8') as f:
-            f.write(f'{bundle.serialize(indent=4)[:-2]},\n    "objects": [\n')
-        written = False
-        try:
-            filename = input_files[0]
-            if not isinstance(filename, Path):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            stix_objects = json.dumps(
-                [parser.fetch_stix_objects], cls=STIXJSONEncoder, indent=4
+        with _open_output(name, overwrite=overwrite) as output:
+            output.write(
+                f'{bundle.serialize(indent=4)[:-2]},\n    "objects": [\n'
             )
-            with open(name, 'at', encoding='utf-8') as f:
-                f.write(stix_objects[8:-8])
-            written = True
-        except Exception as exception:
-            traceback['fails'].append(f'{filename} - {exception.__str__()}')
-        for filename in input_files[1:]:
+            written = False
             try:
+                filename = input_files[0]
                 if not isinstance(filename, Path):
                     filename = Path(filename).resolve()
                 parser.parse_json_file(filename)
                 stix_objects = json.dumps(
                     [parser.fetch_stix_objects], cls=STIXJSONEncoder, indent=4
                 )
-                separator = ',\n' if written else ''
-                with open(name, 'at', encoding='utf-8') as f:
-                    f.write(f"{separator}{stix_objects[8:-8]}")
+                output.write(stix_objects[8:-8])
                 written = True
             except Exception as exception:
                 traceback['fails'].append(f'{filename} - {exception.__str__()}')
+            for filename in input_files[1:]:
+                try:
+                    if not isinstance(filename, Path):
+                        filename = Path(filename).resolve()
+                    parser.parse_json_file(filename)
+                    stix_objects = json.dumps(
+                        [parser.fetch_stix_objects], cls=STIXJSONEncoder,
+                        indent=4
+                    )
+                    separator = ',\n' if written else ''
+                    output.write(f"{separator}{stix_objects[8:-8]}")
+                    written = True
+                except Exception as exception:
+                    traceback['fails'].append(
+                        f'{filename} - {exception.__str__()}'
+                    )
+            if written:
+                output.write('\n    ]\n}')
+            else:
+                # Nothing came out of any input file: the destination keeps
+                # whatever it held rather than taking a bundle header alone
+                output.discard()
         if written:
-            with open(name, 'at', encoding='utf-8') as f:
-                f.write('\n    ]\n}')
             traceback.update(_generate_traceback(debug, parser, name))
-        else:
-            name.unlink(missing_ok=True)
         return traceback
     output_names = []
     for filename in input_files:
@@ -435,8 +467,9 @@ def misp_collection_to_stix2(
             name = _check_output(
                 filename.parent, f'{filename.name}.out', output_dir
             )
-            with open(name, 'wt', encoding='utf-8') as f:
-                f.write(parser.bundle.serialize(indent=4))
+            _write_output(
+                name, parser.bundle.serialize(indent=4), overwrite=overwrite
+            )
             output_names.append(name)
         except Exception as exception:
             traceback['fails'].append(f'{filename} - {exception.__str__()}')
@@ -452,7 +485,8 @@ def misp_to_stix1(
         org: Optional[str] = _default_org,
         version: Optional[str] = _STIX1_default_version,
         output_dir: Optional[_files_type] = None,
-        output_name: Optional[_files_type] = None) -> dict:
+        output_name: Optional[_files_type] = None,
+        overwrite: Optional[bool] = False) -> dict:
     if return_format not in _STIX1_valid_formats:
         return_format = _STIX1_default_format
     if version not in _STIX1_valid_versions:
@@ -467,7 +501,7 @@ def misp_to_stix1(
             filename.parent, f'{filename.name}.out', output_dir, output_name
         )
         _write_raw_stix(
-            parser.stix_package, name, namespace, org, return_format
+            parser.stix_package, name, namespace, org, return_format, overwrite
         )
     except Exception as exception:
         return {'fails': [f'{filename} - {exception.__str__()}']}
@@ -477,7 +511,8 @@ def misp_to_stix1(
 def misp_to_stix2(filename: _files_type, debug: Optional[bool] = False,
                   version: Optional[str] = _STIX2_default_version,
                   output_dir: Optional[_files_type] = None,
-                  output_name: Optional[_files_type] = None) -> dict:
+                  output_name: Optional[_files_type] = None,
+                  overwrite: Optional[bool] = False) -> dict:
     if version not in _STIX2_valid_versions:
         version = _STIX2_default_version
     parser = MISPtoSTIX21Parser() if version == '2.1' else MISPtoSTIX20Parser()
@@ -488,8 +523,10 @@ def misp_to_stix2(filename: _files_type, debug: Optional[bool] = False,
         name = _check_filename(
             filename.parent, f'{filename.name}.out', output_dir, output_name
         )
-        with open(name, 'wt', encoding='utf-8') as f:
-            f.write(json.dumps(parser.bundle, cls=STIXJSONEncoder, indent=4))
+        _write_output(
+            name, json.dumps(parser.bundle, cls=STIXJSONEncoder, indent=4),
+            overwrite=overwrite
+        )
     except Exception as exception:
         return {'fails': [f'{filename} - {exception.__str__()}']}
     return _generate_traceback(debug, parser, name)
@@ -510,6 +547,7 @@ def stix_1_to_misp(filename: _files_type,
                    organisation_uuid: Optional[str] = MISP_org_uuid,
                    output_dir: Optional[_files_type]=None,
                    output_name: Optional[_files_type]=None,
+                   overwrite: Optional[bool] = False,
                    producer: Optional[str] = None,
                    sharing_group_id: Optional[int] = None,
                    single_event: Optional[bool] = False,
@@ -538,14 +576,17 @@ def stix_1_to_misp(filename: _files_type,
         name = _check_filename(
             filename.parent, f'{filename.name}.out', output_dir, output_name
         )
-        with open(name, 'wt', encoding='utf-8') as f:
-            f.write(stix_parser.misp_event.to_json(indent=4))
+        _write_output(
+            name, stix_parser.misp_event.to_json(indent=4),
+            overwrite=overwrite
+        )
         return _generate_traceback(debug, stix_parser, name)
     output_names = []
     for misp_event in stix_parser.misp_events:
         output = output_dir / f'{filename.name}.{misp_event.uuid}.misp.out'
-        with open(output, 'wt', encoding='utf-8') as f:
-            f.write(misp_event.to_json(indent=4))
+        _write_output(
+            output, misp_event.to_json(indent=4), overwrite=overwrite
+        )
         output_names.append(output)
     return _generate_traceback(debug, stix_parser, *output_names)
 
@@ -614,6 +655,7 @@ def stix_2_to_misp(filename: _files_type,
                    organisation_uuid: Optional[str] = MISP_org_uuid,
                    output_dir: Optional[_files_type]=None,
                    output_name: Optional[_files_type]=None,
+                   overwrite: Optional[bool] = False,
                    producer: Optional[str] = None,
                    sharing_group_id: Optional[int] = None,
                    single_event: Optional[bool] = False,
@@ -642,14 +684,17 @@ def stix_2_to_misp(filename: _files_type,
         name = _check_filename(
             filename.parent, f'{filename.name}.out', output_dir, output_name
         )
-        with open(name, 'wt', encoding='utf-8') as f:
-            f.write(stix_parser.misp_event.to_json(indent=4))
+        _write_output(
+            name, stix_parser.misp_event.to_json(indent=4),
+            overwrite=overwrite
+        )
         return _generate_traceback(debug, stix_parser, name)
     output_names = []
     for misp_event in stix_parser.misp_events:
         output = output_dir / f'{filename.name}.{misp_event.uuid}.misp.out'
-        with open(output, 'wt', encoding='utf-8') as f:
-            f.write(misp_event.to_json(indent=4))
+        _write_output(
+            output, misp_event.to_json(indent=4), overwrite=overwrite
+        )
         output_names.append(output)
     return _generate_traceback(debug, stix_parser, *output_names)
 
@@ -721,7 +766,8 @@ def _misp_to_stix(stix_args):
             'debug': stix_args.debug, 'return_format': stix_args.format,
             'version': stix_args.version, 'namespace': stix_args.namespace,
             'org': stix_args.org, 'output_dir': stix_args.output_dir,
-            'output_name': stix_args.output_name
+            'output_name': stix_args.output_name,
+            'overwrite': stix_args.overwrite
         }
         if stix_args.level == 'attribute':
             return misp_attribute_collection_to_stix1(
@@ -734,7 +780,8 @@ def _misp_to_stix(stix_args):
         )
     stix2_args = {
         'debug': stix_args.debug, 'output_dir': stix_args.output_dir,
-        'output_name': stix_args.output_name, 'version': stix_args.version
+        'output_name': stix_args.output_name,
+        'overwrite': stix_args.overwrite, 'version': stix_args.version
     }
     if len(stix_args.file) == 1:
         return misp_to_stix2(stix_args.file[0], **stix2_args)
@@ -783,6 +830,7 @@ def _process_stix_to_misp_files(args) -> dict:
         'output_dir': args.output_dir,
         'organisation_uuid': args.org_uuid,
         'output_name': args.output_name,
+        'overwrite': args.overwrite,
         'producer': args.producer,
         'sharing_group_id': args.sharing_group,
         'single_event': args.single_event,

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -144,8 +144,8 @@ def misp_attribute_collection_to_stix1(
     if single_output:
         stix_package = _create_stix_package(org, version)
         name = _check_filename(
-            Path(__file__).resolve().parent / 'tmp',
-            f'{stix_package.id_}.stix1.{return_format}',
+            _default_output_dir(*input_files),
+            _default_stix1_name(stix_package, return_format),
             output_dir, output_name
         )
         if in_memory:
@@ -271,8 +271,8 @@ def misp_event_collection_to_stix1(
     if single_output:
         stix_package = _create_stix_package(org, version, header=False)
         name = _check_filename(
-            Path(__file__).resolve().parent / 'tmp',
-            f'{stix_package.id_}.stix1.{return_format}',
+            _default_output_dir(*input_files),
+            _default_stix1_name(stix_package, return_format),
             output_dir, output_name
         )
         if in_memory:
@@ -374,7 +374,7 @@ def misp_collection_to_stix2(
             if any(filename not in traceback.get('fails', []) for filename in input_files):
                 bundle = parser.bundle
                 name = _check_filename(
-                    Path(__file__).resolve().parents[1] / 'tmp',
+                    _default_output_dir(*input_files),
                     f"{bundle.id.split('--')[1]}.stix"
                     f"{version.replace('.', '')}.json",
                     output_dir, output_name
@@ -385,7 +385,7 @@ def misp_collection_to_stix2(
             return traceback
         bundle = Bundle_v21() if version == '2.1' else Bundle_v20()
         name = _check_filename(
-            Path(__file__).resolve().parents[1] / 'tmp',
+            _default_output_dir(*input_files),
             f"{bundle.id.split('--')[1]}.stix{version.replace('.', '')}.json",
             output_dir, output_name
         )
@@ -875,7 +875,7 @@ def _check_filename(default_dir: Path, default_name: str,
         output_name = Path(output_name).resolve()
     if output_name.is_dir():
         return output_name / default_name
-    return output_name
+    return _ensure_directory(output_name.parent) / output_name.name
 
 
 def _check_output(
@@ -886,7 +886,32 @@ def _check_output(
         output_dir = Path(output_dir).resolve()
     if output_dir.is_file():
         return output_dir
-    return output_dir / default_name
+    return _ensure_directory(output_dir) / default_name
+
+
+def _default_output_dir(*input_files: _files_type) -> Path:
+    # Where a collection export writes when the caller named no location: the
+    # directory the input files come from, like the single input entries do.
+    # Never the installed package tree - a library has no business using its
+    # own installation directory as an output or scratch area
+    filename = input_files[0]
+    if not isinstance(filename, Path):
+        filename = Path(filename)
+    return filename.resolve().parent
+
+
+def _default_stix1_name(stix_package, return_format: str) -> str:
+    # `<orgname>:STIXPackage-<uuid>` is the package id, not a filename: the
+    # organisation prefix goes with the `:` separator, which Windows and SMB
+    # shares reject
+    return f"{stix_package.id_.split(':')[-1]}.stix1.{return_format}"
+
+
+def _ensure_directory(directory: Path) -> Path:
+    # An output location the caller named is a request: a directory that does
+    # not exist yet is created rather than failing at write time
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
 
 
 _CLASSIFICATION_VALUES = ('internal', 'external')

--- a/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
@@ -27,6 +27,10 @@ class InternalSTIX1toMISPParser(STIX1toMISPParser):
 
     def parse_stix_package(self, **kwargs):
         self._set_parameters(**kwargs)
+        # Every related package is merged into one MISP event - the titles,
+        # dates and timestamps of all of them - so this parser has no per
+        # event mode to ask for, like the External one it sits next to
+        self._set_single_event(True)
         self._set_misp_event(MISPEvent())
         for item in self.stix_package.related_packages.related_package:
             package = item.item

--- a/misp_stix_converter/tools/output_writing_helpers.py
+++ b/misp_stix_converter/tools/output_writing_helpers.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import mkstemp
+from typing import IO, Iterator
+
+# What a conversion writes holds the content of the MISP events or STIX
+# documents it converted - TLP:AMBER and TLP:RED material, attachments
+# included: an output file is readable by the user who produced it and by
+# nobody else, whatever the process umask would have allowed
+_OUTPUT_FILE_MODE = 0o600
+
+
+class _Output:
+    """The scratch file a conversion writes, before it becomes the output.
+
+    `write` takes the content in as many steps as the conversion needs;
+    `discard` says the conversion ended up with nothing worth keeping, so the
+    destination is left as it was.
+    """
+
+    def __init__(self, stream: IO):
+        self._stream = stream
+        self._discarded = False
+
+    @property
+    def discarded(self) -> bool:
+        return self._discarded
+
+    def discard(self):
+        self._discarded = True
+
+    def write(self, content: bytes | str) -> int:
+        return self._stream.write(content)
+
+
+@contextmanager
+def _open_output(
+        destination: Path | str, *, overwrite: bool = False,
+        binary: bool = False) -> Iterator[_Output]:
+    """Write the destination in one step, or not at all.
+
+    Content goes to a scratch file in the destination's own directory - a
+    replace is atomic within a single filesystem only - and reaches the
+    destination once all of it is there. A conversion interrupted halfway
+    through therefore leaves what was there untouched, rather than a
+    truncated file where the operator's previous export used to be, and a
+    destination that already exists is only written when the caller asked
+    for it.
+    """
+    destination = Path(destination)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(_exists_message(destination))
+    handle, scratch_name = mkstemp(
+        dir=destination.parent, prefix=f'.{destination.name}.', suffix='.part'
+    )
+    scratch = Path(scratch_name)
+    try:
+        os.chmod(scratch, _OUTPUT_FILE_MODE)
+        with open(
+                handle, 'wb' if binary else 'wt',
+                encoding=None if binary else 'utf-8') as stream:
+            output = _Output(stream)
+            yield output
+            stream.flush()
+            os.fsync(stream.fileno())
+        if output.discarded:
+            scratch.unlink(missing_ok=True)
+        else:
+            _commit(scratch, destination, overwrite)
+    except BaseException:
+        # However it ended - an exception from the conversion, a signal
+        # killing the process - the scratch file holds converted content and
+        # the destination has not been touched: only the scratch file goes
+        scratch.unlink(missing_ok=True)
+        raise
+
+
+def _write_output(
+        destination: Path | str, content: bytes | str,
+        overwrite: bool = False):
+    with _open_output(
+            destination, overwrite=overwrite,
+            binary=isinstance(content, bytes)) as output:
+        output.write(content)
+
+
+def _commit(scratch: Path, destination: Path, overwrite: bool):
+    # Asked to overwrite, the scratch file replaces whatever is there.
+    # Otherwise the destination has to be *created*: a link fails where a
+    # replace would silently clobber a file that appeared while the
+    # conversion ran, which the check taken before the work cannot see. A
+    # filesystem carrying no links falls back to the replace, and to that
+    # check as its only guard
+    if overwrite:
+        os.replace(scratch, destination)
+        return
+    try:
+        os.link(scratch, destination)
+    except FileExistsError:
+        raise FileExistsError(_exists_message(destination))
+    except OSError:
+        os.replace(scratch, destination)
+        return
+    scratch.unlink(missing_ok=True)
+
+
+def _exists_message(destination: Path) -> str:
+    return (
+        f'{destination} already exists - pass `overwrite=True` '
+        '(`--overwrite` on the command line) to replace it.'
+    )
+
+
+def _private_opener(path: str, flags: int) -> int:
+    # The `opener` a plain `open` call takes to create its file owner-only,
+    # for the content a conversion writes outside the funnel above - the
+    # scratch fragments of a streamed assembly
+    return os.open(path, flags, _OUTPUT_FILE_MODE)

--- a/misp_stix_converter/tools/stix1_writing_helpers.py
+++ b/misp_stix_converter/tools/stix1_writing_helpers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+from .output_writing_helpers import _write_output
 from .stix1_framing import SCHEMALOC_DICT, _handle_namespaces
 from cybox.core.observable import Observables
 from pathlib import Path
@@ -182,17 +183,20 @@ def _format_xml_objects(
 
 def _write_raw_stix(
         package: STIXPackage, filename: Path | str, namespace: str,
-        org: str, return_format: str) -> bool:
+        org: str, return_format: str, overwrite: bool = False) -> bool:
     if return_format == 'xml':
         namespaces = _handle_namespaces(namespace, org)
-        with open(filename, 'wb') as f:
-            f.write(
-                package.to_xml(
-                    auto_namespace=False,
-                    ns_dict=namespaces,
-                    schemaloc_dict=SCHEMALOC_DICT
-                )
-            )
+        _write_output(
+            filename,
+            package.to_xml(
+                auto_namespace=False,
+                ns_dict=namespaces,
+                schemaloc_dict=SCHEMALOC_DICT
+            ),
+            overwrite=overwrite
+        )
     else:
-        with open(filename, 'wt', encoding='utf-8') as f:
-            f.write(json.dumps(package.to_dict(), indent=4))
+        _write_output(
+            filename, json.dumps(package.to_dict(), indent=4),
+            overwrite=overwrite
+        )

--- a/tests/_test_stix.py
+++ b/tests/_test_stix.py
@@ -48,6 +48,59 @@ class TestSTIX(unittest.TestCase):
         self.assertEqual(results['success'], 1)
         self.assertEqual(results['results'][0], output)
 
+    def _check_output_dir_handling(
+            self, conversion, filename, outputs: int = 1, **kwargs):
+        # `output_dir` is documented as a `Path` or a `str`, and how many MISP
+        # events a document yields is the document's own shape rather than a
+        # caller parameter: both types work whichever branch that shape
+        # selects, and a location that does not exist yet is created rather
+        # than failing at write time - `str` and creation crossed, since the
+        # branch reached for one of them is where neither held
+        #
+        # `_check_output_dir_refuses_a_file` covers the other half, for the
+        # conversions that can reach the per-event branch
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        for single_event in (True, False):
+            for as_str in (False, True):
+                for exists in (True, False):
+                    with TemporaryDirectory() as tmp_dir:
+                        directory = (
+                            Path(tmp_dir) / 'missing' / 'output'
+                        ).resolve()
+                        if exists:
+                            directory.mkdir(parents=True)
+                        results = conversion(
+                            filename, single_event=single_event,
+                            output_dir=(
+                                str(directory) if as_str else directory
+                            ), **kwargs
+                        )
+                        self.assertEqual(results['success'], 1)
+                        self.assertTrue(directory.is_dir())
+                        self.assertEqual(
+                            len(results['results']),
+                            1 if single_event else outputs
+                        )
+                        self._check_written_in(directory, results['results'])
+
+    def _check_output_dir_refuses_a_file(self, conversion, filename, taken):
+        # A directory is the only thing that can hold one file per MISP event,
+        # so unlike the output funnels an existing file is not read as the
+        # output file: the conversion says which path it could not make a
+        # directory of, and leaves the file as it was
+        with open(taken, 'wt', encoding='utf-8') as f:
+            f.write('taken')
+        with self.assertRaises(FileExistsError) as context:
+            conversion(filename, output_dir=taken)
+        self.assertIn(str(taken), str(context.exception))
+        self.assertEqual(taken.read_text(encoding='utf-8'), 'taken')
+
+    def _check_written_in(self, directory, outputs):
+        for output in outputs:
+            self.assertEqual(output.parent, directory)
+            self.assertTrue(output.is_file())
+
     @staticmethod
     def _plant_template_definition(directory):
         """Plant a template definition outside the MISP objects directory.

--- a/tests/_test_stix.py
+++ b/tests/_test_stix.py
@@ -23,6 +23,31 @@ class TestSTIX(unittest.TestCase):
         for element in elements:
             self.assertEqual(reference, element)
 
+    def _check_output_write_safety(self, conversion, filename, **kwargs):
+        # What a conversion writes is as sensitive as the document it came
+        # from: the file is readable by its owner alone whatever the process
+        # umask allows, and one that already exists is only replaced when the
+        # caller asked for it, with the refusal naming the file it left as it
+        # was
+        import os
+        umask = os.umask(0)
+        try:
+            results = conversion(filename, **kwargs)
+        finally:
+            os.umask(umask)
+        self.assertEqual(results['success'], 1)
+        output = results['results'][0]
+        self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+        written = output.read_text(encoding='utf-8')
+        with self.assertRaises(FileExistsError) as context:
+            conversion(filename, **kwargs)
+        self.assertIn(str(output), str(context.exception))
+        self.assertIn('overwrite', str(context.exception))
+        self.assertEqual(output.read_text(encoding='utf-8'), written)
+        results = conversion(filename, overwrite=True, **kwargs)
+        self.assertEqual(results['success'], 1)
+        self.assertEqual(results['results'][0], output)
+
     @staticmethod
     def _plant_template_definition(directory):
         """Plant a template definition outside the MISP objects directory.

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -8,6 +8,7 @@ import unittest
 from base64 import b64encode
 from collections import defaultdict
 from datetime import datetime, timezone
+from misp_stix_converter.misp2stix.exportparser import MISPtoSTIXParser
 from pathlib import Path
 from pymisp import MISPAttribute
 from shutil import copyfile
@@ -23,6 +24,10 @@ _ATTRIBUTE_EXCLUSION_LIST = ('disable_correlation', 'to_ids')
 _MISP_OBJECT_EXCLUSION_LIST = (
     'distribution', 'sharing_group_id', 'template_uuid', 'template_version'
 )
+# What an output file the caller never asked to replace holds, and the parsing
+# a conversion goes through on the way to writing one
+_PRESERVED_OUTPUT = 'IMPORTANT PRE-EXISTING CONTENT'
+_parse_json_file = MISPtoSTIXParser.parse_json_file
 
 # Object relations reaching a pattern property-name position, paired with the
 # pattern segment each one must produce. An unquoted metacharacter segment
@@ -98,6 +103,127 @@ class TestCollectionSTIXExport(unittest.TestCase):
             )
         self.assertEqual(self._package_tree_content(), package_tree)
 
+    def _check_destination_appearing_mid_conversion(
+            self, conversion, *input_files, **kwargs):
+        # The check taken before the work cannot see a destination that appears
+        # while the conversion runs: the output file is created rather than
+        # replaced, so the collision is still refused instead of silently
+        # clobbered at the end
+        appeared = []
+
+        def _create_the_destination(parser, filename):
+            if not appeared:
+                appeared.append(filename)
+                output_name.write_text(_PRESERVED_OUTPUT, encoding='utf-8')
+            return _parse_json_file(parser, filename)
+
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            output_name = Path(tmp_dir) / 'previous.out'
+            with patch.object(
+                    MISPtoSTIXParser, 'parse_json_file',
+                    _create_the_destination):
+                with self.assertRaises(FileExistsError) as context:
+                    conversion(*copies, output_name=output_name, **kwargs)
+            self.assertIn(str(output_name), str(context.exception))
+            self.assertEqual(
+                output_name.read_text(encoding='utf-8'), _PRESERVED_OUTPUT
+            )
+            self.assertEqual(
+                sorted(path.name for path in Path(tmp_dir).iterdir()),
+                sorted([copy.name for copy in copies] + [output_name.name])
+            )
+
+    def _check_interrupted_write_keeps_the_destination(
+            self, conversion, *input_files, interrupt=None, **kwargs):
+        # A conversion killed while it writes - `KeyboardInterrupt` is what a
+        # signal raises, and the one thing the per-input `except Exception`
+        # does not catch - leaves the file it was replacing exactly as it was,
+        # and no half-written scratch file next to it. The kill lands on the
+        # second input file's parsing, by the time the first one's content is
+        # written; `interrupt` names an (owner, attribute) pair instead, for a
+        # path whose writing all happens after the last input file is parsed
+        parsed = []
+
+        def _interrupt_the_second_input(parser, filename):
+            parsed.append(filename)
+            if len(parsed) > 1:
+                raise KeyboardInterrupt('Killed while writing')
+            return _parse_json_file(parser, filename)
+
+        def _interrupt_now(*args, **kwargs):
+            raise KeyboardInterrupt('Killed while writing')
+
+        killed = (
+            patch.object(
+                MISPtoSTIXParser, 'parse_json_file',
+                _interrupt_the_second_input
+            ) if interrupt is None
+            else patch.object(*interrupt, _interrupt_now)
+        )
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            output_name = self._preserved_output(tmp_dir)
+            with killed:
+                with self.assertRaises(KeyboardInterrupt):
+                    conversion(
+                        *copies, output_name=output_name, overwrite=True,
+                        **kwargs
+                    )
+            self.assertEqual(
+                output_name.read_text(encoding='utf-8'), _PRESERVED_OUTPUT
+            )
+            self.assertEqual(
+                sorted(path.name for path in Path(tmp_dir).iterdir()),
+                sorted([copy.name for copy in copies] + [output_name.name])
+            )
+
+    def _check_output_file_mode(self, conversion, *input_files, **kwargs):
+        # What a conversion writes carries whatever the events do, TLP:AMBER
+        # and TLP:RED material included: a new output file is readable by its
+        # owner alone, whatever the process umask would have allowed
+        umask = os.umask(0)
+        try:
+            with TemporaryDirectory() as tmp_dir:
+                copies = self._copy_inputs(tmp_dir, *input_files)
+                results = conversion(*copies, **kwargs)
+                self.assertEqual(results['success'], 1)
+                for output in results['results']:
+                    self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+        finally:
+            os.umask(umask)
+
+    def _check_overwrite_policy(
+            self, conversion, *input_files, recorded: bool = False, **kwargs):
+        # An **Output Location** already holding a file is only written when
+        # the caller asked for it: the refusal follows the error channel the
+        # path has for a write it cannot do - recorded per input where the
+        # write sits inside a `try`, raised where it does not - and names the
+        # file it did not touch either way
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            output_name = self._preserved_output(tmp_dir)
+            arguments = {'output_name': output_name, **kwargs}
+            if recorded:
+                results = conversion(*copies, **arguments)
+                self.assertNotIn('success', results)
+                message = results['fails'][0]
+            else:
+                with self.assertRaises(FileExistsError) as context:
+                    conversion(*copies, **arguments)
+                message = str(context.exception)
+            self.assertIn(str(output_name), message)
+            self.assertIn('overwrite', message)
+            self.assertEqual(
+                output_name.read_text(encoding='utf-8'), _PRESERVED_OUTPUT
+            )
+            results = conversion(*copies, overwrite=True, **arguments)
+            self.assertEqual(results['success'], 1)
+            self.assertEqual(results['results'][0], output_name)
+            self.assertNotEqual(
+                output_name.read_text(encoding='utf-8'), _PRESERVED_OUTPUT
+            )
+
     def _collection_files(self, name: str) -> list:
         return [self._current_path / f'{name}_{n}.json' for n in (1, 2)]
 
@@ -115,6 +241,11 @@ class TestCollectionSTIXExport(unittest.TestCase):
             if scratch.is_dir() else None
             for scratch in self._package_tree_scratch
         )
+
+    def _preserved_output(self, tmp_dir: str) -> Path:
+        output_name = Path(tmp_dir) / 'previous.out'
+        output_name.write_text(_PRESERVED_OUTPUT, encoding='utf-8')
+        return output_name
 
 
 class TestCollectionSTIX1Export(TestCollectionSTIXExport):

--- a/tests/_test_stix_export.py
+++ b/tests/_test_stix_export.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import misp_stix_converter
 import os
 import unittest
 from base64 import b64encode
@@ -9,8 +10,10 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from pymisp import MISPAttribute
+from shutil import copyfile
 from stix.core import STIXPackage
 from stix2patterns.validator import validate
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 from uuid import uuid5, UUID
 from ._test_stix import PLANTED_TEMPLATE, TestSTIX
@@ -40,12 +43,78 @@ _PATTERN_SEGMENT_RELATIONS = (
 
 
 class TestCollectionSTIXExport(unittest.TestCase):
+    # The 2 scratch locations the defaults used to resolve to: the package
+    # directory, and its parent - `site-packages` on an install, the
+    # repository root in a source checkout
+    _package_path = Path(misp_stix_converter.__file__).parent
+    _package_tree_scratch = (_package_path / 'tmp', _package_path.parent / 'tmp')
+
     def setUp(self):
         self._current_path = Path(__file__).parent
 
     def tearDown(self):
         for filename in self._current_path.glob('test_*_collection*.json.out'):
             os.remove(filename)
+
+    def _check_created_output_directory(self, conversion, *input_files, **kwargs):
+        # An output directory the caller names but has not created yet is a
+        # request, not a mistake: it is created instead of raising at write
+        # time - whether it is named as the directory itself or as the parent
+        # of an output file name
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            output_dir = Path(tmp_dir) / 'missing' / 'output'
+            results = conversion(
+                *copies, single_output=True, output_dir=output_dir, **kwargs
+            )
+            self.assertEqual(results['success'], 1)
+            self.assertTrue(output_dir.is_dir())
+            self.assertEqual(results['results'][0].parent, output_dir)
+            output_name = Path(tmp_dir) / 'missing too' / 'collection.out'
+            results = conversion(
+                *copies, single_output=True, output_name=output_name, **kwargs
+            )
+            self.assertEqual(results['success'], 1)
+            self.assertEqual(results['results'][0], output_name)
+            self.assertTrue(output_name.is_file())
+
+    def _check_default_single_output(self, conversion, *input_files, **kwargs):
+        # A collection export called with its documented defaults writes next
+        # to the input files, under a name every filesystem accepts, and the
+        # fragments a streamed assembly wrote are gone by the time it returns.
+        # The package tree is left exactly as it was: it is not an output or a
+        # scratch location
+        package_tree = self._package_tree_content()
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            results = conversion(*copies, single_output=True, **kwargs)
+            self.assertEqual(results['success'], 1)
+            output = results['results'][0]
+            self.assertEqual(output.parent, Path(tmp_dir).resolve())
+            self.assertNotIn(':', output.name)
+            self.assertEqual(
+                sorted(path.name for path in Path(tmp_dir).iterdir()),
+                sorted([copy.name for copy in copies] + [output.name])
+            )
+        self.assertEqual(self._package_tree_content(), package_tree)
+
+    def _collection_files(self, name: str) -> list:
+        return [self._current_path / f'{name}_{n}.json' for n in (1, 2)]
+
+    def _copy_inputs(self, tmp_dir: str, *input_files: Path) -> list:
+        return [
+            Path(copyfile(input_file, Path(tmp_dir) / input_file.name))
+            for input_file in input_files
+        ]
+
+    def _package_tree_content(self) -> tuple:
+        # `None` for a location that does not exist - the state a default
+        # writing there would change first
+        return tuple(
+            sorted(path.name for path in scratch.iterdir())
+            if scratch.is_dir() else None
+            for scratch in self._package_tree_scratch
+        )
 
 
 class TestCollectionSTIX1Export(TestCollectionSTIXExport):

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -29,7 +29,8 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
             results = stix_2_to_misp(
-                filename, classification='external', output_dir=Path(tmp_dir)
+                filename, classification='external', output_dir=Path(tmp_dir),
+                overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
@@ -39,7 +40,7 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
             # escapes the entry function.
             results = stix_2_to_misp(
                 filename, classification='internal', debug=True,
-                output_dir=Path(tmp_dir)
+                output_dir=Path(tmp_dir), overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertTrue(

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -610,7 +610,8 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
             results = stix_2_to_misp(
-                filename, classification='external', output_dir=Path(tmp_dir)
+                filename, classification='external', output_dir=Path(tmp_dir),
+                overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)
@@ -620,7 +621,7 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             # escapes the entry function.
             results = stix_2_to_misp(
                 filename, classification='internal', debug=True,
-                output_dir=Path(tmp_dir)
+                output_dir=Path(tmp_dir), overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertTrue(

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -130,6 +130,37 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
                 f.write(bundles.get_bundle_with_multiple_reports().serialize())
             self._check_output_write_safety(stix_2_to_misp, multiple)
 
+    def _multiple_reports_file(self, directory):
+        # 2 Reports, so `single_event` alone selects which branch builds the
+        # output path
+        from pathlib import Path
+        filename = Path(directory) / 'multiple.stix20.json'
+        with open(filename, 'wt', encoding='utf-8') as f:
+            f.write(
+                TestInternalSTIX20Bundles.
+                get_bundle_with_multiple_reports().serialize()
+            )
+        return filename
+
+    def test_stix20_output_dir_takes_a_str_and_is_created(self):
+        from misp_stix_converter import stix_2_to_misp
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            self._check_output_dir_handling(
+                stix_2_to_misp, self._multiple_reports_file(tmp_dir),
+                outputs=2
+            )
+
+    def test_stix20_output_dir_refuses_an_existing_file(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            self._check_output_dir_refuses_a_file(
+                stix_2_to_misp, self._multiple_reports_file(tmp_dir),
+                Path(tmp_dir) / 'not-a-directory'
+            )
+
     def test_stix20_classification_rejects_invalid_value(self):
         from misp_stix_converter import stix_2_to_misp
         with self.assertRaises(ValueError):

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -107,6 +107,29 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         with self.assertLogs('misp_stix_converter', level='WARNING'):
             self.assertTrue(is_stix2_from_misp(bundle.objects))
 
+    def test_stix20_output_writes_are_owner_only_and_refuse_to_overwrite(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundles = TestInternalSTIX20Bundles
+        with TemporaryDirectory() as tmp_dir:
+            single = Path(tmp_dir) / 'single.stix20.json'
+            with open(single, 'wt', encoding='utf-8') as f:
+                f.write(
+                    bundles.get_bundle_with_domain_indicator_attribute(
+                        ).serialize()
+                )
+            self._check_output_write_safety(
+                stix_2_to_misp, single, single_event=True
+            )
+            # A bundle carrying more than one Report takes the multi-event
+            # branch, which builds its per-event file outside the output
+            # funnels
+            multiple = Path(tmp_dir) / 'multiple.stix20.json'
+            with open(multiple, 'wt', encoding='utf-8') as f:
+                f.write(bundles.get_bundle_with_multiple_reports().serialize())
+            self._check_output_write_safety(stix_2_to_misp, multiple)
+
     def test_stix20_classification_rejects_invalid_value(self):
         from misp_stix_converter import stix_2_to_misp
         with self.assertRaises(ValueError):

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -73,7 +73,8 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
                 )
             )
             results = stix_2_to_misp(
-                filename, classification='internal', output_dir=Path(tmp_dir)
+                filename, classification='internal', output_dir=Path(tmp_dir),
+                overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -100,6 +100,29 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         with self.assertLogs('misp_stix_converter', level='WARNING'):
             self.assertTrue(is_stix2_from_misp(bundle.objects))
 
+    def test_stix21_output_writes_are_owner_only_and_refuse_to_overwrite(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundles = TestInternalSTIX21Bundles
+        with TemporaryDirectory() as tmp_dir:
+            single = Path(tmp_dir) / 'single.stix21.json'
+            with open(single, 'wt', encoding='utf-8') as f:
+                f.write(
+                    bundles.get_bundle_with_domain_indicator_attribute(
+                        ).serialize()
+                )
+            self._check_output_write_safety(
+                stix_2_to_misp, single, single_event=True
+            )
+            # A bundle carrying more than one Report takes the multi-event
+            # branch, which builds its per-event file outside the output
+            # funnels
+            multiple = Path(tmp_dir) / 'multiple.stix21.json'
+            with open(multiple, 'wt', encoding='utf-8') as f:
+                f.write(bundles.get_bundle_with_multiple_reports().serialize())
+            self._check_output_write_safety(stix_2_to_misp, multiple)
+
     def test_stix21_classification_rejects_invalid_value(self):
         from misp_stix_converter import stix_2_to_misp
         with self.assertRaises(ValueError):

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -66,7 +66,8 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
                 )
             )
             results = stix_2_to_misp(
-                filename, classification='internal', output_dir=Path(tmp_dir)
+                filename, classification='internal', output_dir=Path(tmp_dir),
+                overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -123,6 +123,37 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
                 f.write(bundles.get_bundle_with_multiple_reports().serialize())
             self._check_output_write_safety(stix_2_to_misp, multiple)
 
+    def _multiple_reports_file(self, directory):
+        # 2 Reports, so `single_event` alone selects which branch builds the
+        # output path
+        from pathlib import Path
+        filename = Path(directory) / 'multiple.stix21.json'
+        with open(filename, 'wt', encoding='utf-8') as f:
+            f.write(
+                TestInternalSTIX21Bundles.
+                get_bundle_with_multiple_reports().serialize()
+            )
+        return filename
+
+    def test_stix21_output_dir_takes_a_str_and_is_created(self):
+        from misp_stix_converter import stix_2_to_misp
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            self._check_output_dir_handling(
+                stix_2_to_misp, self._multiple_reports_file(tmp_dir),
+                outputs=2
+            )
+
+    def test_stix21_output_dir_refuses_an_existing_file(self):
+        from misp_stix_converter import stix_2_to_misp
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        with TemporaryDirectory() as tmp_dir:
+            self._check_output_dir_refuses_a_file(
+                stix_2_to_misp, self._multiple_reports_file(tmp_dir),
+                Path(tmp_dir) / 'not-a-directory'
+            )
+
     def test_stix21_classification_rejects_invalid_value(self):
         from misp_stix_converter import stix_2_to_misp
         with self.assertRaises(ValueError):

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -4292,6 +4292,93 @@ class TestSTIX12MISPExport(TestSTIX12Export):
 
 
 class TestCollectionStix1Export(TestCollectionSTIX1Export):
+    def test_exports_refuse_to_overwrite_an_existing_output(self):
+        attributes = self._collection_files('test_attributes_collection')
+        events = self._collection_files('test_events_collection')
+        # A single input file reports the refusal in the result dict its write
+        # already sits in; a merged output raises it, like any other write it
+        # cannot do on that path
+        for return_format in ('xml', 'json'):
+            self._check_overwrite_policy(
+                misp_to_stix1, events[0], recorded=True,
+                return_format=return_format
+            )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_overwrite_policy(
+                misp_attribute_collection_to_stix1, *attributes,
+                single_output=True, **kwargs
+            )
+            self._check_overwrite_policy(
+                misp_event_collection_to_stix1, *events,
+                single_output=True, **kwargs
+            )
+        self._check_destination_appearing_mid_conversion(
+            misp_event_collection_to_stix1, *events, single_output=True
+        )
+
+    def test_exports_write_owner_only_files(self):
+        attributes = self._collection_files('test_attributes_collection')
+        events = self._collection_files('test_events_collection')
+        for return_format in ('xml', 'json'):
+            self._check_output_file_mode(
+                misp_to_stix1, events[0], return_format=return_format
+            )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_output_file_mode(
+                misp_attribute_collection_to_stix1, *attributes,
+                single_output=True, **kwargs
+            )
+            self._check_output_file_mode(
+                misp_event_collection_to_stix1, *events,
+                single_output=True, **kwargs
+            )
+        # One output per input file: each one is owner-only as well
+        self._check_output_file_mode(misp_event_collection_to_stix1, *events)
+
+    def test_interrupted_streamed_write_keeps_the_destination(self):
+        # The streamed paths are the ones that used to write the output in
+        # several steps, so an interrupted assembly left it truncated. The
+        # Attribute Collection writes nothing before its **Scratch Fragments**
+        # are all there, so the kill has to land inside the assembly itself -
+        # on the footer of the second feature it reads back
+        self._check_interrupted_write_keeps_the_destination(
+            misp_attribute_collection_to_stix1,
+            *self._collection_files('test_attributes_collection'),
+            interrupt=(converter_module.AttributeCollectionHandler, 'footer'),
+            single_output=True
+        )
+        self._check_interrupted_write_keeps_the_destination(
+            misp_event_collection_to_stix1,
+            *self._collection_files('test_events_collection'),
+            single_output=True
+        )
+
+    def test_streamed_events_assembly_converting_nothing_keeps_the_destination(self):
+        # Every input file failing leaves the streamed event assembly with a
+        # header and a footer and nothing between them: it must not report a
+        # success, nor replace the output of the export that did work
+        good, bad = self._collection_files('test_events_collection')
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, good, bad)
+            for copy in copies:
+                with open(copy, 'wt', encoding='utf-8') as f:
+                    f.write('{"Event": {"info": ')
+            output_name = Path(tmp_dir) / 'previous.out'
+            with open(output_name, 'wt', encoding='utf-8') as f:
+                f.write('IMPORTANT PRE-EXISTING CONTENT')
+            results = misp_event_collection_to_stix1(
+                *copies, single_output=True, output_name=output_name,
+                overwrite=True
+            )
+            self.assertNotIn('success', results)
+            self.assertEqual(len(results['fails']), 2)
+            with open(output_name, 'rt', encoding='utf-8') as f:
+                self.assertEqual(f.read(), 'IMPORTANT PRE-EXISTING CONTENT')
+            self.assertEqual(
+                sorted(path.name for path in Path(tmp_dir).iterdir()),
+                sorted([copy.name for copy in copies] + [output_name.name])
+            )
+
     def test_attribute_collection_default_output_location(self):
         input_files = self._collection_files('test_attributes_collection')
         for kwargs in ({}, {'in_memory': True}):

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -4380,7 +4380,7 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self.assertEqual(
             misp_attribute_collection_to_stix1(
                 *input_files, return_format='xml', version='1.1.1',
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -4402,7 +4402,7 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self.assertEqual(
             misp_attribute_collection_to_stix1(
                 *input_files, return_format='xml', version='1.2',
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -4424,7 +4424,8 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self.assertEqual(
             misp_event_collection_to_stix1(
                 *input_files, return_format='xml', version='1.1.1',
-                in_memory=True, single_output=True, output_name=output_file
+                in_memory=True, single_output=True, output_name=output_file,
+                overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -4462,7 +4463,8 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self.assertEqual(
             misp_event_collection_to_stix1(
                 *input_files, return_format='xml', version='1.2',
-                in_memory=True, single_output=True, output_name=output_file
+                in_memory=True, single_output=True, output_name=output_file,
+                overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -4496,7 +4498,8 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self._check_stix1_export_results(output_file, reference_file)
         self.assertEqual(
             misp_event_collection_to_stix1(
-                filename, return_format='xml', version='1.1.1'
+                filename, return_format='xml', version='1.1.1',
+                overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -4514,7 +4517,8 @@ class TestCollectionStix1Export(TestCollectionSTIX1Export):
         self._check_stix1_export_results(output_file, reference_file)
         self.assertEqual(
             misp_event_collection_to_stix1(
-                filename, return_format='xml', version='1.2'
+                filename, return_format='xml', version='1.2',
+                overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -8,10 +8,12 @@ from lxml import etree
 from misp_stix_converter import (InvalidMISPInputError, MISPtoSTIX1AttributesParser,
                                  MISPtoSTIX1EventsParser, misp_attribute_collection_to_stix1,
                                  misp_event_collection_to_stix1, misp_to_stix1)
+from misp_stix_converter import misp_stix_converter as converter_module
 from misp_stix_converter.tools.stix1_framing import _handle_namespaces
 from pymisp import MISPEvent
 from shutil import copyfile
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 from uuid import uuid5, UUID
 from .test_events import *
 from .test_events import _INDICATOR_ATTRIBUTE
@@ -4290,6 +4292,78 @@ class TestSTIX12MISPExport(TestSTIX12Export):
 
 
 class TestCollectionStix1Export(TestCollectionSTIX1Export):
+    def test_attribute_collection_default_output_location(self):
+        input_files = self._collection_files('test_attributes_collection')
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_default_single_output(
+                misp_attribute_collection_to_stix1, *input_files, **kwargs
+            )
+            self._check_created_output_directory(
+                misp_attribute_collection_to_stix1, *input_files, **kwargs
+            )
+
+    def test_event_collection_default_output_location(self):
+        input_files = self._collection_files('test_events_collection')
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_default_single_output(
+                misp_event_collection_to_stix1, *input_files, **kwargs
+            )
+            self._check_created_output_directory(
+                misp_event_collection_to_stix1, *input_files, **kwargs
+            )
+
+    def test_streamed_failure_names_the_input_file_it_comes_from(self):
+        # The streamed assembly names its **Scratch Fragments** after a uuid:
+        # a failing input has to be reported by its own name, not by the
+        # fragment the previous input happened to write
+        good, bad = self._collection_files('test_attributes_collection')
+        with TemporaryDirectory() as tmp_dir:
+            good, bad = self._copy_inputs(tmp_dir, good, bad)
+            with open(bad, 'wt', encoding='utf-8') as f:
+                f.write('{"Attribute": [{"type": "md5", "value": "not a hash"')
+            results = misp_attribute_collection_to_stix1(
+                good, bad, single_output=True
+            )
+            self.assertEqual(len(results['fails']), 1)
+            self.assertIn(str(bad), results['fails'][0])
+
+    def test_streamed_fragments_are_removed_when_the_assembly_fails(self):
+        # The fragments the streamed Attribute Collection writes hold
+        # converted intelligence: an assembly that never completes must not
+        # leave them behind, wherever they were written
+        input_files = self._collection_files('test_attributes_collection')
+        recorded = {}
+        temporary_directory = converter_module.TemporaryDirectory
+
+        def _record_scratch_directory(*args, **kwargs):
+            scratch = temporary_directory(*args, **kwargs)
+            recorded['scratch'] = Path(scratch.name)
+            return scratch
+
+        def _fail_the_assembly(*args, **kwargs):
+            recorded['fragments'] = sorted(
+                path.name for path in recorded['scratch'].iterdir()
+            )
+            raise RuntimeError('Interrupted assembly')
+
+        with TemporaryDirectory() as tmp_dir:
+            copies = self._copy_inputs(tmp_dir, *input_files)
+            with patch.object(
+                    converter_module, 'TemporaryDirectory',
+                    _record_scratch_directory), patch.object(
+                    converter_module, 'stix1_attributes_framing',
+                    _fail_the_assembly):
+                with self.assertRaises(RuntimeError):
+                    misp_attribute_collection_to_stix1(
+                        *copies, single_output=True
+                    )
+            self.assertTrue(recorded['fragments'])
+            self.assertFalse(recorded['scratch'].exists())
+            self.assertEqual(
+                sorted(path.name for path in Path(tmp_dir).iterdir()),
+                sorted(copy.name for copy in copies)
+            )
+
     def test_attribute_collection_export_11(self):
         name = 'test_attributes_collection'
         output_file = self._current_path / f'{name}.json.out'

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -423,7 +423,8 @@ class TestSTIX1Import(TestSTIX):
                 )
             )
             results = stix_1_to_misp(
-                filename, single_event=True, classification='internal'
+                filename, single_event=True, classification='internal',
+                overwrite=True
             )
             self.assertEqual(results['success'], 1)
             self.assertNotIn('warnings', results)

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -396,19 +396,6 @@ class TestSTIX1Import(TestSTIX):
             any('parser stage crash' in error for error in results['errors'])
         )
 
-    ############################################################################
-    #                         CLASSIFICATION OVERRIDE.                         #
-    ############################################################################
-
-    def _internal_titled_package(self):
-        """A package whose header title matches the MISP export convention, so
-        content-based detection classifies it as internal - shaped with the
-        related packages the Internal parser expects."""
-        return self._internal_package(
-            Incident(), inner_title='Incident title',
-            outer_title="Export from ACME's MISP"
-        )
-
     def test_stix_1_output_writes_are_owner_only_and_refuse_to_overwrite(self):
         stix_package = STIXPackage()
         stix_package.add_course_of_action(self._course_of_action())
@@ -436,42 +423,6 @@ class TestSTIX1Import(TestSTIX):
             Incident(), inner_title='Incident title',
             outer_title="Export from ACME's MISP"
         )
-
-    def test_stix_1_output_writes_are_owner_only_and_refuse_to_overwrite(self):
-        # A converted MISP event is as sensitive as the package it came from:
-        # the file it is written to is readable by its owner alone, and one
-        # that already exists is only replaced when the caller asked for it
-        import os
-        stix_package = STIXPackage()
-        stix_package.add_course_of_action(self._course_of_action())
-        with TemporaryDirectory() as tmp_dir:
-            filename = self._write_package(
-                tmp_dir, stix_package, 'course_of_action.xml'
-            )
-            output_name = Path(tmp_dir) / 'event.misp.json'
-            umask = os.umask(0)
-            try:
-                results = stix_1_to_misp(
-                    filename, single_event=True, output_name=output_name
-                )
-            finally:
-                os.umask(umask)
-            self.assertEqual(results['success'], 1)
-            self.assertEqual(output_name.stat().st_mode & 0o777, 0o600)
-            written = output_name.read_text(encoding='utf-8')
-            with self.assertRaises(FileExistsError) as context:
-                stix_1_to_misp(
-                    filename, single_event=True, output_name=output_name
-                )
-            self.assertIn(str(output_name), str(context.exception))
-            self.assertEqual(
-                output_name.read_text(encoding='utf-8'), written
-            )
-            results = stix_1_to_misp(
-                filename, single_event=True, output_name=output_name,
-                overwrite=True
-            )
-            self.assertEqual(results['success'], 1)
 
     def test_stix_1_classification_auto_detection_warns_and_explicit_is_silent(self):
         stix_package = self._internal_titled_package()

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -409,6 +409,70 @@ class TestSTIX1Import(TestSTIX):
             outer_title="Export from ACME's MISP"
         )
 
+    def test_stix_1_output_writes_are_owner_only_and_refuse_to_overwrite(self):
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            # Both branches: the single MISP event written through the output
+            # funnels, and the per-event file the multi-event branch builds
+            # outside them
+            self._check_output_write_safety(
+                stix_1_to_misp, filename, single_event=True
+            )
+            self._check_output_write_safety(stix_1_to_misp, filename)
+
+    ############################################################################
+    #                         CLASSIFICATION OVERRIDE.                         #
+    ############################################################################
+
+    def _internal_titled_package(self):
+        """A package whose header title matches the MISP export convention, so
+        content-based detection classifies it as internal - shaped with the
+        related packages the Internal parser expects."""
+        return self._internal_package(
+            Incident(), inner_title='Incident title',
+            outer_title="Export from ACME's MISP"
+        )
+
+    def test_stix_1_output_writes_are_owner_only_and_refuse_to_overwrite(self):
+        # A converted MISP event is as sensitive as the package it came from:
+        # the file it is written to is readable by its owner alone, and one
+        # that already exists is only replaced when the caller asked for it
+        import os
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            output_name = Path(tmp_dir) / 'event.misp.json'
+            umask = os.umask(0)
+            try:
+                results = stix_1_to_misp(
+                    filename, single_event=True, output_name=output_name
+                )
+            finally:
+                os.umask(umask)
+            self.assertEqual(results['success'], 1)
+            self.assertEqual(output_name.stat().st_mode & 0o777, 0o600)
+            written = output_name.read_text(encoding='utf-8')
+            with self.assertRaises(FileExistsError) as context:
+                stix_1_to_misp(
+                    filename, single_event=True, output_name=output_name
+                )
+            self.assertIn(str(output_name), str(context.exception))
+            self.assertEqual(
+                output_name.read_text(encoding='utf-8'), written
+            )
+            results = stix_1_to_misp(
+                filename, single_event=True, output_name=output_name,
+                overwrite=True
+            )
+            self.assertEqual(results['success'], 1)
+
     def test_stix_1_classification_auto_detection_warns_and_explicit_is_silent(self):
         stix_package = self._internal_titled_package()
         with TemporaryDirectory() as tmp_dir:

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -403,13 +403,52 @@ class TestSTIX1Import(TestSTIX):
             filename = self._write_package(
                 tmp_dir, stix_package, 'course_of_action.xml'
             )
-            # Both branches: the single MISP event written through the output
-            # funnels, and the per-event file the multi-event branch builds
-            # outside them
             self._check_output_write_safety(
                 stix_1_to_misp, filename, single_event=True
             )
-            self._check_output_write_safety(stix_1_to_misp, filename)
+            # Same rules on the destination the caller names as on the default
+            self._check_output_write_safety(
+                stix_1_to_misp, filename, single_event=True,
+                output_name=Path(tmp_dir) / 'event.misp.json'
+            )
+
+    def test_stix_1_internal_import_yields_one_event_by_itself(self):
+        """A STIX 1 import produces one MISP event whatever `single_event`
+        says - the Internal parser merges every related package into one, and
+        the External one forces the flag - so the entry function's per-event
+        branch was reached by the default parameters and could only crash
+        there: nothing sets `misp_events`, so it iterated a `MISPEvent`."""
+        stix_package = self._internal_titled_package()
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(tmp_dir, stix_package, 'internal.xml')
+            results = stix_1_to_misp(filename)
+            self.assertEqual(results['success'], 1)
+            self.assertEqual(len(results['results']), 1)
+            output = results['results'][0]
+            self.assertEqual(output.name, 'internal.xml.out')
+            self.assertTrue(output.is_file())
+            # The explicit flag asks for what the parser does anyway, so it
+            # writes the same file rather than a differently named one
+            self.assertEqual(
+                stix_1_to_misp(
+                    filename, single_event=True, overwrite=True
+                )['results'],
+                [output]
+            )
+
+    def test_stix_1_output_dir_takes_a_str_and_is_created(self):
+        external = STIXPackage()
+        external.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            # Both classifications, since only one MISP event comes out of
+            # either: whatever `single_event` says, a STIX 1 import goes
+            # through the output funnels and never builds a per-event path
+            for name, package in (('external', external),
+                                  ('internal', self._internal_titled_package())):
+                self._check_output_dir_handling(
+                    stix_1_to_misp,
+                    self._write_package(tmp_dir, package, f'{name}.xml')
+                )
 
     ############################################################################
     #                         CLASSIFICATION OVERRIDE.                         #

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -5629,6 +5629,19 @@ class TestSTIX20MISPExportInteroperability(TestSTIX20ExportInteroperability):
 
 
 class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
+    def test_collection_default_output_location(self):
+        input_files = [
+            self._current_path / f'test_events_collection_{n}.json'
+            for n in (1, 2)
+        ]
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_default_single_output(
+                misp_collection_to_stix2, *input_files, version='2.0', **kwargs
+            )
+            self._check_created_output_directory(
+                misp_collection_to_stix2, *input_files, version='2.0', **kwargs
+            )
+
     def test_export_reports_dropped_content_without_debug(self):
         # export records an error for every attribute or object it could not
         # convert, but `_generate_traceback` only attached them when `debug`

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -5629,6 +5629,48 @@ class TestSTIX20MISPExportInteroperability(TestSTIX20ExportInteroperability):
 
 
 class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
+    def test_exports_refuse_to_overwrite_an_existing_output(self):
+        input_files = self._collection_files('test_events_collection')
+        # A single input file reports the refusal in the result dict its write
+        # already sits in; a merged output raises it, like any other write it
+        # cannot do on that path
+        self._check_overwrite_policy(
+            misp_to_stix2, input_files[0], recorded=True, version='2.0'
+        )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_overwrite_policy(
+                misp_collection_to_stix2, *input_files, single_output=True,
+                version='2.0', **kwargs
+            )
+        self._check_destination_appearing_mid_conversion(
+            misp_collection_to_stix2, *input_files, single_output=True,
+            version='2.0'
+        )
+
+    def test_exports_write_owner_only_files(self):
+        input_files = self._collection_files('test_events_collection')
+        self._check_output_file_mode(
+            misp_to_stix2, input_files[0], version='2.0'
+        )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_output_file_mode(
+                misp_collection_to_stix2, *input_files, single_output=True,
+                version='2.0', **kwargs
+            )
+        # One output per input file: each one is owner-only as well
+        self._check_output_file_mode(
+            misp_collection_to_stix2, *input_files, version='2.0'
+        )
+
+    def test_interrupted_streamed_write_keeps_the_destination(self):
+        # The streamed path is the one that used to write the output in
+        # several steps, so an interrupted assembly left it truncated
+        self._check_interrupted_write_keeps_the_destination(
+            misp_collection_to_stix2,
+            *self._collection_files('test_events_collection'),
+            single_output=True, version='2.0'
+        )
+
     def test_collection_default_output_location(self):
         input_files = [
             self._current_path / f'test_events_collection_{n}.json'

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -5673,7 +5673,7 @@ class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.0', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -5695,7 +5695,7 @@ class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.0', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -5717,7 +5717,7 @@ class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.0', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -5750,7 +5750,7 @@ class TestCollectionSTIX20Export(TestCollectionSTIX2Export):
         self._check_stix2_results_export(output_file, reference_file)
         self.assertEqual(
             misp_collection_to_stix2(
-                filename, version='2.0'
+                filename, version='2.0', overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -6873,7 +6873,7 @@ class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.1', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -6904,7 +6904,7 @@ class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.1', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -6926,7 +6926,7 @@ class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
         self.assertEqual(
             misp_collection_to_stix2(
                 *input_files, version='2.1', in_memory=True,
-                single_output=True, output_name=output_file
+                single_output=True, output_name=output_file, overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )
@@ -6959,7 +6959,7 @@ class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
         self._check_stix2_results_export(output_file, reference_file)
         self.assertEqual(
             misp_collection_to_stix2(
-                filename, version='2.1'
+                filename, version='2.1', overwrite=True
             ),
             {'success': 1, 'results': [output_file]}
         )

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -6829,6 +6829,48 @@ class TestSTIX21MISPExportInteroperability(TestSTIX21ExportInteroperability):
 
 
 class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
+    def test_exports_refuse_to_overwrite_an_existing_output(self):
+        input_files = self._collection_files('test_events_collection')
+        # A single input file reports the refusal in the result dict its write
+        # already sits in; a merged output raises it, like any other write it
+        # cannot do on that path
+        self._check_overwrite_policy(
+            misp_to_stix2, input_files[0], recorded=True, version='2.1'
+        )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_overwrite_policy(
+                misp_collection_to_stix2, *input_files, single_output=True,
+                version='2.1', **kwargs
+            )
+        self._check_destination_appearing_mid_conversion(
+            misp_collection_to_stix2, *input_files, single_output=True,
+            version='2.1'
+        )
+
+    def test_exports_write_owner_only_files(self):
+        input_files = self._collection_files('test_events_collection')
+        self._check_output_file_mode(
+            misp_to_stix2, input_files[0], version='2.1'
+        )
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_output_file_mode(
+                misp_collection_to_stix2, *input_files, single_output=True,
+                version='2.1', **kwargs
+            )
+        # One output per input file: each one is owner-only as well
+        self._check_output_file_mode(
+            misp_collection_to_stix2, *input_files, version='2.1'
+        )
+
+    def test_interrupted_streamed_write_keeps_the_destination(self):
+        # The streamed path is the one that used to write the output in
+        # several steps, so an interrupted assembly left it truncated
+        self._check_interrupted_write_keeps_the_destination(
+            misp_collection_to_stix2,
+            *self._collection_files('test_events_collection'),
+            single_output=True, version='2.1'
+        )
+
     def test_collection_default_output_location(self):
         input_files = [
             self._current_path / f'test_events_collection_{n}.json'

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -6829,6 +6829,19 @@ class TestSTIX21MISPExportInteroperability(TestSTIX21ExportInteroperability):
 
 
 class TestCollectionSTIX21Export(TestCollectionSTIX2Export):
+    def test_collection_default_output_location(self):
+        input_files = [
+            self._current_path / f'test_events_collection_{n}.json'
+            for n in (1, 2)
+        ]
+        for kwargs in ({}, {'in_memory': True}):
+            self._check_default_single_output(
+                misp_collection_to_stix2, *input_files, version='2.1', **kwargs
+            )
+            self._check_created_output_directory(
+                misp_collection_to_stix2, *input_files, version='2.1', **kwargs
+            )
+
     def test_export_reports_dropped_content_without_debug(self):
         # export records an error for every attribute or object it could not
         # convert, but `_generate_traceback` only attached them when `debug`


### PR DESCRIPTION
## Description

Everything about the file a conversion produces: which directory it lands in when the caller named none, how it is created once the directory is known, and what the parameters naming that directory accept. Three tickets, nine commits, both conversion directions.

The three are ordered because they share one surface: #97 decides the destination, #98 writes to it, #100 fixes the one destination neither of them funnelled.

## The three fixes

**#97 — where a conversion writes when the caller named nothing.** Several defaults resolved into the installed package tree, which is read-only on a normal install and holds the conversion's own data files on any other. Measured on a source checkout, `parents[1] / 'tmp'` is the repository root: both STIX 2 collection modes had been quietly writing converted events there, while the four STIX 1 paths raised `FileNotFoundError` on a documented call with documented defaults. Every default now writes next to the file it read — the collection entries take the first input file's directory, the single-input entries their own input's — and a directory the caller named is created rather than failing at write time. The STIX 1 collection default name also drops the organisation prefix and the `:` separator it inherited from the package id, which Windows and SMB shares reject. The temp fragments a streamed STIX 1 collection writes moved into a `tempfile` scratch directory of their own, removed however the assembly ends rather than only when it completes.

**#98 — how the file is created.** Every output went through a plain `open`: it took whatever the umask allowed (`0o664` measured), a file already at the destination was replaced with no warning, and a conversion writing in several steps left that destination truncated when it did not finish. All of it now goes through one choke point. Content is written to a scratch file in the destination's own directory, `0o600` whatever the umask allows, and reaches the destination in one step once all of it is there — so an interrupted conversion leaves the previous file exactly as it was. A destination that already exists is not replaced unless the caller passes `overwrite` (`--overwrite` on the command line); without it the last step is a link, so a file that appeared *while* the conversion ran is refused too, not just one the check saw at the start. The refusal is a `FileExistsError` naming the file.

**#100 — the parameter naming the directory.** `output_dir` is documented as a `Path` or a `str`, but the import entries' per-event branch joined the file name onto it directly, so a `str` raised `TypeError`: a documented parameter type worked or crashed depending on how many events the *document* happened to yield, which is not the caller's choice. That branch was also the one destination built outside the output funnels, so a directory that does not exist yet was still an error there while #97 had made every other entry create it. Both go through one funnel now, and a `str` becomes a `Path` in a single place shared by all three funnels.

## What #100 turned up on the STIX 1 side

The finding behind #100 reads as though `stix_1_to_misp` had the same defect as `stix_2_to_misp`. It has the same expression, but not the same reachable failure: `AttributeError: 'str' object has no attribute 'uuid'` fires first, because no STIX 1 parser fills in the list of events that branch iterates, so it walks the keys of a single `MISPEvent` instead. That is reachable with the **default** parameters — `stix_1_to_misp(file)` on MISP-exported STIX 1 crashed, as did `misp_stix_converter import -v 1 -f file.xml` without `-s`.

A STIX 1 import produces one MISP event and always did: the Internal parser merges every related package into one, taking the titles, dates and timestamps of all of them, and the External parser was already saying so. The Internal one now says so too, which is what makes the crash go away. The per-event branch of `stix_1_to_misp` is unreachable as a result; it is left in place rather than deleted. The `--single-event` help and its README line no longer promise one event per file "in case of multiple Report, Grouping or Incident objects" — no Incident was ever split.

## Two decisions worth stating

**A refusal follows the error channel each path already has.** Recorded in `fails` where the write sits inside a per-input `try`, raised where it does not. Normalising that would mean restructuring the channels #88 and #104 settled, and the command line prints the file name either way.

**The overwrite check lives in the writer, not in the path helpers.** A `single_output` collection export takes its default name from the package or bundle id, so the destination is only known after the conversion. The cost is visible only as wasted work: the streamed attribute collection converts before it refuses, while every other path opens its output first and refuses before parsing anything.

## Behaviour changes for library consumers

- Writing onto a path that already holds a file needs `overwrite=True` (`--overwrite`). Fourteen tests in the suite were rewriting a file they had just written and now pass it.
- New output files are `0o600`. Anything downstream reading them as a different user will need the mode changed after the fact.
- Collection exports that relied on the old default location will find their output next to the input files instead of in the package tree or the working directory.
- `stix_1_to_misp` and the STIX 1 import command work with their defaults, where they previously raised `AttributeError`.

## Tests

Each fix has its own coverage commit, and one repairs a test that never ran: #98's test commit had inserted its STIX 1 block twice, so Python kept the older copy and the one meant to cover both write branches was shadowed — it failed as soon as it was un-shadowed, on the STIX 1 crash above.

Coverage is symmetric across 2.0 and 2.1 for everything shared, and spans both classifications on the STIX 1 side: default locations for every entry and both scratch areas, the file mode, the refusal, the opt-in, an interrupted write and a destination appearing mid-conversion, and `output_dir` as a `Path` and a `str` against a directory that exists and one that does not — all four combinations, since the branch that was broken is the one where neither held. Every assertion was measured failing against the unfixed code.
