### PR TITLE
One place builds every MISP taxonomy tag an import writes

### DIFF
--- a/.github/workflows/misp-stix.yml
+++ b/.github/workflows/misp-stix.yml
@@ -46,6 +46,7 @@ jobs:
         poetry run pytest tests/test_stix*_export.py
         poetry run pytest tests/test_stix1_import.py
         poetry run pytest tests/test_*ternal_stix*_import.py
+        poetry run pytest tests/test_import_tag_grammar.py
         poetry run pytest tests/test_stix2_patterning.py
 
     - name: Upload coverage to Codecov

--- a/misp_stix_converter/stix2misp/converters/stix2converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2converter.py
@@ -340,10 +340,11 @@ class ExternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
 
     def _parse_galaxy_as_tag_names(self, stix_object: _GALAXY_OBJECTS_TYPING,
                                    object_type: Union[str, None]) -> dict:
+        tag_name = self.main_parser._build_tag(
+            'misp-galaxy', object_type or stix_object.type, stix_object.name
+        )
         return {
-            'tag_names': [
-                f'misp-galaxy:{object_type or stix_object.type}="{stix_object.name}"'
-            ],
+            'tag_names': [tag_name] if tag_name is not None else [],
             'used': {self.event_uuid: False}
         }
 
@@ -466,10 +467,11 @@ class InternalSTIX2Converter(STIX2Converter, metaclass=ABCMeta):
     def _parse_galaxy_as_tag_names(
             self, stix_object: _GALAXY_OBJECTS_TYPING) -> dict:
         galaxy_type, _ = self._extract_galaxy_labels(stix_object)
+        tag_name = self.main_parser._build_tag(
+            'misp-galaxy', galaxy_type, stix_object.name
+        )
         return {
-            'tag_names': [
-                f'misp-galaxy:{galaxy_type}="{stix_object.name}"'
-            ],
+            'tag_names': [tag_name] if tag_name is not None else [],
             'used': {self.event_uuid: False}
         }
 

--- a/misp_stix_converter/stix2misp/external_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix1_to_misp.py
@@ -163,8 +163,12 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
                                 }
                             )
                         elif vulnerability.title:
-                            title = vulnerability.title
-                            galaxies.add(f'misp-galaxy:branded-vulnerability="{title}"')
+                            tag_name = self._build_tag(
+                                'misp-galaxy', 'branded-vulnerability',
+                                vulnerability.title
+                            )
+                            if tag_name is not None:
+                                galaxies.add(tag_name)
         if len(attributes) == 1:
             attributes[0].update(self._sanitise_attribute_uuid(ttp.id_))
         return attributes
@@ -276,7 +280,11 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
             for marking in handling.marking_structures:
                 parser = self._mapping.marking_mapping(marking._XSI_TYPE)
                 if parser is not None:
-                    yield from getattr(self, parser)(marking)
+                    # A marking field a taxonomy tag can be made of nothing
+                    # from writes no tag: the one place they are filtered out.
+                    for tag in getattr(self, parser)(marking):
+                        if tag is not None:
+                            yield tag
 
     def _parse_observables(self, observables: Optional[Observables] = None, to_ids: bool = False):
         for observable in observables or self.stix_package.observables:
@@ -381,29 +389,33 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
     #                   MARKING DEFINITIONS PARSING METHODS.                   #
     ############################################################################
 
-    @staticmethod
-    def _parse_AIS_marking(marking: AISMarkingStructure):
+    def _parse_AIS_marking(self, marking: AISMarkingStructure):
         for feature in ('is_proprietary', 'not_proprietary'):
             proprietary = getattr(marking, feature)
             if proprietary is None:
                 continue
-            yield f'ais-marking:AISMarking="{feature.title()}"'
+            yield self._build_tag(
+                'ais-marking', 'AISMarking', feature.title()
+            )
             if hasattr(proprietary, 'cisa_proprietary'):
                 cisa_proprietary = (
                     'true' if proprietary.cisa_proprietary.numerator == 1
                     else 'false'
                 )
-                yield f'ais-marking:CISA_Proprietary="{cisa_proprietary}"'
+                yield self._build_tag(
+                    'ais-marking', 'CISA_Proprietary', cisa_proprietary
+                )
             if hasattr(proprietary, 'ais_consent'):
-                consent = proprietary.ais_consent.consent
-                yield f'ais-marking:AISConsent="{consent}"'
+                yield self._build_tag(
+                    'ais-marking', 'AISConsent', proprietary.ais_consent.consent
+                )
             if hasattr(proprietary, 'tlp_marking'):
-                color = proprietary.tlp_marking.color
-                yield f'ais-marking:TLPMarking="{color}"'
+                yield self._build_tag(
+                    'ais-marking', 'TLPMarking', proprietary.tlp_marking.color
+                )
 
-    @staticmethod
-    def _parse_TLP_marking(marking: TLPMarkingStructure):
-        yield f'tlp:{marking.color.lower()}'
+    def _parse_TLP_marking(self, marking: TLPMarkingStructure):
+        yield self._build_tag('tlp', marking.color.lower())
 
     ############################################################################
     #                             UTILITY METHODS.                             #

--- a/misp_stix_converter/stix2misp/importparser.py
+++ b/misp_stix_converter/stix2misp/importparser.py
@@ -18,14 +18,15 @@ _DEFAULT_DISTRIBUTION = 0
 _VALID_DISTRIBUTIONS = (0, 1, 2, 3, 4)
 _RFC_VERSIONS = (1, 3, 4, 5)
 
-# The producer is written into the MISP taxonomy tag
-# `misp-galaxy:producer="<producer>"`, a grammar with no escaping of its own: a
-# `"` in the value closes it, and the rest of the name is then read as further
-# taxonomy entries of the tag - a name a bundle chose for itself deciding what
-# else the event is tagged with. The control characters cannot be written into
-# the XML and CSV exports the tag reaches either. Both are taken out of the
-# value, along with the whitespace around what is left - the rest is kept as it
-# stands, inner spaces and the `:` and `=` a plain name may carry included.
+# What a conversion writes text into a MISP taxonomy tag with. The grammar
+# `<namespace>:<predicate>="<value>"` has no escaping of its own: a `"` closes
+# the slot it appears in, and what follows is then read as further taxonomy
+# entries of the tag - text a document chose for itself deciding what else the
+# record is tagged with. The control characters cannot be written into the XML
+# and CSV exports the tag reaches either. Both are taken out of every slot a
+# document reaches, along with the whitespace around what is left - the rest is
+# kept as it stands, inner spaces and the `:` and `=` a plain name may carry
+# included. `_build_tag` is where they all go through.
 _TAG_VALUE_METACHARACTERS = re.compile(r'["\x00-\x1f\x7f]')
 
 
@@ -91,7 +92,63 @@ class STIXtoMISPParser(AbstractParser):
             return
         if name != producer:
             self._sanitised_producer_warning(producer, name)
-        misp_event.add_tag(f'misp-galaxy:producer="{name}"')
+        misp_event.add_tag(self._build_tag('misp-galaxy', 'producer', name))
+
+    def _build_tag(
+            self, namespace: str, predicate: str,
+            value: Optional[str] = None) -> Optional[str]:
+        """Write the MISP taxonomy tag a conversion tags a record with.
+
+        The one place a tag is built out of text the converted document
+        supplied. The taxonomy grammar is the library's own and has no escaping
+        of its own: a `"` ends the slot it appears in and what follows is read
+        as further taxonomy entries, so what a slot cannot carry is taken out
+        of each of them - the predicate naming the entry as much as the value
+        it carries, both being slots the document reaches.
+
+        :param namespace: the taxonomy the tag belongs to
+        :param predicate: the entry of that taxonomy the tag is
+        :param value: the value that entry carries, for the tags that have one
+        :return: the tag, or None when a slot nothing survives from leaves no
+            tag to write
+        """
+        slots = (namespace, predicate) if value is None else (
+            namespace, predicate, value
+        )
+        cleaned = []
+        for slot in slots:
+            text = _TAG_VALUE_METACHARACTERS.sub('', str(slot)).strip()
+            if not text:
+                self._unusable_tag_value_warning(slot)
+                return None
+            if text != str(slot):
+                self._sanitised_tag_value_warning(slot, text)
+            cleaned.append(text)
+        if value is None:
+            return '{}:{}'.format(*cleaned)
+        return '{}:{}="{}"'.format(*cleaned)
+
+    def _build_cluster_tag(
+            self, cluster_type: str, value: str,
+            uuid: str) -> Optional[str]:
+        """Write the tag naming a Galaxy Cluster the conversion also creates.
+
+        MISP attaches a cluster to a record by matching the tag against the
+        cluster, so a tag cleaned while the cluster keeps the value it was sent
+        would name no cluster at all. The value a tag cannot be made of is
+        therefore not cleaned here but replaced by the cluster uuid, which any
+        tag can carry - the cluster keeping the value the document supplied.
+
+        :param cluster_type: the galaxy the cluster belongs to
+        :param value: the value the cluster is named by
+        :param uuid: the cluster uuid, the tag's fallback to name it with
+        :return: the tag naming the cluster
+        """
+        cleaned = _TAG_VALUE_METACHARACTERS.sub('', str(value)).strip()
+        if cleaned != str(value):
+            self._cluster_tag_by_uuid_warning(value, uuid)
+            value = uuid
+        return self._build_tag('misp-galaxy', cluster_type, value)
 
     def _populate_misp_event(self):
         self.misp_events.append(self.misp_event)
@@ -251,6 +308,25 @@ class STIXtoMISPParser(AbstractParser):
             f'Sanitised producer name: {producer} - what a MISP taxonomy tag '
             'value cannot carry was taken out, the event is tagged as '
             f'produced by {sanitised}'
+        )
+
+    def _cluster_tag_by_uuid_warning(self, value: Any, uuid: str):
+        self._add_warning(
+            f'Sanitised galaxy cluster tag: {value} - the cluster value '
+            'carries what a MISP taxonomy tag value cannot, the tag names the '
+            f'cluster by its uuid {uuid} instead'
+        )
+
+    def _sanitised_tag_value_warning(self, value: Any, sanitised: str):
+        self._add_warning(
+            f'Sanitised tag value: {value} - what a MISP taxonomy tag value '
+            f'cannot carry was taken out, the tag written carries {sanitised}'
+        )
+
+    def _unusable_tag_value_warning(self, value: Any):
+        self._add_warning(
+            f'Unusable tag value: {value} - nothing a MISP taxonomy tag value '
+            'can be made of, no tag is written'
         )
 
     def _sharing_group_id_error(self, exception: Exception):

--- a/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix2_to_misp.py
@@ -22,7 +22,7 @@ from stix2.v20.sdo import CustomObject as CustomObject_v20
 from stix2.v20.sro import Sighting as Sighting_v20
 from stix2.v21.sdo import CustomObject as CustomObject_v21
 from stix2.v21.sro import Sighting as Sighting_v21
-from typing import Iterator, Union
+from typing import Iterator, Optional, Union
 
 _STORAGE_VARIABLE_NAMES = ('_indicator', '_observed_data')
 
@@ -306,10 +306,12 @@ class InternalSTIX2toMISPParser(STIX2toMISPParser):
         for cluster in misp_galaxy.clusters:
             misp_layer.add_tag(self._galaxy_cluster_tag(cluster))
 
-    @staticmethod
-    def _galaxy_cluster_tag(cluster) -> str:
-        tag_value = cluster.uuid if cluster.type.startswith('stix-') else cluster.value
-        return f'misp-galaxy:{cluster.type}="{tag_value}"'
+    def _galaxy_cluster_tag(self, cluster) -> Optional[str]:
+        if cluster.type.startswith('stix-'):
+            return self._build_tag('misp-galaxy', cluster.type, cluster.uuid)
+        return self._build_cluster_tag(
+            cluster.type, cluster.value, cluster.uuid
+        )
 
     def _add_object_galaxies(self, misp_object: MISPObject, galaxies: dict):
         for galaxy in self._aggregate_galaxy_clusters(galaxies):

--- a/misp_stix_converter/stix2misp/stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix1_to_misp.py
@@ -658,7 +658,8 @@ class STIX1toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
                 yield from self._resolve_galaxy(names, default_value)
 
     def _resolve_galaxy(self, galaxy_name: str, default_value: str) -> list:
-        return [f'misp-galaxy:{default_value}="{galaxy_name}"']
+        tag_name = self._build_tag('misp-galaxy', default_value, galaxy_name)
+        return [tag_name] if tag_name is not None else []
 
     ############################################################################
     #                             UTILITY METHODS.                             #

--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -908,7 +908,11 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         rule_effect = privilege['rule_effect']
         yield 'rule_effect', rule_effect
         if rule_effect == 'permit':
-            tags.append(f'acs-marking:privilege_action="{privilege_action}"')
+            tag = self._build_tag(
+                'acs-marking', 'privilege_action', privilege_action
+            )
+            if tag is not None:
+                tags.append(tag)
         for field, scope in privilege['privilege_scope'].items():
             yield f'privilege_scope.{field}', scope
 
@@ -937,11 +941,16 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
             if isinstance(values, dict):
                 for field, subvalues in values.items():
                     if field in self._mapping.marking_vocabularies_fields():
-                        if isinstance(subvalues, list):
-                            for subvalue in subvalues:
-                                tags.append(f'acs-marking:{field}="{subvalue}"')
-                        else:
-                            tags.append(f'acs-marking:{field}="{subvalues}"')
+                        values = (
+                            subvalues if isinstance(subvalues, list)
+                            else [subvalues]
+                        )
+                        for subvalue in values:
+                            tag = self._build_tag(
+                                'acs-marking', field, subvalue
+                            )
+                            if tag is not None:
+                                tags.append(tag)
                     meta[f'{key}.{field}'] = subvalues
                 continue
             if key == 'access_privilege':
@@ -1388,17 +1397,18 @@ class STIX2toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         self._load_marking_definition(marking)
         return True
 
-    @staticmethod
-    def _parse_confidence_level(confidence_level: int) -> str:
+    def _parse_confidence_level(self, confidence_level: int) -> str:
         if confidence_level == 100:
-            return 'misp:confidence-level="completely-confident"'
-        if confidence_level >= 75:
-            return 'misp:confidence-level="usually-confident"'
-        if confidence_level >= 50:
-            return 'misp:confidence-level="fairly-confident"'
-        if confidence_level >= 25:
-            return 'misp:confidence-level="rarely-confident"'
-        return 'misp:confidence-level="unconfident"'
+            level = 'completely-confident'
+        elif confidence_level >= 75:
+            level = 'usually-confident'
+        elif confidence_level >= 50:
+            level = 'fairly-confident'
+        elif confidence_level >= 25:
+            level = 'rarely-confident'
+        else:
+            level = 'unconfident'
+        return self._build_tag('misp', 'confidence-level', level)
 
     ############################################################################
     #                   ERRORS AND WARNINGS HANDLING METHODS                   #

--- a/tests/_test_stix_import.py
+++ b/tests/_test_stix_import.py
@@ -24,6 +24,13 @@ UUIDv4 = UUID('76beed5f-7251-457e-8c2a-b45f7b589d3d')
 SMUGGLING_PRODUCER = 'Evil" tlp:clear misp-galaxy:producer="CIRCL'
 SANITISED_PRODUCER = 'Evil tlp:clear misp-galaxy:producer=CIRCL'
 
+# The same, in the slots of the other tags a conversion writes: the value a
+# galaxy is named by, and the predicate naming the taxonomy it belongs to.
+SMUGGLING_TAG_VALUE = 'Evil" tlp:red misp-galaxy:mitre-malware="BISCUIT'
+SANITISED_TAG_VALUE = 'Evil tlp:red misp-galaxy:mitre-malware=BISCUIT'
+SMUGGLING_TAG_PREDICATE = 'mitre-malware" tlp:red misp-galaxy:threat-actor="APT'
+SANITISED_TAG_PREDICATE = 'mitre-malware tlp:red misp-galaxy:threat-actor=APT'
+
 _GALAXY_SUMMARY_MAPPING = {
     'attack-pattern': 'Attack Pattern (mitre-attack-pattern)',
     'course-of-action': 'Course of Action (mitre-course-of-action)',
@@ -250,6 +257,28 @@ class TestSTIX2Import(TestSTIX):
         self.assertEqual(len(producer_warnings), 1)
         for value in (producer, sanitised):
             self.assertIn(value, producer_warnings[0])
+
+    def _check_sanitised_tag_warning(self, value, sanitised, warnings):
+        """Text a conversion wrote into a tag is one taxonomy entry of it."""
+        tag_warnings = self._reports_matching(warnings, 'Sanitised tag value')
+        self.assertEqual(len(tag_warnings), 1)
+        for reported in (value, sanitised):
+            self.assertIn(reported, tag_warnings[0])
+
+    def _check_unusable_tag_warning(self, value, warnings):
+        """Text a taxonomy tag has nothing left to carry from writes no tag."""
+        tag_warnings = self._reports_matching(warnings, 'Unusable tag value')
+        self.assertEqual(len(tag_warnings), 1)
+        self.assertIn(value, tag_warnings[0])
+
+    def _check_cluster_tag_by_uuid_warning(self, value, uuid, warnings):
+        """A cluster a tag cannot name by value is named by its uuid."""
+        tag_warnings = self._reports_matching(
+            warnings, 'Sanitised galaxy cluster tag'
+        )
+        self.assertEqual(len(tag_warnings), 1)
+        for reported in (value, uuid):
+            self.assertIn(reported, tag_warnings[0])
 
     def _check_uuid_collision_warning(self, record_uuid, object_ids, warnings):
         """Two STIX ids, one MISP uuid: both records stay, the loss is named."""

--- a/tests/test_external_stix20_bundles.py
+++ b/tests/test_external_stix20_bundles.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import SMUGGLING_PRODUCER, TestSTIX2Bundles
+from ._test_stix_import import (
+    SMUGGLING_PRODUCER, SMUGGLING_TAG_VALUE, TestSTIX2Bundles)
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -2306,6 +2307,13 @@ class TestExternalSTIX20Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_malware_galaxy(cls):
         return cls.__assemble_galaxy_bundle(*_MALWARE_OBJECTS)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_name(cls):
+        """A Threat Actor naming itself what a taxonomy tag cannot carry."""
+        event_galaxy, attribute_galaxy = deepcopy(_THREAT_ACTOR_OBJECTS)
+        event_galaxy['name'] = SMUGGLING_TAG_VALUE
+        return cls.__assemble_galaxy_bundle(event_galaxy, attribute_galaxy)
 
     @classmethod
     def get_bundle_with_threat_actor_galaxy(cls):

--- a/tests/test_external_stix20_import.py
+++ b/tests/test_external_stix20_import.py
@@ -5,8 +5,9 @@ from .test_external_stix20_bundles import (
     TestExternalSTIX20Bundles, TLP_1_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX20
 from ._test_stix_import import (
-    SANITISED_PRODUCER, SMUGGLING_PRODUCER, TestExternalSTIX2Import,
-    TestSTIX20Import, UUIDv4, MISP_org_uuid)
+    SANITISED_PRODUCER, SANITISED_TAG_VALUE, SMUGGLING_PRODUCER,
+    SMUGGLING_TAG_VALUE, TestExternalSTIX2Import, TestSTIX20Import,
+    UUIDv4, MISP_org_uuid)
 from uuid import uuid5
 
 
@@ -988,6 +989,24 @@ class TestExternalSTIX20Import(TestExternalSTIX2Import, TestSTIX20, TestSTIX20Im
         self.assertEqual(meta['labels'], attribute_malware.labels)
         self._populate_external_galaxy_documentation(
             galaxy=event.galaxies[0], malware=event_malware
+        )
+
+    def test_stix20_bundle_with_metacharacters_in_galaxy_name_as_tags(self):
+        bundle = TestExternalSTIX20Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        # The galaxy name asks for taxonomy entries of its own inside the tag
+        # it is written into: what the event gets is one tag.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(
+            f'misp-galaxy:threat-actor="{SANITISED_TAG_VALUE}"', tags
+        )
+        self.assertNotIn(
+            f'misp-galaxy:threat-actor="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_VALUE, SANITISED_TAG_VALUE, self.parser.warnings
         )
 
     def test_stix20_bundle_with_threat_actor_galaxy(self):

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import SMUGGLING_PRODUCER, TestSTIX2Bundles, UUIDv4
+from ._test_stix_import import (
+    SMUGGLING_PRODUCER, SMUGGLING_TAG_VALUE, TestSTIX2Bundles, UUIDv4)
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -2881,6 +2882,19 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(ip_address, *acs_marking_definitions)
 
     @classmethod
+    def get_bundle_with_metacharacters_in_acs_marking(cls):
+        """An ACS Marking vocabulary field asking for taxonomy entries of its
+        own inside the tag the conversion writes it into."""
+        ip_address = deepcopy(_IP_ADDRESS_ATTRIBUTES[2])
+        acs_marking_definitions = deepcopy(_ACS_MARKING_DEFINITION_OBJECTS)
+        extension = next(
+            iter(acs_marking_definitions[0]['extensions'].values())
+        )
+        extension['control_set']['classification'] = SMUGGLING_TAG_VALUE
+        ip_address['object_marking_refs'] = [acs_marking_definitions[0]['id']]
+        return cls.__assemble_bundle(ip_address, *acs_marking_definitions)
+
+    @classmethod
     def __tlp_markings_bundle(cls, addresses, markings):
         bundle = deepcopy(cls.__bundle)
         grouping = deepcopy(cls.__grouping)
@@ -3127,6 +3141,13 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_malware_galaxy(cls):
         return cls.__assemble_galaxy_bundle(*_MALWARE_OBJECTS)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_name(cls):
+        """A Threat Actor naming itself what a taxonomy tag cannot carry."""
+        event_galaxy, attribute_galaxy = deepcopy(_THREAT_ACTOR_OBJECTS)
+        event_galaxy['name'] = SMUGGLING_TAG_VALUE
+        return cls.__assemble_galaxy_bundle(event_galaxy, attribute_galaxy)
 
     @classmethod
     def get_bundle_with_threat_actor_galaxy(cls):

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -5,8 +5,9 @@ from .test_external_stix21_bundles import (
     TestExternalSTIX21Bundles, TLP_1_0_EXPECTED_TAGS, TLP_2_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX21
 from ._test_stix_import import (
-    SANITISED_PRODUCER, SMUGGLING_PRODUCER, TestExternalSTIX2Import,
-    TestSTIX21Import, UUIDv4, MISP_org_uuid)
+    SANITISED_PRODUCER, SANITISED_TAG_VALUE, SMUGGLING_PRODUCER,
+    SMUGGLING_TAG_VALUE, TestExternalSTIX2Import, TestSTIX21Import,
+    UUIDv4, MISP_org_uuid)
 from uuid import uuid5
 
 _ACS_EXTENSION_ID = 'extension-definition--3a65884d-005a-4290-8335-cb2d778a83ce'
@@ -790,6 +791,21 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             for stix_object in (campaign, indicator, attribute_campaign):
                 self.assertIn(stix_object.id, reported)
 
+    def test_stix21_bundle_with_metacharacters_in_acs_marking(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_metacharacters_in_acs_marking()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        # A marking field is written into a taxonomy tag of the library's own:
+        # what it carries is one entry of it, whatever the field asks for.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(
+            f'acs-marking:classification="{SANITISED_TAG_VALUE}"', tags
+        )
+        self.assertNotIn(
+            f'acs-marking:classification="{SMUGGLING_TAG_VALUE}"', tags
+        )
+
     def test_stix21_bundle_with_acs_marking(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_acs_marking()
         self.parser.load_stix_bundle(bundle)
@@ -1262,6 +1278,24 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self.assertEqual(meta['malware_types'], attribute_malware.malware_types)
         self._populate_external_galaxy_documentation(
             galaxy=event.galaxies[0], malware=event_malware
+        )
+
+    def test_stix21_bundle_with_metacharacters_in_galaxy_name_as_tags(self):
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        # The galaxy name asks for taxonomy entries of its own inside the tag
+        # it is written into: what the event gets is one tag.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(
+            f'misp-galaxy:threat-actor="{SANITISED_TAG_VALUE}"', tags
+        )
+        self.assertNotIn(
+            f'misp-galaxy:threat-actor="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_VALUE, SANITISED_TAG_VALUE, self.parser.warnings
         )
 
     def test_stix21_bundle_with_threat_actor_galaxy(self):

--- a/tests/test_import_tag_grammar.py
+++ b/tests/test_import_tag_grammar.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import ast
+import re
+import unittest
+from misp_stix_converter.stix2misp import importparser
+from pathlib import Path
+
+_IMPORT_SOURCES = Path(importparser.__file__).parent
+# Where every MISP taxonomy tag an import writes is built (ADR-0012).
+_TAG_BUILDER_SOURCE = 'importparser.py'
+
+# The two shapes a MISP taxonomy tag literal takes, as the source reads once
+# the interpolated parts of an f-string are replaced by `{}`: the entry with a
+# value, `<namespace>:<predicate>="<value>"`, and the bare entry, `tlp:<color>`.
+_TAG_LITERALS = (
+    re.compile(r'^[a-z][a-z0-9_.\-]*:\S*="'),
+    re.compile(r'^[a-z][a-z0-9_.\-]*:\{\}$')
+)
+
+
+def _matched_literals(tree) -> set:
+    """The tag literals a module reads rather than writes.
+
+    A literal compared against the labels a document carries is the
+    conversion recognising its own STIX output, not tagging a MISP record
+    with it, so the one place tags are built has nothing to do with it.
+    """
+    return {
+        id(node.left) for node in ast.walk(tree)
+        if isinstance(node, ast.Compare) and any(
+            isinstance(operator, (ast.In, ast.NotIn)) for operator in node.ops
+        )
+    }
+
+
+def _literal_text(node) -> str:
+    """The text a string node reads as, interpolated parts left as `{}`."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return ''.join(
+            part.value if isinstance(part, ast.Constant) else '{}'
+            for part in node.values
+        )
+    return ''
+
+
+class TestImportTagGrammar(unittest.TestCase):
+
+    def test_no_taxonomy_tag_is_written_outside_the_tag_builder(self):
+        """One function writes every tag an import produces (ADR-0012).
+
+        The number of places text a converted document supplied can reach the
+        MISP taxonomy grammar is then a property of the design rather than of
+        the last search for them: this test is that property.
+        """
+        written_elsewhere = []
+        for path in sorted(_IMPORT_SOURCES.rglob('*.py')):
+            if path.name == _TAG_BUILDER_SOURCE:
+                continue
+            tree = ast.parse(path.read_text(encoding='utf-8'))
+            matched = _matched_literals(tree)
+            for node in ast.walk(tree):
+                if id(node) in matched:
+                    continue
+                text = _literal_text(node)
+                if any(pattern.match(text) for pattern in _TAG_LITERALS):
+                    written_elsewhere.append(
+                        f'{path.relative_to(_IMPORT_SOURCES)}: {text}'
+                    )
+        self.assertEqual(written_elsewhere, [])

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import TestSTIX2Bundles
+from ._test_stix_import import (
+    SMUGGLING_TAG_PREDICATE, SMUGGLING_TAG_VALUE, TestSTIX2Bundles)
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -8464,6 +8465,20 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_intrusion_set_galaxy(cls):
         return cls.__assemble_bundle(_INTRUSION_SET_GALAXY)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_name(cls):
+        """A galaxy naming itself what a taxonomy tag value cannot carry."""
+        malware = deepcopy(_MALWARE_GALAXY)
+        malware['name'] = SMUGGLING_TAG_VALUE
+        return cls.__assemble_bundle(malware)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_type(cls):
+        """A galaxy type label asking for taxonomy entries of its own."""
+        return cls.get_bundle_with_malformed_galaxy_labels(
+            [f'misp:galaxy-type="{SMUGGLING_TAG_PREDICATE}"']
+        )
 
     @classmethod
     def get_bundle_with_malformed_galaxy_labels(cls, labels):

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -6,7 +6,9 @@ from uuid import uuid5
 from .test_internal_stix20_bundles import (
     TestInternalSTIX20Bundles, TLP_1_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX20
-from ._test_stix_import import TestInternalSTIX2Import, TestSTIX20Import, UUIDv4
+from ._test_stix_import import (
+    SANITISED_TAG_PREDICATE, SANITISED_TAG_VALUE, SMUGGLING_TAG_PREDICATE,
+    SMUGGLING_TAG_VALUE, TestInternalSTIX2Import, TestSTIX20Import, UUIDv4)
 
 
 class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Import):
@@ -2220,6 +2222,61 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         # The galaxy is the one the type label names, name label or not.
         self._check_malware_galaxy(event.galaxies[0], malware)
         self._check_galaxy_without_name_label(malware, self.parser.warnings)
+
+    def test_stix20_bundle_with_metacharacters_in_galaxy_cluster_value(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        cluster = event.galaxies[0].clusters[0]
+        # The cluster keeps the value the bundle sent: what a tag cannot carry
+        # is not censored, the tag names the cluster by its uuid instead - the
+        # only value that keeps MISP's cluster-to-tag match working.
+        self.assertIn(SMUGGLING_TAG_VALUE, cluster.value)
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(f'misp-galaxy:mitre-malware="{cluster.uuid}"', tags)
+        self.assertNotIn(
+            f'misp-galaxy:mitre-malware="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_cluster_tag_by_uuid_warning(
+            cluster.value, cluster.uuid, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_metacharacters_in_galaxy_name_as_tags(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        # The galaxy name asks for taxonomy entries of its own inside the tag
+        # it is written into: what the event gets is one tag.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(f'misp-galaxy:mitre-malware="{SANITISED_TAG_VALUE}"', tags)
+        self.assertNotIn(
+            f'misp-galaxy:mitre-malware="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_VALUE, SANITISED_TAG_VALUE, self.parser.warnings
+        )
+
+    def test_stix20_bundle_with_metacharacters_in_galaxy_type_as_tags(self):
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_metacharacters_in_galaxy_type()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        malware = bundle.objects[-1]
+        # The predicate slot is the conversion's own grammar just as the value
+        # slot is: a galaxy type label cannot write taxonomy entries either.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(
+            f'misp-galaxy:{SANITISED_TAG_PREDICATE}="{malware.name}"', tags
+        )
+        self.assertNotIn(
+            f'misp-galaxy:{SMUGGLING_TAG_PREDICATE}="{malware.name}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_PREDICATE, SANITISED_TAG_PREDICATE,
+            self.parser.warnings
+        )
 
     def test_stix20_bundle_with_malformed_galaxy_labels_as_tags(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_malformed_galaxy_labels(

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ._test_stix_import import TestSTIX2Bundles
+from ._test_stix_import import (
+    SMUGGLING_TAG_PREDICATE, SMUGGLING_TAG_VALUE, TestSTIX2Bundles)
 from base64 import b64encode
 from copy import deepcopy
 from pathlib import Path
@@ -10578,6 +10579,20 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_location_galaxies(cls):
         return cls.__assemble_bundle(*_LOCATION_GALAXIES)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_name(cls):
+        """A galaxy naming itself what a taxonomy tag value cannot carry."""
+        malware = deepcopy(_MALWARE_GALAXY)
+        malware['name'] = SMUGGLING_TAG_VALUE
+        return cls.__assemble_bundle(malware)
+
+    @classmethod
+    def get_bundle_with_metacharacters_in_galaxy_type(cls):
+        """A galaxy type label asking for taxonomy entries of its own."""
+        return cls.get_bundle_with_malformed_galaxy_labels(
+            [f'misp:galaxy-type="{SMUGGLING_TAG_PREDICATE}"']
+        )
 
     @classmethod
     def get_bundle_with_malformed_galaxy_labels(cls, labels):

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -6,7 +6,9 @@ from uuid import uuid5
 from .test_internal_stix21_bundles import (
     TestInternalSTIX21Bundles, TLP_1_0_EXPECTED_TAGS, TLP_2_0_EXPECTED_TAGS)
 from ._test_stix import TestSTIX21
-from ._test_stix_import import TestInternalSTIX2Import, TestSTIX21Import, UUIDv4
+from ._test_stix_import import (
+    SANITISED_TAG_PREDICATE, SANITISED_TAG_VALUE, SMUGGLING_TAG_PREDICATE,
+    SMUGGLING_TAG_VALUE, TestInternalSTIX2Import, TestSTIX21Import, UUIDv4)
 
 
 class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Import):
@@ -2641,6 +2643,61 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
         # The galaxy is the one the type label names, name label or not.
         self._check_malware_galaxy(event.galaxies[0], malware)
         self._check_galaxy_without_name_label(malware, self.parser.warnings)
+
+    def test_stix21_bundle_with_metacharacters_in_galaxy_cluster_value(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        cluster = event.galaxies[0].clusters[0]
+        # The cluster keeps the value the bundle sent: what a tag cannot carry
+        # is not censored, the tag names the cluster by its uuid instead - the
+        # only value that keeps MISP's cluster-to-tag match working.
+        self.assertIn(SMUGGLING_TAG_VALUE, cluster.value)
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(f'misp-galaxy:mitre-malware="{cluster.uuid}"', tags)
+        self.assertNotIn(
+            f'misp-galaxy:mitre-malware="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_cluster_tag_by_uuid_warning(
+            cluster.value, cluster.uuid, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_metacharacters_in_galaxy_name_as_tags(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_metacharacters_in_galaxy_name()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        # The galaxy name asks for taxonomy entries of its own inside the tag
+        # it is written into: what the event gets is one tag.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(f'misp-galaxy:mitre-malware="{SANITISED_TAG_VALUE}"', tags)
+        self.assertNotIn(
+            f'misp-galaxy:mitre-malware="{SMUGGLING_TAG_VALUE}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_VALUE, SANITISED_TAG_VALUE, self.parser.warnings
+        )
+
+    def test_stix21_bundle_with_metacharacters_in_galaxy_type_as_tags(self):
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_metacharacters_in_galaxy_type()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle(galaxies_as_tags=True)
+        event = self.parser.misp_event
+        malware = bundle.objects[-1]
+        # The predicate slot is the conversion's own grammar just as the value
+        # slot is: a galaxy type label cannot write taxonomy entries either.
+        tags = {tag.name for tag in event.tags}
+        self.assertIn(
+            f'misp-galaxy:{SANITISED_TAG_PREDICATE}="{malware.name}"', tags
+        )
+        self.assertNotIn(
+            f'misp-galaxy:{SMUGGLING_TAG_PREDICATE}="{malware.name}"', tags
+        )
+        self._check_sanitised_tag_warning(
+            SMUGGLING_TAG_PREDICATE, SANITISED_TAG_PREDICATE,
+            self.parser.warnings
+        )
 
     def test_stix21_bundle_with_malformed_galaxy_labels_as_tags(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_malformed_galaxy_labels(

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -19,13 +19,21 @@ from stix.coa import CourseOfAction, Objective
 from stix.common import Statement
 from stix.common.related import RelatedPackage, RelatedPackages
 from stix.core import STIXHeader, STIXPackage
+from stix.data_marking import Marking, MarkingSpecification
+from stix.extensions.marking.tlp import TLPMarkingStructure
 from stix.incident import Incident
 from stix.incident.history import History, HistoryItem, JournalEntry
 from stix.indicator import Indicator
 from stix.threat_actor import ThreatActor
+from stix.ttp import TTP, Behavior
+from stix.ttp.infrastructure import Infrastructure
+from stix.ttp.malware_instance import MalwareInstance
+from stix.ttp.resource import Resource
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from ._test_stix import TestSTIX
+from ._test_stix_import import (
+    SANITISED_TAG_VALUE, SMUGGLING_TAG_VALUE)
 
 _COA_UUID = '4c1e5f2a-8b3d-4a6c-9e7f-1d2b3c4d5e6f'
 _OBSERVABLE_UUID = '7a9b0c1d-2e3f-4a5b-8c9d-0e1f2a3b4c5d'
@@ -701,6 +709,64 @@ class TestSTIX1Import(TestSTIX):
         self.assertEqual(
             parser.misp_event.info, 'Imported from external STIX 1.1.1 Package'
         )
+
+    ############################################################################
+    #                              GALAXY TAGS.                                #
+    ############################################################################
+
+    @classmethod
+    def _ttp_with_malware_title(cls, title):
+        """A TTP naming a malware what a taxonomy tag value cannot carry, over
+        infrastructure the galaxy tag then lands on as an attribute."""
+        ttp = TTP()
+        ttp.id_ = f'MISP:TTP-{_ACTOR_UUID}'
+        malware_instance = MalwareInstance()
+        malware_instance.title = title
+        ttp.behavior = Behavior()
+        ttp.behavior.add_malware_instance(malware_instance)
+        address = Address()
+        address.address_value = '198.51.100.16'
+        address.category = 'ipv4-addr'
+        address_object = Object(address)
+        address_object.id_ = f'MISP:Address-{_IP_UUID}'
+        infrastructure = Infrastructure()
+        infrastructure.observable_characterization = Observables(
+            [Observable(address_object)]
+        )
+        ttp.resources = Resource()
+        ttp.resources.infrastructure = infrastructure
+        return ttp
+
+    def test_external_ttp_galaxy_title_writes_one_taxonomy_entry(self):
+        """A malware title is written into the tag the galaxy is: whatever
+        further taxonomy entries the title asks for, what is written is one."""
+        stix_package = STIXPackage()
+        stix_package.add_ttp(self._ttp_with_malware_title(SMUGGLING_TAG_VALUE))
+        parser = self._parse_external_package(stix_package)
+        attribute = parser.misp_event.attributes[0]
+        tags = {tag['name'] for tag in attribute.tags}
+        self.assertIn(f'misp-galaxy:ransomware="{SANITISED_TAG_VALUE}"', tags)
+        self.assertNotIn(
+            f'misp-galaxy:ransomware="{SMUGGLING_TAG_VALUE}"', tags
+        )
+
+    def test_external_tlp_marking_writes_one_taxonomy_entry(self):
+        """A TLP colour is written into a taxonomy tag of the library's own: it
+        names one entry of the `tlp` taxonomy, whatever the colour carries."""
+        stix_package = STIXPackage()
+        header = STIXHeader()
+        marking = MarkingSpecification()
+        tlp_marking = TLPMarkingStructure()
+        tlp_marking.color = 'AMBER" tlp:red'
+        marking.marking_structures.append(tlp_marking)
+        handling = Marking()
+        handling.add_marking(marking)
+        header.handling = handling
+        stix_package.stix_header = header
+        parser = self._parse_external_package(stix_package)
+        tags = {tag['name'] for tag in parser.misp_event.tags}
+        self.assertIn('tlp:amber tlp:red', tags)
+        self.assertNotIn('tlp:amber" tlp:red', tags)
 
     ############################################################################
     #                         PARSER STATE ISOLATION.                          #


### PR DESCRIPTION
## Description

#93 fixed the `misp-galaxy:producer` tag: a producer name carrying a `"` closed the value and had the rest of itself read as more taxonomy entries, so a bundle could tag the event it created with the `tlp:`, `PAP:` or `workflow:` values of its choosing. It fixed one tag. A sweep of the import tree finds twelve more places where text a converted document supplied is written into a tag the same way, none of them covered by that fix.

Two things the sweep found that the producer fix had not raised. **The taxonomy predicate is a slot too**, not only the value: `misp-galaxy:{galaxy_type}="{name}"` takes `galaxy_type` from the `misp:galaxy-type` label the document carries, so a label of `mitre-malware" tlp:red misp-galaxy:threat-actor="APT` breaks out of the tag even if every value is clean. Three sites interpolate that half. **And nothing downstream filters**: `MISPEvent().add_tag('a" tlp:red')` stores the string whole, so the library is the last place this can be caught.

## What was reachable

A galaxy name (`stix_object.name` on both the internal and external STIX 2 paths, an Identity or organisation name and a malware or attack-pattern title on the STIX 1 paths, a vulnerability title where no CVE id is given), a galaxy cluster value, a galaxy type label, an ACS marking's vocabulary fields and its `privilege_action`, an AIS marking's consent and TLP colour, and a STIX 1 TLP colour.

## The rule

Every tag is built by one function on the parser both directions inherit from, and no tag literal is left anywhere else. What a slot cannot carry — the `"`, and the control characters no XML or CSV export can write — is taken out of **both** slots, and each distinct alteration is reported. A slot nothing survives from leaves no tag rather than an empty one, which is what the producer tag already did.

**A galaxy cluster is named by its uuid when its value cannot be a tag value.** MISP attaches a cluster to a record by matching the tag against the cluster as an exact string, so cleaning the tag while the cluster keeps the value the document sent would leave the tag naming no cluster at all. Rather than censor the cluster, the tag keys on the cluster uuid, which any tag can carry — and only in that case, so a clean bundle round-trips byte for byte. Cluster types already prefixed `stix-` did this unconditionally; this extends it to the case that needs it.

**A test asserts no tag is built outside that function.** It reads the import sources as syntax rather than as lines, so an f-string is measured by the shape it writes whatever it interpolates, and `str.format`, `%` and concatenation cannot slip past. The number of places a document's text can reach the tag grammar is a property of the design now, rather than of the last search for them — which is how these twelve outlived #93. Running it immediately found a thirteenth site nobody had counted, the five confidence-level tags, which now go through the builder too.

## What is not touched

The tags a sender writes whole and an import copies — `tlp:*`, `PAP:*`, `workflow:*` and the labels a bundle carries — stay verbatim, as does every galaxy cluster `value`, `description` and `meta`. Preserving the context a document carries is what the import is for, and enforcement is carried by the distribution field, which the operator owns. What separates the two is who wrote the grammar, not who supplied the text: a sender's own tag is theirs to write, a slot in a tag this library authored is not.

## What changes for a caller

Nothing, for any content that had no metacharacters in it: the builder produces the string the f-strings produced, and the 1992 existing tests pass with no assertion changed. Nothing raises that did not raise before — the builder returns nothing to write and the call sites drop the tag.

Two edges worth naming. Whitespace around a slot is now trimmed, and the trim is reported, so a galaxy name sent with surrounding spaces is tagged without them. A field that is empty writes no tag where it used to write `namespace:predicate=""`.

## Tests

11 behaviour tests, each measured failing before its fix: the value slot and the predicate slot in `galaxies_as_tags` mode across 2.0 and 2.1 internal, the same on the external path, the cluster-named-by-uuid case on both versions, an ACS marking vocabulary field, and on STIX 1 a TTP galaxy title and a TLP marking colour. Plus the invariant test above, and the CI step now runs it.
