### PR TITLE
Refuse an oversized STIX document before it is parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ STIX 1 specific arguments:
 ##### Import parameters
 
 ```bash
-usage: misp_stix_converter import [-h] -f FILE [FILE ...] [-v {1,2}] [-s] [-o OUTPUT_NAME] [--output-dir OUTPUT_DIR] [--overwrite] [-d {0,1,2,3,4}] [-sg SHARING_GROUP] [--galaxies-as-tags]
+usage: misp_stix_converter import [-h] -f FILE [FILE ...] [-v {1,2}] [-s] [-o OUTPUT_NAME] [--output-dir OUTPUT_DIR] [--overwrite] [--max-input-size MB] [-d {0,1,2,3,4}] [-sg SHARING_GROUP] [--galaxies-as-tags]
                                   [--no-force-galaxy-cluster]
                                   [--org-uuid ORG_UUID] [-cd {0,1,2,3,4}] [-csg CLUSTER_SHARING_GROUP] [-t TITLE] [-p PRODUCER] [-c CONFIG] [-u URL] [-a API_KEY] [--skip-ssl]
 
@@ -179,6 +179,8 @@ options:
   --output-dir OUTPUT_DIR
                         Output directory - default is the directory the input files come from. Created if it does not exist.
   --overwrite           Replace an output file that already exists - without it a conversion writing onto an existing file fails and leaves it as it is.
+  --max-input-size MB   Maximum accepted input size, in MB - a document larger than this is refused before it is parsed (default is 100). Use 0 to turn the limit off: conversion costs 2 to 7 times the
+                        input size in memory, and a few seconds of CPU per MB of STIX 2.
   -d, --distribution {0,1,2,3,4}
                         Distribution level for the imported MISP content (default is 0) - 0: Your organisation only - 1: This community only - 2: Connected communities - 3: All communities - 4: Sharing Group
   -sg, --sharing-group SHARING_GROUP
@@ -201,6 +203,47 @@ options:
                         Authentication key to connect to your MISP instance.
   --skip-ssl            Skip SSL certificate checking when connecting to your MISP instance.
 ```
+
+#### Conversion cost and input limits
+
+An import parses the document it is given in full before it converts it, so the
+cost of a conversion is decided by the size of the input:
+
+- **Memory**: 2 to 7 times the input size, on top of whatever the caller already
+  holds - the whole document is materialised, and nothing streams.
+- **CPU**: a few seconds of a single core per MB of STIX 2 (measured between
+  1.9 and 6.5 s/MB on indicator-heavy bundles, growing linearly with the number
+  of objects). A 100 MB TAXII poll is therefore several CPU-minutes of work,
+  produced by whoever uploads it for the price of the upload.
+
+Both STIX loaders refuse a document above a maximum input size **before parsing
+it**, so an oversized document costs a `stat()` rather than a full parse. The
+default is **100 MB**, and the caller raises it - or turns it off with `0` - per
+conversion:
+
+```python
+from misp_stix_converter import stix_2_to_misp
+
+# a 250 MB bundle this caller knows it wants
+stix_2_to_misp('bundle.json', max_size=250 * 1024 * 1024)
+# no limit at all
+stix_2_to_misp('bundle.json', max_size=0)
+```
+
+`max_size` is accepted by `stix_1_to_misp`, `stix1_to_misp_instance`,
+`stix_2_to_misp`, `stix2_to_misp_instance`, by the parsers'
+`parse_stix_content()` and by the loading helpers themselves
+(`load_stix1_package`, `load_stix2_file`, and `load_stix2_content` for the
+serialised content it is given as a string or a `BytesIO` - a `dict` or `list`
+the caller already built is past the point a limit could save anything); the
+command line names the same limit in MB with `--max-input-size`. A document
+above the limit is reported as an error, and raises `STIXInputSizeError` (a
+`STIXLoadingError`) for the callers that use the library directly.
+
+The limit bounds one conversion, not the load a host accepts: since the cost is
+linear in the input size and paid entirely in one worker, an integrator running
+imports concurrently - MISP core included - should also cap how many run at
+once.
 
 ### In Python scripts
 

--- a/misp_stix_converter/__init__.py
+++ b/misp_stix_converter/__init__.py
@@ -2,7 +2,7 @@ __version__ = '2026.7.8'
 
 import argparse
 from .misp2stix import InvalidMISPInputError  # noqa
-from .tools import STIXLoadingError  # noqa
+from .tools import STIXInputSizeError, STIXLoadingError  # noqa
 from .misp2stix import MISPtoSTIX1AttributesParser, MISPtoSTIX1EventsParser  # noqa
 from .misp2stix import MISPtoSTIX1Mapping  # noqa
 from .misp2stix import MISPtoSTIX20Parser, MISPtoSTIX21Parser  # noqa
@@ -21,6 +21,18 @@ from .stix2misp import MissingSTIXContentError  # noqa
 from .stix2misp import STIX2PatternParser  # noqa
 from .stix2misp import MISP_org_uuid  # noqa
 from pathlib import Path
+
+
+def _max_input_size(value: str) -> int:
+    # 0 turns the limit off, and nothing below it means anything: without this
+    # `--max-input-size -1` would silently convert without a limit
+    size = int(value)
+    if size < 0:
+        raise argparse.ArgumentTypeError(
+            'the maximum input size cannot be negative - use 0 to turn the '
+            'limit off'
+        )
+    return size
 
 
 def _handle_return_message(traceback):
@@ -142,6 +154,13 @@ def main():
         help='Replace an output file that already exists - without it a '
              'conversion writing onto an existing file fails and leaves it '
              'as it is.'
+    )
+    import_parser.add_argument(
+        '--max-input-size', type=_max_input_size, default=None, metavar='MB',
+        help='Maximum accepted input size, in MB - a document larger than '
+             'this is refused before it is parsed (default is 100). Use 0 to '
+             'turn the limit off: conversion costs 2 to 7 times the input '
+             'size in memory, and a few seconds of CPU per MB of STIX 2.'
     )
     import_parser.add_argument(
         '--classification', choices=['internal', 'external'], default=None,

--- a/misp_stix_converter/misp_stix_converter.py
+++ b/misp_stix_converter/misp_stix_converter.py
@@ -547,6 +547,7 @@ def stix_1_to_misp(filename: _files_type,
                    distribution: Optional[int] = 0,
                    force_contextual_data: Optional[bool] = False,
                    galaxies_as_tags: Optional[bool] = False,
+                   max_size: Optional[int] = None,
                    organisation_uuid: Optional[str] = MISP_org_uuid,
                    output_dir: Optional[_files_type]=None,
                    output_name: Optional[_files_type]=None,
@@ -559,7 +560,7 @@ def stix_1_to_misp(filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        stix_package = load_stix1_package(filename)
+        stix_package = load_stix1_package(filename, max_size=max_size)
         detected = is_stix1_from_misp(stix_package)
         parser, args = get_stix1_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -601,6 +602,7 @@ def stix1_to_misp_instance(misp: PyMISP, filename: _files_type,
                            distribution: Optional[int] = 0,
                            force_contextual_data: Optional[bool] = False,
                            galaxies_as_tags: Optional[bool] = False,
+                           max_size: Optional[int] = None,
                            organisation_uuid: Optional[str] = MISP_org_uuid,
                            producer: Optional[str] = None,
                            sharing_group_id: Optional[int] = None,
@@ -610,7 +612,7 @@ def stix1_to_misp_instance(misp: PyMISP, filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        stix_package = load_stix1_package(filename)
+        stix_package = load_stix1_package(filename, max_size=max_size)
         detected = is_stix1_from_misp(stix_package)
         parser, args = get_stix1_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -654,6 +656,7 @@ def stix_2_to_misp(filename: _files_type,
                    distribution: Optional[int] = 0,
                    force_contextual_data: Optional[bool] = False,
                    galaxies_as_tags: Optional[bool] = False,
+                   max_size: Optional[int] = None,
                    organisation_uuid: Optional[str] = MISP_org_uuid,
                    output_dir: Optional[_files_type]=None,
                    output_name: Optional[_files_type]=None,
@@ -666,7 +669,7 @@ def stix_2_to_misp(filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        bundle = load_stix2_file(filename)
+        bundle = load_stix2_file(filename, max_size=max_size)
         detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
         parser, args = get_stix2_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -708,6 +711,7 @@ def stix2_to_misp_instance(misp: PyMISP, filename: _files_type,
                            distribution: Optional[int] = 0,
                            force_contextual_data: Optional[bool] = False,
                            galaxies_as_tags: Optional[bool] = False,
+                           max_size: Optional[int] = None,
                            organisation_uuid: Optional[str] = MISP_org_uuid,
                            producer: Optional[str] = None,
                            sharing_group_id: Optional[int] = None,
@@ -717,7 +721,7 @@ def stix2_to_misp_instance(misp: PyMISP, filename: _files_type,
     if isinstance(filename, str):
         filename = Path(filename).resolve()
     try:
-        bundle = load_stix2_file(filename)
+        bundle = load_stix2_file(filename, max_size=max_size)
         detected = is_stix2_from_misp(getattr(bundle, 'objects', []))
         parser, args = get_stix2_parser(
             detected if from_misp is None else from_misp, distribution,
@@ -816,6 +820,13 @@ def _stix_to_misp(args):
     return _process_stix_to_misp_files(args)
 
 
+def _max_size_from_args(args) -> Optional[int]:
+    # the command line names a size in MB, the library a size in bytes
+    if args.max_input_size is None:
+        return None
+    return args.max_input_size * 1024 * 1024
+
+
 def _process_stix_to_misp_files(args) -> dict:
     results = defaultdict(dict)
     success = []
@@ -828,6 +839,7 @@ def _process_stix_to_misp_files(args) -> dict:
         'distribution': args.distribution,
         'force_contextual_data': not args.no_force_contextual_data,
         'galaxies_as_tags': args.galaxies_as_tags,
+        'max_size': _max_size_from_args(args),
         'output_dir': args.output_dir,
         'organisation_uuid': args.org_uuid,
         'output_name': args.output_name,
@@ -878,6 +890,7 @@ def _process_stix_to_misp_instance(misp: PyMISP, args) -> dict:
         'distribution': args.distribution,
         'force_contextual_data': not args.no_force_contextual_data,
         'galaxies_as_tags': args.galaxies_as_tags,
+        'max_size': _max_size_from_args(args),
         'organisation_uuid': args.org_uuid,
         'producer': args.producer,
         'sharing_group_id': args.sharing_group,

--- a/misp_stix_converter/stix2misp/stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix1_to_misp.py
@@ -23,7 +23,7 @@ from pymisp import MISPAttribute, MISPObject
 from stix.coa import CourseOfAction
 from stix.core import STIXPackage
 from stix.threat_actor import ThreatActor
-from typing import Union
+from typing import Optional, Union
 from uuid import uuid4
 
 _ADDRESS_TYPING = Union[address_object.Address, address_object.EmailAddress]
@@ -60,8 +60,9 @@ class STIX1toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
     def load_stix_package(self, stix_package: STIXPackage):
         self.__stix_package = stix_package
 
-    def parse_stix_content(self, filename: Union[Path, str], **kwargs):
-        self.__stix_package = load_stix1_package(filename)
+    def parse_stix_content(self, filename: Union[Path, str],
+                           max_size: Optional[int] = None, **kwargs):
+        self.__stix_package = load_stix1_package(filename, max_size=max_size)
         self.parse_stix_package(**kwargs)
 
     def _reset_bundle_state(self):

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from ..tools.exceptions import STIXLoadingError, _reduce_input_path
+from ..tools.exceptions import (
+    STIXInputSizeError, STIXLoadingError, _reduce_input_path)
 from ..tools.stix2_loading_helpers import load_stix2_file
 from .exceptions import (
     MarkingDefinitionLoadingError, MissingSTIXContentError,
@@ -185,9 +186,14 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._load_stix_bundle(bundle)
         self._set_indicator_references()
 
-    def parse_stix_content(self, filename: str, **kwargs):
+    def parse_stix_content(self, filename: str,
+                           max_size: Optional[int] = None, **kwargs):
         try:
-            bundle = load_stix2_file(filename)
+            bundle = load_stix2_file(filename, max_size=max_size)
+        except STIXInputSizeError:
+            # the size limit reports the limit it enforced, not what the
+            # document it never read holds
+            raise
         except Exception as exception:
             raise STIXLoadingError(
                 'Error while loading the STIX 2 content: '

--- a/misp_stix_converter/tools/__init__.py
+++ b/misp_stix_converter/tools/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .exceptions import STIXLoadingError  # noqa
+from .exceptions import STIXInputSizeError, STIXLoadingError  # noqa
 from .stix1_framing import stix1_attributes_framing, stix1_framing  # noqa
 from .stix1_loading_helpers import load_stix1_package  # noqa
 from .stix1_to_misp_helpers import get_stix1_parser, is_stix1_from_misp  # noqa
@@ -17,7 +17,7 @@ from .stix2_loading_helpers import load_stix2_content, load_stix2_file  # noqa
 from .stix2_to_misp_helpers import get_stix2_parser, is_stix2_from_misp  # noqa
 
 __all__ = [
-    'STIXLoadingError',
+    'STIXInputSizeError', 'STIXLoadingError',
     'get_stix1_parser', 'is_stix1_from_misp', 'load_stix1_package',
     'get_stix2_parser', 'is_stix2_from_misp', 'load_stix2_content', 'load_stix2_file',
     'stix1_attributes_framing', 'stix1_framing',

--- a/misp_stix_converter/tools/exceptions.py
+++ b/misp_stix_converter/tools/exceptions.py
@@ -12,6 +12,11 @@ class STIXLoadingError(Exception):
         self.message = message
 
 
+class STIXInputSizeError(STIXLoadingError):
+    """Raised when an input document is larger than the accepted maximum,
+    instead of parsing it to find out what it holds."""
+
+
 def _reduce_input_path(message: str, filename) -> str:
     """Underlying parsing errors embed the resolved input path - keep the
     operator-facing text down to the file name."""

--- a/misp_stix_converter/tools/input_limits.py
+++ b/misp_stix_converter/tools/input_limits.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
+from .exceptions import STIXInputSizeError
+from pathlib import Path
+from typing import Optional
+
+# The documented default: a document larger than this is refused before it is
+# parsed. Conversion costs 2 to 7 times the input size in memory - and, for
+# STIX 2, about 4.4 seconds of CPU per megabyte - so the cap bounds what one
+# document can make the converting host spend on it. Raisable per call, and
+# `max_size=0` turns the limit off.
+_MAX_INPUT_SIZE = 100 * 1024 * 1024
+
+# How much of a string is encoded at a time to size it: enough that the count
+# costs one pass, little enough that it never holds a second copy of the
+# document it is sizing.
+_SIZING_CHUNK_SIZE = 1024 * 1024
+
+
+def _utf8_size(content: str) -> int:
+    """The number of bytes a string holds - what the limit is expressed in -
+    without encoding the whole of it at once: an ASCII document is its own
+    length, and anything else is counted a chunk at a time."""
+    if content.isascii():
+        return len(content)
+    return sum(
+        len(content[index:index + _SIZING_CHUNK_SIZE].encode('utf-8'))
+        for index in range(0, len(content), _SIZING_CHUNK_SIZE)
+    )
+
+
+def _check_input_size(size: int, max_size: Optional[int]) -> None:
+    """`max_size` is the caller's limit in bytes, `None` the documented default
+    and anything at or below 0 no limit at all."""
+    limit = _MAX_INPUT_SIZE if max_size is None else max_size
+    if limit <= 0 or size <= limit:
+        return
+    raise STIXInputSizeError(
+        'The STIX content is larger than the maximum accepted input size '
+        f'({limit} bytes) - raise the `max_size` argument to convert it anyway'
+    )
+
+
+def _check_input_file_size(filename, max_size: Optional[int]) -> None:
+    """The size comes from the filesystem, so a document above the limit is
+    refused without a byte of it being read. A file whose size cannot be read
+    is left to the parser, which reports what makes it unreadable."""
+    try:
+        size = Path(filename).stat().st_size
+    except (OSError, TypeError, ValueError):
+        return
+    _check_input_size(size, max_size)

--- a/misp_stix_converter/tools/stix1_loading_helpers.py
+++ b/misp_stix_converter/tools/stix1_loading_helpers.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 
 from .exceptions import STIXLoadingError, _reduce_input_path
+from .input_limits import _check_input_file_size
+from lxml import etree
 from mixbox.namespaces import NamespaceNotFoundError
 from pathlib import Path
 from stix.core import STIXPackage
+from stix.xmlconst import TAG_STIX_PACKAGE
+from typing import Optional
+
+# How much of a document is read at a time while looking for its root element.
+# One chunk holds the whole start tag of any ordinary document; the loop below
+# exists for the ones carrying an unusual number of attributes on it.
+_ROOT_ELEMENT_CHUNK_SIZE = 8192
 
 
 def _update_namespaces():
@@ -20,18 +29,56 @@ def _update_namespaces():
         register_namespace(namespace)
 
 
-def load_stix1_package(filename, tries=0):
+def _check_stix1_root_element(filename):
+    """`mixbox` builds the whole document tree before it looks at the root
+    element, so XML that is not a STIX package at all is materialised - at 2 to
+    7 times its size in memory - only to be refused. Read the root element on
+    its own instead, and refuse the document on what `mixbox` would refuse it
+    on: an exact tag match against the one tag it supports.
+
+    The settings keep the properties `mixbox.xml.get_xml_parser()` relies on
+    for the real parse: no entity is resolved, no DTD is loaded and nothing is
+    fetched from the network. `huge_tree` stays off, unlike there, since a peek
+    has no reason to accept an oversized start tag - a document lxml refuses to
+    read here simply falls through to the parser, which reports what is wrong
+    with it. Only a root element positively identified as something else is
+    refused."""
+    parser = etree.XMLPullParser(
+        events=('start',), resolve_entities=False, no_network=True,
+        load_dtd=False, huge_tree=False
+    )
+    try:
+        with open(filename, 'rb') as f:
+            while chunk := f.read(_ROOT_ELEMENT_CHUNK_SIZE):
+                parser.feed(chunk)
+                for _, element in parser.read_events():
+                    if element.tag == TAG_STIX_PACKAGE:
+                        return
+                    raise STIXLoadingError(
+                        f'Document root element ({element.tag}) is not the '
+                        f'STIX 1 package root element ({TAG_STIX_PACKAGE})'
+                    )
+    except (OSError, TypeError, ValueError, etree.LxmlError):
+        return
+
+
+def load_stix1_package(filename, tries=0, max_size: Optional[int] = None):
     # lxml treats a plain string argument as a filename *or* a URL - resolving
     # it here keeps `file://` targets out of the parser for every caller
     if isinstance(filename, str):
         filename = Path(filename).resolve()
+    if tries == 0:
+        # both checks are the document's own, so the namespace retry below does
+        # not run them again
+        _check_input_file_size(filename, max_size)
+        _check_stix1_root_element(filename)
     try:
         return STIXPackage.from_xml(filename)
     except NamespaceNotFoundError as error:
         if tries > 0:
             raise STIXLoadingError('Cannot handle STIX namespace') from error
         _update_namespaces()
-        return load_stix1_package(filename, tries + 1)
+        return load_stix1_package(filename, tries + 1, max_size=max_size)
     except NotImplementedError as error:
         raise STIXLoadingError('Missing python library: stix_edh') from error
     except ImportError as error:

--- a/misp_stix_converter/tools/stix2_loading_helpers.py
+++ b/misp_stix_converter/tools/stix2_loading_helpers.py
@@ -2,6 +2,8 @@
 
 import json
 from .exceptions import STIXLoadingError
+from .input_limits import (
+    _check_input_file_size, _check_input_size, _utf8_size)
 from io import BytesIO
 from stix2.exceptions import InvalidValueError, ParseError
 from stix2.parsing import dict_to_stix2, parse as stix2_parser
@@ -85,32 +87,33 @@ def _handle_stix2_loading_error(
 
 
 def load_stix2_content(stix_content: BytesIO | dict | list | str,
-                       invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
+                       invalid_objects: Optional[dict] = None,
+                       max_size: Optional[int] = None) -> _BUNDLE_TYPING:
     if invalid_objects is None:
         invalid_objects = {}
     duplicate_invalid_ids: set = set()
-    if isinstance(stix_content, dict):
-        try:
-            bundle = dict_to_stix2(
-                stix_content, allow_custom=True, interoperability=True
-            )
-        except (InvalidValueError, KeyError, ParseError, ValueError):
-            # the 2.1 code path in `stix2` reports an object without a `type`
-            # property as a bare KeyError where the 2.0 one uses ParseError
-            bundle = _handle_stix2_loading_error(
-                stix_content, invalid_objects, duplicate_invalid_ids
-            )
-    else:
+    if not isinstance(stix_content, (dict, list)):
         if isinstance(stix_content, BytesIO):
+            # the buffer is sized before it is decoded: decoding an oversized
+            # document is already a copy of it
+            _check_input_size(stix_content.getbuffer().nbytes, max_size)
             stix_content = stix_content.getvalue().decode('utf-8')
-        try:
-            bundle = stix2_parser(
-                stix_content, allow_custom=True, interoperability=True
-            )
-        except (InvalidValueError, KeyError, ParseError, ValueError):
-            bundle = _handle_stix2_loading_error(
-                json.loads(stix_content), invalid_objects, duplicate_invalid_ids
-            )
+        else:
+            _check_input_size(_utf8_size(stix_content), max_size)
+        # `stix2`'s own parser deserialises the JSON and builds the objects in
+        # one call, so the recovery path below had to deserialise the document
+        # a second time: read it once here instead
+        stix_content = json.loads(stix_content)
+    try:
+        bundle = dict_to_stix2(
+            stix_content, allow_custom=True, interoperability=True
+        )
+    except (InvalidValueError, KeyError, ParseError, ValueError):
+        # the 2.1 code path in `stix2` reports an object without a `type`
+        # property as a bare KeyError where the 2.0 one uses ParseError
+        bundle = _handle_stix2_loading_error(
+            stix_content, invalid_objects, duplicate_invalid_ids
+        )
     # keeps the recovered invalid objects with the bundle they came from, so
     # `load_stix_bundle` sees them even when the caller does not pass the dict
     bundle._invalid_objects = invalid_objects
@@ -120,8 +123,14 @@ def load_stix2_content(stix_content: BytesIO | dict | list | str,
     return bundle
 
 
-def load_stix2_file(
-        filename, invalid_objects: Optional[dict] = None) -> _BUNDLE_TYPING:
+def load_stix2_file(filename, invalid_objects: Optional[dict] = None,
+                    max_size: Optional[int] = None) -> _BUNDLE_TYPING:
+    _check_input_file_size(filename, max_size)
     with open(filename, 'rt', encoding='utf-8') as f:
-        stix_content = f.read()
+        # the file is deserialised as it is read: holding the whole document as
+        # a string *and* as the structure it parses into doubles what the
+        # largest accepted document costs
+        stix_content = json.load(f)
+    # the size was checked on the file: what reaches the content loader is the
+    # structure it deserialised into, which no limit can un-materialise
     return load_stix2_content(stix_content, invalid_objects)

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -296,6 +296,18 @@ class TestSTIX2Import(TestSTIX):
                 filename, debug=debug, output_dir=Path(tmp_dir)
             )
 
+    def _import_bundle_with_size_limit(self, bundle, max_size: int) -> dict:
+        # The size limit is checked on the file the entry point is handed, so
+        # what the caller reads back is the error dict naming the limit the
+        # document exceeded - no part of the document is parsed.
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'oversized.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            return stix_2_to_misp(
+                filename, max_size=max_size, output_dir=Path(tmp_dir)
+            )
+
     def _check_object_attribute_uuid(self, attr, object_id, value=None):
         self.assertEqual(
             attr.uuid,

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -304,6 +304,157 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         load_stix2_content(stix_content)
         self.assertEqual(stix_content, original)
 
+    def test_stix20_oversized_file_is_refused_before_it_is_parsed(self):
+        # Nothing checked an input size: a document was materialised in full -
+        # at 2 to 7 times its size in memory - and only then looked at, so an
+        # oversized document cost the conversion host the whole parse.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_file
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'oversized.stix20.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with patch.object(stix2_loading_helpers.json, 'load') as json_load:
+                with self.assertRaises(STIXInputSizeError) as context:
+                    load_stix2_file(filename, max_size=64)
+        json_load.assert_not_called()
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix20_oversized_content_is_refused_before_it_is_parsed(self):
+        # The in-memory path is the one MISP core and the other library
+        # consumers reach, so the limit cannot live on the file path alone.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_content
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from unittest.mock import patch
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        with patch.object(stix2_loading_helpers.json, 'loads') as json_loads:
+            with self.assertRaises(STIXInputSizeError) as context:
+                load_stix2_content(bundle.serialize(), max_size=64)
+        json_loads.assert_not_called()
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix20_input_size_limit_is_raisable_and_can_be_turned_off(self):
+        from misp_stix_converter.tools import load_stix2_content
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        content = bundle.serialize()
+        for max_size in (len(content), 0):
+            self.assertEqual(
+                load_stix2_content(content, max_size=max_size).id, bundle.id
+            )
+
+    def test_stix20_input_size_limit_is_counted_in_bytes(self):
+        # The limit is a size in bytes, so a document is measured in bytes:
+        # counting the characters of a multibyte one accepted up to 4 times the
+        # limit the caller set.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_content
+        content = self._stix20_content_with_a_multibyte_name()
+        self.assertGreater(len(content.encode('utf-8')), len(content))
+        with self.assertRaises(STIXInputSizeError):
+            load_stix2_content(content, max_size=len(content))
+        self.assertEqual(
+            load_stix2_content(
+                content, max_size=len(content.encode('utf-8'))
+            ).id,
+            'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda'
+        )
+
+    def _stix20_content_with_a_multibyte_name(self) -> str:
+        import json
+        return json.dumps(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'identity',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'Cliché Threat Intelligence Ünit',
+                        'identity_class': 'organization'
+                    }
+                ]
+            },
+            ensure_ascii=False
+        )
+
+    def test_stix20_default_input_size_limit_is_the_documented_one(self):
+        # The documented default is what a caller setting no limit of its own
+        # gets - the value the README and ADR-0011 name.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import input_limits, load_stix2_content
+        from unittest.mock import patch
+        self.assertEqual(input_limits._MAX_INPUT_SIZE, 100 * 1024 * 1024)
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        with patch.object(input_limits, '_MAX_INPUT_SIZE', 64):
+            with self.assertRaises(STIXInputSizeError):
+                load_stix2_content(bundle.serialize())
+
+    def test_stix20_parser_honours_the_input_size_limit(self):
+        # MISP core converts through the parser rather than through the entry
+        # functions (ADR-0009), so the limit has to be reachable there too.
+        from misp_stix_converter import STIXInputSizeError
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'oversized.stix20.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with self.assertRaises(STIXInputSizeError) as context:
+                self.parser.parse_stix_content(filename, max_size=64)
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix20_entry_point_reports_the_input_size_limit(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_domain_attributes()
+        results = self._import_bundle_with_size_limit(bundle, 64)
+        self.assertIn('errors', results)
+        self.assertTrue(
+            any('64 bytes' in error for error in results['errors'])
+        )
+
+    def test_stix20_content_is_deserialised_exactly_once(self):
+        # A document failing the whole-bundle load was deserialised twice:
+        # `stix2` read the JSON, then the recovery path read the same string
+        # again - the second read of a document engineered to be expensive to
+        # parse costs as much as the first.
+        import json
+        from misp_stix_converter.tools import load_stix2_content
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from unittest.mock import patch
+        content = json.dumps(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'indicator',
+                        'id': 'indicator--10440d97-42bb-4b17-a439'
+                              '-9dd5e17dd93e',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'labels': ['malicious-activity'],
+                        'pattern': 'NOT A VALID PATTERN',
+                        'valid_from': '2020-10-25T16:22:00.000Z'
+                    }
+                ]
+            }
+        )
+        with patch.object(
+                stix2_loading_helpers.json, 'loads',
+                wraps=json.loads) as json_loads:
+            load_stix2_content(content)
+        self.assertEqual(json_loads.call_count, 1)
+
     def _load_stix20_content_with_invalid_markings(self, *markings):
         from misp_stix_converter.tools import load_stix2_content
         return load_stix2_content(

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -169,7 +169,8 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             classification=None, cluster_distribution=0,
             cluster_sharing_group=None, debug=False, distribution=0,
             file=[Path('bundle.json')], galaxies_as_tags=False,
-            no_force_contextual_data=False, org_uuid=MISP_org_uuid,
+            max_input_size=None, no_force_contextual_data=False,
+            org_uuid=MISP_org_uuid,
             producer=None, sharing_group=None, single_event=False,
             title=None, version='2'
         )

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -352,6 +352,157 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         load_stix2_content(stix_content)
         self.assertEqual(stix_content, original)
 
+    def test_stix21_oversized_file_is_refused_before_it_is_parsed(self):
+        # Nothing checked an input size: a document was materialised in full -
+        # at 2 to 7 times its size in memory - and only then looked at, so an
+        # oversized document cost the conversion host the whole parse.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_file
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'oversized.stix21.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with patch.object(stix2_loading_helpers.json, 'load') as json_load:
+                with self.assertRaises(STIXInputSizeError) as context:
+                    load_stix2_file(filename, max_size=64)
+        json_load.assert_not_called()
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix21_oversized_content_is_refused_before_it_is_parsed(self):
+        # The in-memory path is the one MISP core and the other library
+        # consumers reach, so the limit cannot live on the file path alone.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_content
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from unittest.mock import patch
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        with patch.object(stix2_loading_helpers.json, 'loads') as json_loads:
+            with self.assertRaises(STIXInputSizeError) as context:
+                load_stix2_content(bundle.serialize(), max_size=64)
+        json_loads.assert_not_called()
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix21_input_size_limit_is_raisable_and_can_be_turned_off(self):
+        from misp_stix_converter.tools import load_stix2_content
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        content = bundle.serialize()
+        for max_size in (len(content), 0):
+            self.assertEqual(
+                load_stix2_content(content, max_size=max_size).id, bundle.id
+            )
+
+    def test_stix21_input_size_limit_is_counted_in_bytes(self):
+        # The limit is a size in bytes, so a document is measured in bytes:
+        # counting the characters of a multibyte one accepted up to 4 times the
+        # limit the caller set.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import load_stix2_content
+        content = self._stix21_content_with_a_multibyte_name()
+        self.assertGreater(len(content.encode('utf-8')), len(content))
+        with self.assertRaises(STIXInputSizeError):
+            load_stix2_content(content, max_size=len(content))
+        self.assertEqual(
+            load_stix2_content(
+                content, max_size=len(content.encode('utf-8'))
+            ).id,
+            'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda'
+        )
+
+    def _stix21_content_with_a_multibyte_name(self) -> str:
+        import json
+        return json.dumps(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'identity',
+                        'spec_version': '2.1',
+                        'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'Cliché Threat Intelligence Ünit',
+                        'identity_class': 'organization'
+                    }
+                ]
+            },
+            ensure_ascii=False
+        )
+
+    def test_stix21_default_input_size_limit_is_the_documented_one(self):
+        # The documented default is what a caller setting no limit of its own
+        # gets - the value the README and ADR-0011 name.
+        from misp_stix_converter import STIXInputSizeError
+        from misp_stix_converter.tools import input_limits, load_stix2_content
+        from unittest.mock import patch
+        self.assertEqual(input_limits._MAX_INPUT_SIZE, 100 * 1024 * 1024)
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        with patch.object(input_limits, '_MAX_INPUT_SIZE', 64):
+            with self.assertRaises(STIXInputSizeError):
+                load_stix2_content(bundle.serialize())
+
+    def test_stix21_parser_honours_the_input_size_limit(self):
+        # MISP core converts through the parser rather than through the entry
+        # functions (ADR-0009), so the limit has to be reachable there too.
+        from misp_stix_converter import STIXInputSizeError
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'oversized.stix21.json'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(bundle.serialize())
+            with self.assertRaises(STIXInputSizeError) as context:
+                self.parser.parse_stix_content(filename, max_size=64)
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix21_entry_point_reports_the_input_size_limit(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_attributes()
+        results = self._import_bundle_with_size_limit(bundle, 64)
+        self.assertIn('errors', results)
+        self.assertTrue(
+            any('64 bytes' in error for error in results['errors'])
+        )
+
+    def test_stix21_content_is_deserialised_exactly_once(self):
+        # A document failing the whole-bundle load was deserialised twice:
+        # `stix2` read the JSON, then the recovery path read the same string
+        # again - the second read of a document engineered to be expensive to
+        # parse costs as much as the first.
+        import json
+        from misp_stix_converter.tools import load_stix2_content
+        from misp_stix_converter.tools import stix2_loading_helpers
+        from unittest.mock import patch
+        content = json.dumps(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    {
+                        'type': 'indicator',
+                        'spec_version': '2.1',
+                        'id': 'indicator--10440d97-42bb-4b17-a439'
+                              '-9dd5e17dd93e',
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': 'NOT A VALID PATTERN',
+                        'pattern_type': 'stix',
+                        'valid_from': '2020-10-25T16:22:00.000Z'
+                    }
+                ]
+            }
+        )
+        with patch.object(
+                stix2_loading_helpers.json, 'loads',
+                wraps=json.loads) as json_loads:
+            load_stix2_content(content)
+        self.assertEqual(json_loads.call_count, 1)
+
     def _load_stix21_content_with_invalid_markings(self, *markings):
         from misp_stix_converter.tools import load_stix2_content
         return load_stix2_content(

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -429,6 +429,94 @@ class TestSTIX1Import(TestSTIX):
             package = load_stix1_package(filename)
         self.assertEqual(package.ttps.ttp[0].title, 'MAEC carrying TTP')
 
+    def test_load_stix1_package_refuses_an_oversized_document(self):
+        """Nothing checked an input size: libxml2 built the whole tree - 2 to 7
+        times the document size in memory - before `mixbox` looked at what the
+        document even is, so an oversized document cost the whole parse."""
+        from misp_stix_converter import STIXInputSizeError
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            with patch.object(
+                    stix1_loading_helpers.STIXPackage, 'from_xml') as from_xml:
+                with self.assertRaises(STIXInputSizeError) as context:
+                    load_stix1_package(filename, max_size=64)
+        from_xml.assert_not_called()
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_load_stix1_package_input_size_limit_is_raisable(self):
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            for max_size in (filename.stat().st_size, 0):
+                package = load_stix1_package(filename, max_size=max_size)
+                self.assertEqual(len(package.courses_of_action), 1)
+
+    def test_load_stix1_package_refuses_a_document_that_is_not_a_package(self):
+        """`mixbox` checks the root element only once the tree it builds is
+        complete: reading the root element on its own refuses a document that
+        is not a STIX package without materialising any of it."""
+        with TemporaryDirectory() as tmp_dir:
+            filename = Path(tmp_dir) / 'not_stix.xml'
+            with open(filename, 'wt', encoding='utf-8') as f:
+                f.write(f'<not-stix>{"a" * 4096}</not-stix>')
+            with patch.object(
+                    stix1_loading_helpers.STIXPackage, 'from_xml') as from_xml:
+                with self.assertRaises(STIXLoadingError) as context:
+                    load_stix1_package(filename)
+        from_xml.assert_not_called()
+        self.assertIn('not-stix', str(context.exception))
+
+    def test_load_stix1_package_root_element_check_accepts_a_package(self):
+        """The peek refuses only what it positively identified as something
+        else: a STIX package reaches the parser, whatever the size of the root
+        element it starts with."""
+        stix_package = STIXPackage()
+        stix_package.stix_header = STIXHeader(
+            title=f'Package with a long title: {"a" * 8192}'
+        )
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            package = load_stix1_package(filename)
+        self.assertEqual(len(package.courses_of_action), 1)
+
+    def test_parse_stix_content_honours_the_input_size_limit(self):
+        # MISP core converts through the parsers rather than through the entry
+        # functions (ADR-0009), so the limit has to be reachable there too.
+        from misp_stix_converter import STIXInputSizeError
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            parser = ExternalSTIX1toMISPParser()
+            with self.assertRaises(STIXInputSizeError) as context:
+                parser.parse_stix_content(filename, max_size=64)
+        self.assertIn('64 bytes', str(context.exception))
+
+    def test_stix_1_to_misp_reports_the_input_size_limit(self):
+        stix_package = STIXPackage()
+        stix_package.add_course_of_action(self._course_of_action())
+        with TemporaryDirectory() as tmp_dir:
+            filename = self._write_package(
+                tmp_dir, stix_package, 'course_of_action.xml'
+            )
+            results = stix_1_to_misp(filename, max_size=64)
+        self.assertIn('errors', results)
+        self.assertTrue(
+            any('64 bytes' in error for error in results['errors'])
+        )
+
     def test_stix_1_to_misp_returns_error_dict_on_malformed_content(self):
         with TemporaryDirectory() as tmp_dir:
             filename = Path(tmp_dir) / 'malformed.xml'


### PR DESCRIPTION
## Description

An import parsed whatever it was handed, in full, before anything looked at it: no size limit, no depth limit, no timeout, and nothing streaming. The size of the input therefore decided the cost of a conversion — 2 to 7 times the input size in memory, and a few seconds of a single core per MB of STIX 2 — and the sender chose the size. Worse, the checks that would have refused the document ran *after* it was built: mixbox compares the root element against the one tag it supports only once the whole tree exists, so XML that is not a STIX package at all was materialised purely to be refused.

One ticket, three commits, both formats, import direction only.

## The limit

`tools/input_limits.py` holds the default — 100 MB — and the two checks: a file is sized with `stat()`, so an oversized document costs no read at all, and content handed over in memory is sized by the bytes it holds before it is deserialised. A document above the limit raises `STIXInputSizeError`, a `STIXLoadingError` subclass, so every handler that already catches loading failures catches this one; the message names the limit that was enforced, never the document that was not read. The entry functions report it in their result dict as they report any loading failure.

`max_size` is the caller's: `None` means the documented default, `0` — or anything below — means no limit. It is threaded through `load_stix1_package`, `load_stix2_file` and `load_stix2_content`, through both parsers' `parse_stix_content()`, and through the four import entry functions; the command line names the same limit in MB as `--max-input-size`, which rejects a negative value rather than treating it as a way to turn the limit off.

Strings are measured in bytes rather than characters — an ASCII document by its own length, anything else counted a chunk at a time — so sizing a document never costs a second copy of it, and a multibyte document is not accepted at up to four times the limit its caller set.

## The checks that now run first

**STIX 1: the root element, on its own.** A chunked pull parser reads the first start tag of the file and refuses the document when that tag is not `{http://stix.mitre.org/stix-1}STIX_Package` — the exact comparison mixbox makes once its tree is built, so nothing that loaded before is refused now. Its settings keep the properties mixbox relies on for the real parse: no entity is resolved, no DTD is loaded, nothing is fetched from the network. `huge_tree` stays off, unlike there, since a peek has no reason to accept an oversized start tag. The peek refuses only what it positively identified as something else: a document lxml cannot read falls through to the parser, which reports what is wrong with it.

**STIX 2: one deserialisation instead of two.** There is no cheap invariant to check in JSON — nothing about a document's structure is visible until it is deserialised in full — so what the loader does instead is stop doing the work twice. `stix2`'s parser deserialises the JSON and builds the objects in one call, so a document that failed the whole-bundle load had its JSON read a second time by the recovery path. The file is now read straight into `json.load()`, the string branch is folded into the dict branch, and the recovery path reuses the result. That also stops the file path holding the document twice, as a string and as the structure it parses into.

## What this does not change

**Nothing that used to convert stops converting**, unless it is over 100 MB — feed-sized and TAXII-poll-sized content is untouched, and a caller that wants more says so.

**Content handed over as a `dict` or a `list` is deliberately not sized.** The caller already materialised it; there is nothing left for a limit to save. Stated in the README and in the CONTEXT.md term rather than left to be discovered.

**No top-level `type` pre-check for STIX 2.** A bundle that lost its `type` is currently recovered from its `objects`, and `stix2` fails on a missing `type` before it constructs anything, so the pre-check would trade a real robustness behaviour for nothing.

**The Export direction's MISP JSON inputs keep no limit.** That contract is ADR-0008's, and an export limit is a decision about MISP's own content rather than about a document a third party sent.

**A parse is never interrupted.** A timeout needs a thread or a subprocess the library does not own; the size limit bounds the same cost through the variable the sender actually controls.

## Behaviour changes for library consumers

- A conversion of a document above 100 MB now fails where it used to succeed. Callers that convert larger documents pass `max_size` (in bytes) or `--max-input-size` (in MB), or `0` to remove the limit.
- `load_stix2_content` given a `list` now raises `STIXLoadingError` instead of an uncaught `TypeError`.
- `STIXInputSizeError` is exported top-level for callers that want to tell "too big" from "malformed".

## The cost, documented

The README now states what a conversion costs — 2 to 7 times the input size in memory, and between 1.9 and 6.5 s of single-core CPU per MB of STIX 2, growing linearly with the number of objects — and says plainly that a limit bounds one conversion, not the load a host accepts. An integrator running imports concurrently, MISP core included, has to cap how many run at once; the library has no way to know what else the host is doing. Decisions and measurements in `docs/adr/0011-input-size-limit-and-conversion-cost.md`, vocabulary in CONTEXT.md as **Input Size Limit**.

Measured after the change: a 24 MB bundle and a 30 MB non-STIX XML document are both refused in about 0.1 ms with peak memory flat (166.4 → 166.7 MB).

## Tests

Twenty-two tests, symmetric across STIX 2.0 and 2.1 where the behaviour is shared.

Per STIX 2 version: an oversized file and oversized in-memory content are both refused with the JSON deserialisation never called, the limit is raisable and can be turned off, the default is the one the documentation names, the parser's own `parse_stix_content` honours it — the path MISP core takes — the entry function reports it, a document is deserialised exactly once, and a multibyte document is measured in bytes rather than characters.

For STIX 1: an oversized document is refused with `STIXPackage.from_xml` never called, the limit is raisable, a document that is not a STIX package is refused with the parser never called, a package whose root element runs past the first chunk still loads, and both `parse_stix_content` and `stix_1_to_misp` report the limit.

Suite is 1992 green.

Fixes #99
