### PR TITLE
Stop a STIX 1 conversion inheriting the state of the one before it

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,20 @@ response = misp_to_stix1(
 ```
 The resulting STIX1 Package is then available in a `filename.out` file
 
+**STIX 1 export is not thread-safe.** The identifier namespace an exported STIX 1
+Package uses lives in a module-level generator inside `mixbox`, so it is process-wide.
+`misp_to_stix1`, `misp_event_collection_to_stix1` and `misp_attribute_collection_to_stix1`
+set it for the duration of one conversion and put back whatever they found, which keeps
+sequential and nested exports apart — but two exports running at the same time in one
+process share that one generator and can attribute identifiers to each other's
+organisation. Convert in one thread, or in separate processes.
+
+Driving a parser yourself (the `MISPtoSTIX1EventsParser` example above) or calling the
+`stix1_framing` / `stix1_attributes_framing` helpers directly gets no such window: the
+framing helpers set the namespace and leave it set, and a parser used on its own never
+sets it at all. Wrap those calls yourself if the same process exports for more than one
+organisation.
+
 - Convert a MISP Event in STIX2:
 
 ```python

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -12,7 +12,7 @@ from .tools.output_writing_helpers import (
     _open_output, _private_opener, _write_output)
 from .tools.stix1_framing import (
     stix1_attributes_framing, stix1_framing, _create_stix_package,
-    _validate_namespace)
+    _scoped_id_namespace, _validate_namespace)
 from .tools.stix1_loading_helpers import load_stix1_package
 from .tools.stix1_to_misp_helpers import get_stix1_parser, is_stix1_from_misp
 from .tools.stix1_writing_helpers import (
@@ -127,126 +127,127 @@ def misp_attribute_collection_to_stix1(
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
     namespace = _validate_namespace(namespace)
-    parser = MISPtoSTIX1AttributesParser(org, version)
-    if len(input_files) == 1:
-        try:
-            filename = input_files[0]
-            if isinstance(filename, str):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            name = _check_filename(
-                filename.parent, f'{filename.name}.out', output_dir, output_name
-            )
-            _write_raw_stix(
-                parser.stix_package, name, namespace, org, return_format,
-                overwrite
-            )
-            return _generate_traceback(debug, parser, name)
-        except Exception as exception:
-            return {'fails': [f'{filename} -  {exception.__str__()}']}
-    traceback = defaultdict(list)
-    if single_output:
-        stix_package = _create_stix_package(org, version)
-        name = _check_filename(
-            _default_output_dir(*input_files),
-            _default_stix1_name(stix_package, return_format),
-            output_dir, output_name
-        )
-        if in_memory:
-            for filename in input_files:
-                try:
-                    parser.parse_json_file(filename)
-                    current = parser.stix_package
-                    for campaign in current.campaigns:
-                        stix_package.add_campaign(campaign)
-                    for course_of_action in current.courses_of_action:
-                        stix_package.add_course_of_action(course_of_action)
-                    for exploit_target in current.exploit_targets:
-                        stix_package.add_exploit_target(exploit_target)
-                    for indicator in current.indicators:
-                        stix_package.add_indicator(indicator)
-                    for observable in current.observables:
-                        stix_package.add_observable(observable)
-                    for threat_actor in current.threat_actors:
-                        stix_package.add_threat_actor(threat_actor)
-                    if current.ttps is not None:
-                        for ttp in current.ttps:
-                            stix_package.add_ttp(ttp)
-                except Exception as exception:
-                    traceback['fails'].append(f'{filename} - {exception.__str__()}')
-            if any(filename not in traceback.get('fails', []) for filename in input_files):
+    with _scoped_id_namespace(namespace, org):
+        parser = MISPtoSTIX1AttributesParser(org, version)
+        if len(input_files) == 1:
+            try:
+                filename = input_files[0]
+                if isinstance(filename, str):
+                    filename = Path(filename).resolve()
+                parser.parse_json_file(filename)
+                name = _check_filename(
+                    filename.parent, f'{filename.name}.out', output_dir, output_name
+                )
                 _write_raw_stix(
-                    stix_package, name, namespace, org, return_format,
+                    parser.stix_package, name, namespace, org, return_format,
                     overwrite
                 )
-                traceback.update(_generate_traceback(debug, parser, name))
-            return traceback
-        handler = AttributeCollectionHandler(return_format)
-        # The per-feature fragments hold converted content: they live in a
-        # scratch directory of their own, removed however the assembly ends
-        with TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            for filename in input_files:
-                try:
-                    parser.parse_json_file(filename)
-                    package = parser.stix_package
-                    for feature in _STIX1_features:
-                        values = getattr(package, feature)
-                        if values:
-                            content = globals()[f'write_{feature}'](values, return_format)
-                            if not content.strip():
-                                continue
-                            fragment = handler.get_filename(feature)
-                            if fragment is None:
-                                fragment = handler.set_feature(feature, uuid4())
+                return _generate_traceback(debug, parser, name)
+            except Exception as exception:
+                return {'fails': [f'{filename} -  {exception.__str__()}']}
+        traceback = defaultdict(list)
+        if single_output:
+            stix_package = _create_stix_package(org, version)
+            name = _check_filename(
+                _default_output_dir(*input_files),
+                _default_stix1_name(stix_package, return_format),
+                output_dir, output_name
+            )
+            if in_memory:
+                for filename in input_files:
+                    try:
+                        parser.parse_json_file(filename)
+                        current = parser.stix_package
+                        for campaign in current.campaigns:
+                            stix_package.add_campaign(campaign)
+                        for course_of_action in current.courses_of_action:
+                            stix_package.add_course_of_action(course_of_action)
+                        for exploit_target in current.exploit_targets:
+                            stix_package.add_exploit_target(exploit_target)
+                        for indicator in current.indicators:
+                            stix_package.add_indicator(indicator)
+                        for observable in current.observables:
+                            stix_package.add_observable(observable)
+                        for threat_actor in current.threat_actors:
+                            stix_package.add_threat_actor(threat_actor)
+                        if current.ttps is not None:
+                            for ttp in current.ttps:
+                                stix_package.add_ttp(ttp)
+                    except Exception as exception:
+                        traceback['fails'].append(f'{filename} - {exception.__str__()}')
+                if any(filename not in traceback.get('fails', []) for filename in input_files):
+                    _write_raw_stix(
+                        stix_package, name, namespace, org, return_format,
+                        overwrite
+                    )
+                    traceback.update(_generate_traceback(debug, parser, name))
+                return traceback
+            handler = AttributeCollectionHandler(return_format)
+            # The per-feature fragments hold converted content: they live in a
+            # scratch directory of their own, removed however the assembly ends
+            with TemporaryDirectory() as tmp_dir:
+                tmp_path = Path(tmp_dir)
+                for filename in input_files:
+                    try:
+                        parser.parse_json_file(filename)
+                        package = parser.stix_package
+                        for feature in _STIX1_features:
+                            values = getattr(package, feature)
+                            if values:
+                                content = globals()[f'write_{feature}'](values, return_format)
+                                if not content.strip():
+                                    continue
+                                fragment = handler.get_filename(feature)
+                                if fragment is None:
+                                    fragment = handler.set_feature(feature, uuid4())
+                                    with open(
+                                            tmp_path / fragment, 'wt',
+                                            encoding='utf-8',
+                                            opener=_private_opener) as f:
+                                        f.write(f'{handler.header(feature)}{content}')
+                                    continue
                                 with open(
-                                        tmp_path / fragment, 'wt',
+                                        tmp_path / fragment, 'at',
                                         encoding='utf-8',
                                         opener=_private_opener) as f:
-                                    f.write(f'{handler.header(feature)}{content}')
-                                continue
-                            with open(
-                                    tmp_path / fragment, 'at',
-                                    encoding='utf-8',
-                                    opener=_private_opener) as f:
-                                f.write(content)
-                except Exception as exception:
-                    traceback['fails'].append(f'{filename} - {exception.__str__()}')
-            if any(filename not in traceback.get('fails', []) for filename in input_files):
-                header, _, footer = stix1_attributes_framing(
-                    namespace, org, return_format, stix_package.version
+                                    f.write(content)
+                    except Exception as exception:
+                        traceback['fails'].append(f'{filename} - {exception.__str__()}')
+                if any(filename not in traceback.get('fails', []) for filename in input_files):
+                    header, _, footer = stix1_attributes_framing(
+                        namespace, org, return_format, stix_package.version
+                    )
+                    with _open_output(name, overwrite=overwrite) as output:
+                        output.write(header)
+                        for feature, fragment in handler.features.items():
+                            with open(tmp_path / fragment, 'rt', encoding='utf-8') as current:
+                                content = current.read() if return_format == 'xml' else current.read()[:-2]
+                            current_footer = handler.footer(feature)
+                            if return_format == 'json' and feature == list(handler.features)[-1]:
+                                current_footer = current_footer[:-2]
+                            output.write(f'{content}{current_footer}')
+                        output.write(footer)
+                    traceback.update(_generate_traceback(debug, parser, name))
+            return traceback
+        output_names = []
+        for filename in input_files:
+            try:
+                if isinstance(filename, str):
+                    filename = Path(filename).resolve()
+                parser.parse_json_file(filename)
+                name = _check_output(
+                    filename.parent, f'{filename.name}.out', output_dir
                 )
-                with _open_output(name, overwrite=overwrite) as output:
-                    output.write(header)
-                    for feature, fragment in handler.features.items():
-                        with open(tmp_path / fragment, 'rt', encoding='utf-8') as current:
-                            content = current.read() if return_format == 'xml' else current.read()[:-2]
-                        current_footer = handler.footer(feature)
-                        if return_format == 'json' and feature == list(handler.features)[-1]:
-                            current_footer = current_footer[:-2]
-                        output.write(f'{content}{current_footer}')
-                    output.write(footer)
-                traceback.update(_generate_traceback(debug, parser, name))
+                _write_raw_stix(
+                    parser.stix_package, name, namespace, org, return_format,
+                    overwrite
+                )
+                output_names.append(name)
+            except Exception as exception:
+                traceback['fails'].append(f'{filename} - {exception.__str__()}')
+        if output_names:
+            traceback.update(_generate_traceback(debug, parser, *output_names))
         return traceback
-    output_names = []
-    for filename in input_files:
-        try:
-            if isinstance(filename, str):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            name = _check_output(
-                filename.parent, f'{filename.name}.out', output_dir
-            )
-            _write_raw_stix(
-                parser.stix_package, name, namespace, org, return_format,
-                overwrite
-            )
-            output_names.append(name)
-        except Exception as exception:
-            traceback['fails'].append(f'{filename} - {exception.__str__()}')
-    if output_names:
-        traceback.update(_generate_traceback(debug, parser, *output_names))
-    return traceback
 
 
 def misp_event_collection_to_stix1(
@@ -265,100 +266,101 @@ def misp_event_collection_to_stix1(
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
     namespace = _validate_namespace(namespace)
-    _write_args = (namespace, org, return_format, overwrite)
-    parser = MISPtoSTIX1EventsParser(org, version)
-    if len(input_files) == 1:
-        filename = input_files[0]
-        try:
-            if not isinstance(filename, Path):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            name = _check_filename(
-                filename.parent, f'{filename.name}.out', output_dir, output_name
-            )
-            _write_raw_stix(parser.stix_package, name, *_write_args)
-            return _generate_traceback(debug, parser, name)
-        except Exception as exception:
-            return {'fails': [f'{filename} - {exception.__str__()}']}
-    traceback = defaultdict(list)
-    if single_output:
-        stix_package = _create_stix_package(org, version, header=False)
-        name = _check_filename(
-            _default_output_dir(*input_files),
-            _default_stix1_name(stix_package, return_format),
-            output_dir, output_name
-        )
-        if in_memory:
-            for filename in input_files:
-                try:
-                    if not isinstance(filename, Path):
-                        filename = Path(filename).resolve()
-                    parser.parse_json_file(filename)
-                    if parser.stix_package.related_packages is not None:
-                        for related_package in parser.stix_package.related_packages:
-                            stix_package.add_related_package(related_package)
-                    else:
-                        stix_package.add_related_package(parser.stix_package)
-                except Exception as exception:
-                    traceback['fails'].append(f'{filename} - {exception.__str__()}')
-            if any(filename not in traceback.get('fails', []) for filename in input_files):
-                _write_raw_stix(stix_package, name, *_write_args)
-                traceback.update(_generate_traceback(debug, parser, name))
-            return traceback
-        header, separator, footer = stix1_framing(
-            namespace, org, return_format, stix_package.version
-        )
-        written = False
-        with _open_output(name, overwrite=overwrite) as output:
+    with _scoped_id_namespace(namespace, org):
+        _write_args = (namespace, org, return_format, overwrite)
+        parser = MISPtoSTIX1EventsParser(org, version)
+        if len(input_files) == 1:
             filename = input_files[0]
             try:
                 if not isinstance(filename, Path):
                     filename = Path(filename).resolve()
                 parser.parse_json_file(filename)
-                content = write_events(parser.stix_package, return_format)
-                output.write(f'{header}{content}')
-                written = True
+                name = _check_filename(
+                    filename.parent, f'{filename.name}.out', output_dir, output_name
+                )
+                _write_raw_stix(parser.stix_package, name, *_write_args)
+                return _generate_traceback(debug, parser, name)
             except Exception as exception:
-                traceback['fails'].append(filename)
-            for filename in input_files[1:]:
+                return {'fails': [f'{filename} - {exception.__str__()}']}
+        traceback = defaultdict(list)
+        if single_output:
+            stix_package = _create_stix_package(org, version, header=False)
+            name = _check_filename(
+                _default_output_dir(*input_files),
+                _default_stix1_name(stix_package, return_format),
+                output_dir, output_name
+            )
+            if in_memory:
+                for filename in input_files:
+                    try:
+                        if not isinstance(filename, Path):
+                            filename = Path(filename).resolve()
+                        parser.parse_json_file(filename)
+                        if parser.stix_package.related_packages is not None:
+                            for related_package in parser.stix_package.related_packages:
+                                stix_package.add_related_package(related_package)
+                        else:
+                            stix_package.add_related_package(parser.stix_package)
+                    except Exception as exception:
+                        traceback['fails'].append(f'{filename} - {exception.__str__()}')
+                if any(filename not in traceback.get('fails', []) for filename in input_files):
+                    _write_raw_stix(stix_package, name, *_write_args)
+                    traceback.update(_generate_traceback(debug, parser, name))
+                return traceback
+            header, separator, footer = stix1_framing(
+                namespace, org, return_format, stix_package.version
+            )
+            written = False
+            with _open_output(name, overwrite=overwrite) as output:
+                filename = input_files[0]
                 try:
                     if not isinstance(filename, Path):
                         filename = Path(filename).resolve()
                     parser.parse_json_file(filename)
                     content = write_events(parser.stix_package, return_format)
-                    output.write(
-                        f'{separator}{content}' if written else content
-                    )
+                    output.write(f'{header}{content}')
                     written = True
                 except Exception as exception:
-                    traceback['fails'].append(
-                        f'{filename} - {exception.__str__()}'
-                    )
+                    traceback['fails'].append(filename)
+                for filename in input_files[1:]:
+                    try:
+                        if not isinstance(filename, Path):
+                            filename = Path(filename).resolve()
+                        parser.parse_json_file(filename)
+                        content = write_events(parser.stix_package, return_format)
+                        output.write(
+                            f'{separator}{content}' if written else content
+                        )
+                        written = True
+                    except Exception as exception:
+                        traceback['fails'].append(
+                            f'{filename} - {exception.__str__()}'
+                        )
+                if written:
+                    output.write(footer)
+                else:
+                    # No input file converted: the destination keeps whatever it
+                    # held rather than taking a header and a footer alone
+                    output.discard()
             if written:
-                output.write(footer)
-            else:
-                # No input file converted: the destination keeps whatever it
-                # held rather than taking a header and a footer alone
-                output.discard()
-        if written:
-            traceback.update(_generate_traceback(debug, parser, name))
+                traceback.update(_generate_traceback(debug, parser, name))
+            return traceback
+        output_names = []
+        for filename in input_files:
+            try:
+                if not isinstance(filename, Path):
+                    filename = Path(filename).resolve()
+                parser.parse_json_file(filename)
+                name = _check_output(
+                    filename.parent, f'{filename.name}.out', output_dir
+                )
+                _write_raw_stix(parser.stix_package, name, *_write_args)
+                output_names.append(name)
+            except Exception as exception:
+                traceback['fails'].append(f'{filename} - {exception.__str__()}')
+        if output_names:
+            traceback.update(_generate_traceback(debug, parser, *output_names))
         return traceback
-    output_names = []
-    for filename in input_files:
-        try:
-            if not isinstance(filename, Path):
-                filename = Path(filename).resolve()
-            parser.parse_json_file(filename)
-            name = _check_output(
-                filename.parent, f'{filename.name}.out', output_dir
-            )
-            _write_raw_stix(parser.stix_package, name, *_write_args)
-            output_names.append(name)
-        except Exception as exception:
-            traceback['fails'].append(f'{filename} - {exception.__str__()}')
-    if output_names:
-        traceback.update(_generate_traceback(debug, parser, *output_names))
-    return traceback
 
 
 def misp_collection_to_stix2(
@@ -492,20 +494,21 @@ def misp_to_stix1(
     if version not in _STIX1_valid_versions:
         version = _STIX1_default_version
     namespace = _validate_namespace(namespace)
-    parser = MISPtoSTIX1EventsParser(org, version)
-    try:
-        if not isinstance(filename, Path):
-            filename = Path(filename).resolve()
-        parser.parse_json_file(filename)
-        name = _check_filename(
-            filename.parent, f'{filename.name}.out', output_dir, output_name
-        )
-        _write_raw_stix(
-            parser.stix_package, name, namespace, org, return_format, overwrite
-        )
-    except Exception as exception:
-        return {'fails': [f'{filename} - {exception.__str__()}']}
-    return _generate_traceback(debug, parser, name)
+    with _scoped_id_namespace(namespace, org):
+        parser = MISPtoSTIX1EventsParser(org, version)
+        try:
+            if not isinstance(filename, Path):
+                filename = Path(filename).resolve()
+            parser.parse_json_file(filename)
+            name = _check_filename(
+                filename.parent, f'{filename.name}.out', output_dir, output_name
+            )
+            _write_raw_stix(
+                parser.stix_package, name, namespace, org, return_format, overwrite
+            )
+        except Exception as exception:
+            return {'fails': [f'{filename} - {exception.__str__()}']}
+        return _generate_traceback(debug, parser, name)
 
 
 def misp_to_stix2(filename: _files_type, debug: Optional[bool] = False,

--- a/misp_stix_converter/stix2misp/external_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix1_to_misp.py
@@ -20,12 +20,11 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
     def __init__(self):
         super().__init__()
         self._mapping = ExternalSTIX1toMISPMapping
-        self.__dns_objects = defaultdict(dict)
-        self.__dns_ips = []
 
     def parse_stix_package(self, cluster_distribution: Optional[int] = 0,
                            cluster_sharing_group_id: Optional[int] = None,
                            organisation_uuid: Optional[str] = None, **kwargs):
+        self._reset_bundle_state()
         self._set_parameters(**kwargs)
         self._set_single_event(True)
         self._set_cluster_distribution(
@@ -100,6 +99,14 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
             for ip, ip_attribute in self.dns_objects['ip'].items():
                 if ip not in self.dns_ips:
                     self.misp_event.add_attribute(**ip_attribute)
+
+    def _reset_bundle_state(self):
+        super()._reset_bundle_state()
+        # The DNS bookkeeping is only turned into MISP content once the whole
+        # package is parsed, so a second package inheriting it gets an event
+        # carrying the passive DNS records of the first one
+        self.__dns_objects = defaultdict(dict)
+        self.__dns_ips = []
 
     ############################################################################
     #                                PROPERTIES                                #

--- a/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
@@ -21,11 +21,9 @@ class InternalSTIX1toMISPParser(STIX1toMISPParser):
     def __init__(self):
         super().__init__()
         self._mapping = InternalSTIX1toMISPMapping
-        self.__dates = set()
-        self.__timestamps = set()
-        self.__titles = set()
 
     def parse_stix_package(self, **kwargs):
+        self._reset_bundle_state()
         self._set_parameters(**kwargs)
         # Every related package is merged into one MISP event - the titles,
         # dates and timestamps of all of them - so this parser has no per
@@ -127,6 +125,16 @@ class InternalSTIX1toMISPParser(STIX1toMISPParser):
         self.misp_event.info = ' - '.join(self.titles)
         self.misp_event.date = max(self.dates)
         self.misp_event.timestamp = max(self.timestamps)
+
+    def _reset_bundle_state(self):
+        super()._reset_bundle_state()
+        # Every related package of one document contributes its title, date and
+        # timestamp to the single event they are merged into - which makes them
+        # the state a second document must not inherit, or its event is named
+        # after both and dated from whichever is the later
+        self.__dates = set()
+        self.__timestamps = set()
+        self.__titles = set()
 
     ############################################################################
     #                                PROPERTIES                                #

--- a/misp_stix_converter/stix2misp/stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix1_to_misp.py
@@ -53,8 +53,9 @@ class StixObjectTypeError(Exception):
 class STIX1toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def __init__(self):
         super().__init__()
-        self.__galaxies = set()
-        self.__references = defaultdict(list)
+        # Every accumulator this parser keeps is created by the reset hook, so
+        # a fresh instance starts from the state a reused one is put back into
+        self._reset_bundle_state()
 
     def load_stix_package(self, stix_package: STIXPackage):
         self.__stix_package = stix_package
@@ -62,6 +63,17 @@ class STIX1toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def parse_stix_content(self, filename: Union[Path, str], **kwargs):
         self.__stix_package = load_stix1_package(filename)
         self.parse_stix_package(**kwargs)
+
+    def _reset_bundle_state(self):
+        # An instance parsing a second package must not carry the galaxies and
+        # references of the first one into the event it builds from it. Called
+        # at the top of `parse_stix_package` rather than at loading time, where
+        # the STIX 2 parsers reset: `parse_stix_content` sets the package
+        # itself instead of going through `load_stix_package`, so parsing is
+        # the one step every entry into a conversion takes.
+        super()._reset_bundle_state()
+        self.__galaxies = set()
+        self.__references = defaultdict(list)
 
     ############################################################################
     #                                PROPERTIES                                #

--- a/misp_stix_converter/tools/stix1_framing.py
+++ b/misp_stix_converter/tools/stix1_framing.py
@@ -3,11 +3,12 @@
 import json
 import re
 from ..misp_stix_mapping import Mapping
+from contextlib import contextmanager
 from datetime import datetime
 from mixbox import idgen
 from mixbox.namespaces import Namespace
 from stix.core import STIXHeader, STIXPackage
-from typing import Optional
+from typing import Iterator, Optional
 from uuid import UUID, uuid4
 
 # STIX header
@@ -155,7 +156,7 @@ def stix_xml_separator():
 def _create_stix_package(
         orgname: str, version: str,  header: Optional[bool] = True,
         uuid: Optional[UUID | str] = None) -> STIXPackage:
-    parsed_orgname = re.sub('[\W]+', '', orgname.replace(' ', '_'))
+    parsed_orgname = _parse_orgname(orgname)
     if uuid is None:
         uuid = uuid4()
     stix_package = STIXPackage(
@@ -173,14 +174,49 @@ def _create_stix_package(
 
 def _handle_namespaces(namespace: str, orgname: str) -> tuple:
     namespace = _validate_namespace(namespace)
-    parsed_orgname = re.sub('[\W]+', '', orgname.replace(' ', '_'))
+    parsed_orgname = _parse_orgname(orgname)
     namespaces = {namespace: parsed_orgname}
     namespaces.update(NS_DICT)
+    _set_id_namespace(namespace, parsed_orgname)
+    return namespaces
+
+
+def _parse_orgname(orgname: str) -> str:
+    return re.sub(r'[\W]+', '', orgname.replace(' ', '_'))
+
+
+@contextmanager
+def _scoped_id_namespace(namespace: str, orgname: str) -> Iterator[None]:
+    """Hold the mixbox identifier namespace for the duration of one export.
+
+    mixbox keeps the namespace on a module-level generator, so setting it is a
+    process-wide change: every STIX 1 object built anywhere in the process
+    takes its id prefix from whatever was set last. Setting it on entry is what
+    makes a conversion generate its own organisation's ids rather than the ids
+    of whichever export ran before it, and putting back what was found - on the
+    way out of a returning export and of a raising one alike - is what keeps
+    the change from outliving the export. Exports running *at the same time*
+    still share the one generator: STIX 1 export is not thread-safe, and cannot
+    be while mixbox holds the namespace globally.
+
+    :param namespace: the Export Namespace, already validated
+    :param orgname: the organisation name the identifier prefix comes from
+    """
+    # The public getters drop the schema location, so what is saved is the
+    # generator's own Namespace: the value put back is the value found
+    previous = idgen._get_generator().namespace
+    _set_id_namespace(namespace, _parse_orgname(orgname))
+    try:
+        yield
+    finally:
+        idgen.set_id_namespace(previous)
+
+
+def _set_id_namespace(namespace: str, parsed_orgname: str):
     try:
         idgen.set_id_namespace(Namespace(namespace, parsed_orgname))
     except TypeError:
         idgen.set_id_namespace(Namespace(namespace, parsed_orgname, 'MISP'))
-    return namespaces
 
 
 def _stix1_attributes_framing(namespace: str, orgname: str, return_format: str,

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -9,7 +9,10 @@ from misp_stix_converter import (InvalidMISPInputError, MISPtoSTIX1AttributesPar
                                  MISPtoSTIX1EventsParser, misp_attribute_collection_to_stix1,
                                  misp_event_collection_to_stix1, misp_to_stix1)
 from misp_stix_converter import misp_stix_converter as converter_module
-from misp_stix_converter.tools.stix1_framing import _handle_namespaces
+from misp_stix_converter.tools.stix1_framing import (
+    _handle_namespaces, _scoped_id_namespace)
+from mixbox import idgen
+from mixbox.namespaces import Namespace
 from pymisp import MISPEvent
 from shutil import copyfile
 from tempfile import TemporaryDirectory
@@ -95,7 +98,28 @@ class TestSTIX1InputContract(TestSTIX):
         self.assertIsNotNone(parser.stix_package)
 
 
-class TestSTIX1NamespaceParameter(TestSTIX):
+class _STIX1NamespaceTestCase(TestSTIX):
+    # What the two namespace test classes below share: the input files, the
+    # copy that keeps an export inside its temporary directory, and the
+    # process-global mixbox id namespace put back the way the suite found it
+    _DEFAULT_NAMESPACE = 'https://misp-project.org'
+
+    def setUp(self):
+        self._events_file = Path(__file__).parent / 'test_events_collection_1.json'
+        self._attributes_file = Path(__file__).parent / 'test_attributes_collection_1.json'
+
+    def tearDown(self):
+        # The exports restore the id namespace themselves; calling the framing
+        # helper directly does not, so the default goes back by hand
+        _handle_namespaces(self._DEFAULT_NAMESPACE, 'MISP')
+
+    def _copy_input(self, tmp_dir, input_file):
+        filename = Path(tmp_dir) / input_file.name
+        copyfile(input_file, filename)
+        return filename
+
+
+class TestSTIX1NamespaceParameter(_STIX1NamespaceTestCase):
     # Every STIX 1 export entry validates the `namespace` parameter - the
     # framing writes it into the root element as it stands - so a rejected
     # value produces no output at all.
@@ -111,22 +135,7 @@ class TestSTIX1NamespaceParameter(TestSTIX):
         '',
         None
     )
-    _DEFAULT_NAMESPACE = 'https://misp-project.org'
     _VALID_NAMESPACE = 'http://custom.example/misp'
-
-    def setUp(self):
-        self._events_file = Path(__file__).parent / 'test_events_collection_1.json'
-        self._attributes_file = Path(__file__).parent / 'test_attributes_collection_1.json'
-
-    def tearDown(self):
-        # Framing sets the process-global mixbox id namespace: put the default
-        # back, so the exports a custom namespace ran here stay contained
-        _handle_namespaces(self._DEFAULT_NAMESPACE, 'MISP')
-
-    def _copy_input(self, tmp_dir, input_file):
-        filename = Path(tmp_dir) / input_file.name
-        copyfile(input_file, filename)
-        return filename
 
     def _export_event(self, tmp_dir, **kwargs):
         filename = self._copy_input(tmp_dir, self._events_file)
@@ -200,6 +209,140 @@ class TestSTIX1NamespaceParameter(TestSTIX):
             ],
             'MISP'
         )
+
+
+class TestSTIX1IdNamespaceScope(_STIX1NamespaceTestCase):
+    # mixbox keeps the id namespace on a module-level generator, so what it
+    # holds decides the prefix of every STIX 1 id the process builds - both
+    # while an event is converted and while the package is serialised. An
+    # export therefore has to set its own and put back what it found.
+    _EXPORT_NAMESPACE = 'http://org-b.example'
+    _EXPORT_ORGNAME = 'OrgB'
+    _OTHER_NAMESPACE = 'http://org-a.example'
+    _OTHER_ORGNAME = 'OrgA'
+
+    def setUp(self):
+        super().setUp()
+        idgen.set_id_namespace(
+            Namespace(self._OTHER_NAMESPACE, self._OTHER_ORGNAME)
+        )
+
+    def _export_arguments(self):
+        return {
+            'namespace': self._EXPORT_NAMESPACE, 'org': self._EXPORT_ORGNAME
+        }
+
+    def _assert_namespace_is_restored(self):
+        self.assertEqual(idgen.get_id_namespace(), self._OTHER_NAMESPACE)
+        self.assertEqual(idgen.get_id_namespace_prefix(), self._OTHER_ORGNAME)
+
+    def _generated_id_spy(self, parser_class):
+        # An id created at the moment the input is converted takes the prefix
+        # every id that conversion builds takes
+        generated = []
+        parse_json_file = parser_class.parse_json_file
+
+        def spy(parser, filename):
+            generated.append(idgen.create_id('indicator'))
+            return parse_json_file(parser, filename)
+
+        return generated, patch.object(
+            parser_class, 'parse_json_file', autospec=True, side_effect=spy
+        )
+
+    def test_single_event_export_restores_the_previous_namespace(self):
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._copy_input(tmp_dir, self._events_file)
+            self.assertEqual(
+                misp_to_stix1(filename, **self._export_arguments()),
+                {'success': 1, 'results': [Path(f'{filename}.out')]}
+            )
+        self._assert_namespace_is_restored()
+
+    def test_event_collection_export_restores_the_previous_namespace(self):
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._copy_input(tmp_dir, self._events_file)
+            self.assertEqual(
+                misp_event_collection_to_stix1(
+                    filename, filename, single_output=True,
+                    output_dir=tmp_dir, **self._export_arguments()
+                )['success'],
+                1
+            )
+        self._assert_namespace_is_restored()
+
+    def test_attribute_collection_export_restores_the_previous_namespace(self):
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._copy_input(tmp_dir, self._attributes_file)
+            self.assertEqual(
+                misp_attribute_collection_to_stix1(
+                    filename, filename, single_output=True,
+                    output_dir=tmp_dir, **self._export_arguments()
+                )['success'],
+                1
+            )
+        self._assert_namespace_is_restored()
+
+    def test_an_export_recording_a_failure_restores_the_previous_namespace(self):
+        with TemporaryDirectory() as tmp_dir:
+            missing = Path(tmp_dir) / 'missing.json'
+            self.assertIn(
+                'fails', misp_to_stix1(missing, **self._export_arguments())
+            )
+        self._assert_namespace_is_restored()
+
+    def test_a_raising_export_restores_the_previous_namespace(self):
+        # An output file that already exists is refused by raising, from
+        # outside any `try`: the namespace goes back on that way out too
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._copy_input(tmp_dir, self._events_file)
+            taken = Path(tmp_dir) / 'taken.xml'
+            taken.write_text('mine')
+            with self.assertRaises(FileExistsError):
+                misp_event_collection_to_stix1(
+                    filename, filename, single_output=True,
+                    output_dir=tmp_dir, output_name=str(taken),
+                    **self._export_arguments()
+                )
+            self.assertEqual(taken.read_text(), 'mine')
+        self._assert_namespace_is_restored()
+
+    def test_an_export_converts_under_its_own_namespace(self):
+        # Before the scope existed the namespace was set at write time, after
+        # the input was converted, so the ids an export generated carried the
+        # *previous* export's prefix
+        for parser_class, function, input_file in (
+                (MISPtoSTIX1EventsParser, misp_to_stix1, self._events_file),
+                (MISPtoSTIX1EventsParser, misp_event_collection_to_stix1,
+                 self._events_file),
+                (MISPtoSTIX1AttributesParser,
+                 misp_attribute_collection_to_stix1, self._attributes_file)):
+            generated, spy = self._generated_id_spy(parser_class)
+            with TemporaryDirectory() as tmp_dir:
+                filename = self._copy_input(tmp_dir, input_file)
+                with spy:
+                    function(filename, **self._export_arguments())
+            self.assertEqual(len(generated), 1)
+            self.assertTrue(
+                generated[0].startswith(f'{self._EXPORT_ORGNAME}:'),
+                f'{function.__name__} generated {generated[0]}'
+            )
+
+    def test_an_export_leaves_an_enclosing_scope_generating_its_own_ids(self):
+        # The finding's interleaving scenario: an export for one organisation
+        # completes while another organisation's scope is still open
+        with _scoped_id_namespace(self._OTHER_NAMESPACE, self._OTHER_ORGNAME):
+            with TemporaryDirectory() as tmp_dir:
+                filename = self._copy_input(tmp_dir, self._events_file)
+                self.assertEqual(
+                    misp_to_stix1(filename, **self._export_arguments()),
+                    {'success': 1, 'results': [Path(f'{filename}.out')]}
+                )
+            self.assertTrue(
+                idgen.create_id('indicator').startswith(
+                    f'{self._OTHER_ORGNAME}:'
+                )
+            )
 
 
 class TestStix1Export(TestSTIX):

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -2,8 +2,11 @@
 # -*- coding: utf-8 -*-
 
 from cybox.core import Object, Observable, Observables, RelatedObject
+from cybox.objects.address_object import Address
 from cybox.objects.domain_name_object import DomainName
 from cybox.objects.file_object import File
+from cybox.objects.uri_object import URI
+from datetime import datetime
 from misp_stix_converter import stix_1_to_misp, STIXLoadingError
 from misp_stix_converter.tools import load_stix1_package, stix1_loading_helpers
 from mixbox.namespaces import NamespaceNotFoundError
@@ -18,6 +21,8 @@ from stix.common.related import RelatedPackage, RelatedPackages
 from stix.core import STIXHeader, STIXPackage
 from stix.incident import Incident
 from stix.incident.history import History, HistoryItem, JournalEntry
+from stix.indicator import Indicator
+from stix.threat_actor import ThreatActor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from ._test_stix import TestSTIX
@@ -25,6 +30,10 @@ from ._test_stix import TestSTIX
 _COA_UUID = '4c1e5f2a-8b3d-4a6c-9e7f-1d2b3c4d5e6f'
 _OBSERVABLE_UUID = '7a9b0c1d-2e3f-4a5b-8c9d-0e1f2a3b4c5d'
 _RELATED_UUID = '1b2c3d4e-5f6a-4b8c-9d0e-1f2a3b4c5d6e'
+_ACTOR_UUID = '5e6f7a8b-9c0d-4e1f-8a2b-3c4d5e6f7a8b'
+_DOMAIN_UUID = '2d3e4f5a-6b7c-4d8e-9f0a-1b2c3d4e5f6a'
+_IP_UUID = '3e4f5a6b-7c8d-4e9f-8a0b-1c2d3e4f5a6b'
+_URL_UUID = '4f5a6b7c-8d9e-4f0a-8b1c-2d3e4f5a6b7c'
 
 
 class TestSTIX1Import(TestSTIX):
@@ -63,14 +72,62 @@ class TestSTIX1Import(TestSTIX):
         file_object.related_objects.append(related_object)
         return Observable(file_object)
 
-    def _parse_external_package(self, stix_package):
-        parser = ExternalSTIX1toMISPParser()
+    @staticmethod
+    def _indicator(observable_object, uuid):
+        indicator = Indicator()
+        indicator.id_ = f'MISP:Indicator-{uuid}'
+        indicator.add_observable(Observable(observable_object))
+        return indicator
+
+    @classmethod
+    def _domain_indicator(cls, value):
+        domain = DomainName()
+        domain.value = value
+        domain_object = Object(domain)
+        domain_object.id_ = f'MISP:DomainName-{_DOMAIN_UUID}'
+        return cls._indicator(domain_object, _DOMAIN_UUID)
+
+    @classmethod
+    def _ip_indicator(cls, value):
+        address = Address()
+        address.address_value = value
+        address.category = 'ipv4-addr'
+        address.is_source = False
+        address_object = Object(address)
+        address_object.id_ = f'MISP:Address-{_IP_UUID}'
+        return cls._indicator(address_object, _IP_UUID)
+
+    @classmethod
+    def _url_indicator(cls, value):
+        """A URL Indicator resolving to the IP one above: the pair the parser
+        holds back in its DNS bookkeeping until the whole package is parsed,
+        then turns into a `passive-dns` object."""
+        uri = URI()
+        uri.value = value
+        uri.type_ = URI.TYPE_URL
+        uri_object = Object(uri)
+        uri_object.id_ = f'MISP:URI-{_URL_UUID}'
+        related_object = RelatedObject()
+        related_object.idref = f'MISP:Address-{_IP_UUID}'
+        related_object.relationship = 'Resolved_To'
+        uri_object.related_objects.append(related_object)
+        return cls._indicator(uri_object, _URL_UUID)
+
+    @staticmethod
+    def _threat_actor(title):
+        threat_actor = ThreatActor()
+        threat_actor.id_ = f'MISP:ThreatActor-{_ACTOR_UUID}'
+        threat_actor.title = title
+        return threat_actor
+
+    def _parse_external_package(self, stix_package, parser=None):
+        parser = parser or ExternalSTIX1toMISPParser()
         parser.load_stix_package(stix_package)
         parser.parse_stix_package()
         return parser
 
-    def _parse_internal_package(self, stix_package):
-        parser = InternalSTIX1toMISPParser()
+    def _parse_internal_package(self, stix_package, parser=None):
+        parser = parser or InternalSTIX1toMISPParser()
         parser.load_stix_package(stix_package)
         parser.parse_stix_package()
         return parser
@@ -103,12 +160,15 @@ class TestSTIX1Import(TestSTIX):
         return filename
 
     @classmethod
-    def _internal_package(cls, incident, inner_title=None, outer_title=None):
+    def _internal_package(cls, incident, inner_title=None, outer_title=None,
+                          threat_actor=None):
         """Wrap an Incident the way the MISP STIX 1 export does: one related
         package per event, each carrying its own header, inside a wrapper
         package carrying the collection-level header."""
         inner_package = STIXPackage()
         inner_package.add_incident(incident)
+        if threat_actor is not None:
+            inner_package.add_threat_actor(threat_actor)
         if inner_title is not None:
             inner_package.stix_header = cls._stix_header(inner_title)
         stix_package = STIXPackage()
@@ -553,3 +613,98 @@ class TestSTIX1Import(TestSTIX):
         self.assertEqual(
             parser.misp_event.info, 'Imported from external STIX 1.1.1 Package'
         )
+
+    ############################################################################
+    #                         PARSER STATE ISOLATION.                          #
+    ############################################################################
+
+    def _external_package_with_state(self):
+        """A package exercising every accumulator the External parser keeps: the
+        DNS bookkeeping (the URL/IP pair), the references (the related object of
+        an observable with no value of its own) and the galaxies."""
+        stix_package = STIXPackage()
+        stix_package.add_indicator(self._url_indicator('http://evil.example/a'))
+        stix_package.add_indicator(self._ip_indicator('198.51.100.4'))
+        stix_package.add_threat_actor(self._threat_actor('APT-A'))
+        stix_package.observables = Observables(
+            [self._observable_with_related_object()]
+        )
+        return stix_package
+
+    @staticmethod
+    def _event_content(misp_event):
+        # A package with no timestamp of its own leaves the event without a
+        # date and a timestamp at all, so neither can simply be read
+        return {
+            'info': misp_event.info,
+            'date': str(getattr(misp_event, 'date', None)),
+            'timestamp': getattr(misp_event, 'timestamp', None),
+            'attributes': sorted(
+                (attribute.type, attribute.value)
+                for attribute in misp_event.attributes
+            ),
+            'objects': sorted(
+                (misp_object.name, attribute.object_relation, attribute.value)
+                for misp_object in misp_event.objects
+                for attribute in misp_object.attributes
+            )
+        }
+
+    def test_external_parser_reused_for_a_second_package_starts_clean(self):
+        """The event a reused parser builds from a package has to be the event a
+        fresh parser builds from it: the first package's DNS bookkeeping,
+        references and galaxies are its own, and a second package inheriting
+        them takes in content no document of its own ever carried."""
+        first = self._external_package_with_state()
+        second = STIXPackage()
+        second.add_indicator(self._domain_indicator('circl.lu'))
+        expected = self._event_content(
+            self._parse_external_package(second).misp_event
+        )
+        parser = self._parse_external_package(first)
+        # the first package's own event is the one it gets on a fresh parser
+        self.assertEqual(
+            self._event_content(parser.misp_event),
+            self._event_content(
+                self._parse_external_package(first).misp_event
+            )
+        )
+        self._parse_external_package(second, parser)
+        self.assertEqual(self._event_content(parser.misp_event), expected)
+        self.assertEqual(parser.galaxies, set())
+        self.assertEqual(parser.references, {})
+        self.assertEqual(parser.dns_objects, {})
+        self.assertEqual(parser.dns_ips, [])
+
+    def test_internal_parser_reused_for_a_second_package_starts_clean(self):
+        """The Internal parser merges every related package of one document
+        into one event - the titles, dates and timestamps of all of them - so a
+        reused instance has to drop them between documents, or the second event
+        is named after both and dated from whichever is the later."""
+        first_incident = Incident()
+        first_incident.title = 'Event A'
+        first_incident.timestamp = datetime(2026, 7, 1, 12, 0)
+        first = self._internal_package(
+            first_incident, threat_actor=self._threat_actor('APT-A')
+        )
+        second_incident = Incident()
+        second_incident.title = 'Event B'
+        second_incident.timestamp = datetime(2026, 1, 15, 8, 0)
+        second = self._internal_package(second_incident)
+        expected = self._event_content(
+            self._parse_internal_package(second).misp_event
+        )
+        parser = self._parse_internal_package(first)
+        # the first package's own event is the one it gets on a fresh parser
+        self.assertEqual(
+            self._event_content(parser.misp_event),
+            self._event_content(
+                self._parse_internal_package(first).misp_event
+            )
+        )
+        self._parse_internal_package(second, parser)
+        self.assertEqual(self._event_content(parser.misp_event), expected)
+        self.assertEqual(parser.misp_event.info, 'Event B')
+        self.assertEqual(parser.galaxies, set())
+        self.assertEqual(parser.dates, {second_incident.timestamp.date()})
+        self.assertEqual(parser.titles, {'Event B'})


### PR DESCRIPTION
## Description

Two ways one STIX 1 conversion could reach into the next one in the same process: a parser instance reused for a second package kept everything the first one put on it, and the identifier namespace an export runs under was a process-wide global set after the conversion rather than around it. Two tickets, four commits, both conversion directions, STIX 1 only.

## The two fixes

**#101 — a parser reused for a second package started with the first one's content.** The accumulators the STIX 1 parsers keep live on the instance, and nothing cleared them between packages, so the second event took in content no document of its own carried: the External parser's DNS bookkeeping, held back until the whole package is parsed and only then turned into `passive-dns` objects; the Internal parser's titles, dates and timestamps, which every related package of one document contributes to — an event named after both documents, dated from whichever is the later, and carrying the other one's passive DNS records. The galaxies and the references, shared by both parsers, went the same way. This is the STIX 1 counterpart of the STIX 2 galaxy leak fixed under S9-01, testable now that the STIX 1 import suite exists.

All three parsers gain the `_reset_bundle_state` hook the STIX 2 parsers have, and each parser's accumulators are created *by* the hook rather than in `__init__`, so a fresh instance and a reused one start from the same state — the fresh path exercises the reset code rather than duplicating it. The hook is called at the top of `parse_stix_package` rather than at loading time, where the STIX 2 parsers reset: `parse_stix_content` sets the package itself instead of going through `load_stix_package`, so parsing is the one step every entry into a conversion takes.

The entry functions build a parser per file, so nothing in the library was hitting this. The reuse it makes safe is the one API consumers do.

**#102 — ids took whichever organisation the previous export left behind.** mixbox keeps the identifier namespace on a module-level generator, and the STIX 1 export set it inside `_handle_namespaces`, which runs at *write* time — after the input has been converted. Every identifier a conversion generated therefore carried the previous export's organisation prefix, and the value stayed set once the export returned, so a caller generating ids of its own afterwards got that same prefix. The finding described the misattribution as a threading problem; it is reachable sequentially. The JSON return format gained the most: it never called `_handle_namespaces` at all, so a JSON export had never set the namespace.

`_scoped_id_namespace` in `tools/stix1_framing.py` saves the `Namespace` in force, sets the export's own, and puts the saved one back in a `finally`. `misp_to_stix1`, `misp_event_collection_to_stix1` and `misp_attribute_collection_to_stix1` each wrap their whole body in it, entered right after `_validate_namespace` so an invalid namespace still raises before the global is touched. mixbox ships `idgen.temp_id_namespace` for exactly this and it is broken — its `finally` hands the setter a dict, raising `ValueError: Must be a Namespace object` — hence a local context manager.

Concurrent exports still share the one generator and cannot be separated while mixbox holds the namespace globally. That limitation is now written down in the README rather than implied.

## What this does not change

**No shipped identifier changes.** 272 `create_id` calls fire during one export of `misp_test_events.json` and none of the results reach the output — the converter overwrites every id from `_orgname_id`. The parse-time prefix is latent today; what the scope protects is the caller's own generated ids, ids generated by a nested export, and any future converter path that leaves an id to mixbox.

**The public framing helpers keep the old contract on purpose.** `stix1_framing` and `stix1_attributes_framing` are in `tools/__init__.py`'s `__all__` and still set the namespace without restoring it, because leaving it set is what a direct caller gets today, and a bare `MISPtoSTIX1EventsParser` never sets it at all. Making `_handle_namespaces` pure would give one choke point but would silently change both. The boundary is documented instead — the README names which paths open a scope and which leave the namespace to the caller. Whether that asymmetry deserves a follow-up ticket is left open.

## Behaviour changes for library consumers

- A STIX 1 export through the three entry functions no longer leaves the identifier namespace set after it returns. A caller that relied on that side effect to generate ids afterwards must set the namespace itself, or call the `stix1_framing` helpers, which still leave it set.
- A parser instance reused across packages no longer accumulates across them. A caller that deliberately merged several packages onto one instance gets one event per package instead.

## Tests

Nine tests, each measured against the unfixed code.

On the import side, one parser instance converting two packages produces the same two events as two fresh instances, for the Internal and the External parser — the External fixture exercises every accumulator that parser keeps (the URL/IP pair the DNS bookkeeping holds back, a related object with no value of its own, a threat actor for the galaxies), the Internal one two documents with distinct titles, dates and timestamps.

On the export side, all three entry functions restore the namespace they found; an export converts under its own namespace rather than the previous one's; an export nested inside a caller's scope leaves that scope generating its own ids again; and the namespace is restored whether the export raises or records the failure. Six of the seven were measured red against a no-op scope. The seventh — the recorded-failure one — passes either way, since a parse failure never reached the write-time set; it is kept as the counterpart to the raising one, which lands on the `_open_output` refusal sitting outside every `try`.

Fixes #101
Fixes #102
