### PR TITLE
Refuse a MISP collection handed to the wrong STIX 1 conversion

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -1121,6 +1121,12 @@ class MISPtoSTIX1AttributesParser(MISPtoSTIX1Parser):
             raise InvalidMISPInputError(
                 'Input does not look like a MISP attributes collection.'
             )
+        for index, attribute in enumerate(attributes):
+            if not (isinstance(attribute, dict) and 'type' in attribute):
+                raise InvalidMISPInputError(
+                    'Input does not look like a MISP attributes collection: '
+                    f'item {index} is not a MISP attribute.'
+                )
         self._stix_package = STIXPackage()
         for attribute in attributes:
             self._resolve_attribute(attribute)
@@ -1168,10 +1174,22 @@ class MISPtoSTIX1EventsParser(MISPtoSTIX1Parser):
         if not isinstance(json_content, dict):
             raise InvalidMISPInputError('Input does not look like a MISP event.')
         if json_content.get('response') is not None:
+            events = json_content['response']
+            if not isinstance(events, list):
+                raise InvalidMISPInputError(
+                    'Input does not look like a MISP events collection.'
+                )
+            for index, event in enumerate(events):
+                if not (isinstance(event, dict)
+                        and ('Event' in event or 'info' in event)):
+                    raise InvalidMISPInputError(
+                        'Input does not look like a MISP events collection: '
+                        f'item {index} is not a MISP event.'
+                    )
             package = _create_stix_package(
                 self._orgname, self._version, header=False
             )
-            for event in json_content['response']:
+            for event in events:
                 self.parse_misp_event(event)
                 package.add_related_package(self._stix_package)
             self._stix_package = package

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -72,6 +72,20 @@ class TestSTIX1InputContract(TestSTIX):
                 {'Attribute': [deepcopy(_INDICATOR_ATTRIBUTE)]}
             )
 
+    def test_events_parser_wrapped_attributes_list_raises(self):
+        # Right wrapper, wrong items: attributes under the `response` key.
+        with self.assertRaises(InvalidMISPInputError):
+            self._events_parser().parse_json_content(
+                {'response': [deepcopy(_INDICATOR_ATTRIBUTE)]}
+            )
+
+    def test_events_parser_wrapped_attributes_collection_raises(self):
+        # The restSearch attributes collection shape, handed to the events parser.
+        with self.assertRaises(InvalidMISPInputError):
+            self._events_parser().parse_json_content(
+                {'response': {'Attribute': [deepcopy(_INDICATOR_ATTRIBUTE)]}}
+            )
+
     def test_events_parser_bare_event_converts(self):
         parser = self._events_parser()
         parser.parse_json_content(get_base_event()['Event'])
@@ -84,6 +98,13 @@ class TestSTIX1InputContract(TestSTIX):
     def test_attributes_parser_empty_dict_raises(self):
         with self.assertRaises(InvalidMISPInputError):
             self._attributes_parser().parse_json_content({})
+
+    def test_attributes_parser_events_collection_raises(self):
+        # A valid events collection is the wrong layer for the attributes parser.
+        with self.assertRaises(InvalidMISPInputError):
+            self._attributes_parser().parse_json_content(
+                {'response': [get_base_event()]}
+            )
 
     def test_attributes_parser_bare_list_converts(self):
         parser = self._attributes_parser()


### PR DESCRIPTION
## Description

STIX 1 has no auto-detection: the caller picks the data layer by picking the conversion — `misp_attribute_collection_to_stix1` or `misp_event_collection_to_stix1`, the two parsers behind them, or the CLI `--level` flag. Pick the wrong one and the input guard did not notice, because it validated the container the items arrived in and never the items themselves. A `{"response": …}` wrapper unwrapped to something iterable, passed the type check, and the first item that lacked an expected key threw whatever it threw — that exception's text was what the operator was shown:

```
misp_attribute_collection_to_stix1('events_collection.json')
  -> {'fails': ["… -  'type'"]}
misp_event_collection_to_stix1('attributes_collection.json')
  -> {'fails': ["… - string indices must be integers, not 'str'"]}
```

A dictionary key and an interpreter message, in place of a diagnosis. The second one is worse than it reads: an attributes collection wraps a *dict* under `response`, so iterating it yields the key `"Attribute"` and a bare string was carried into the event parsing path before anything noticed it was not an event.

## The check

Both parsers now check the items, not only the container, and check all of them before any conversion starts. An attributes collection is refused unless every item is a record with a `type`; an events collection is refused unless `response` holds a list and every item in it is a record with an `Event` or an `info`. The refusal is `InvalidMISPInputError`, the signal these parsers already raise for input that is not their layer, and the message names the item that does not belong rather than the symptom it produced.

Refusing before the package is built means a wrong-layer input writes no output file at all, where before it produced a failure only after part of the work was done.

## What is not touched

**Nothing that converted before stops converting.** The whole existing suite passes with no assertion changed.

**A mixed collection is refused rather than partly converted.** Item-level *validity* stays what it was — a well-formed attribute with bad content is still recorded as a conversion error and the batch continues. What is refused here is an item that is not of the parser's layer at all, which is the same call the STIX 2 dispatcher already makes for a list it cannot resolve to one kind.

**The events-parser half was never reported.** It was found while fixing the attributes one, and it is the same defect in the mirror direction.

## Behaviour changes for library consumers

- A wrong-layer collection raises `InvalidMISPInputError` where it used to raise `KeyError` or `TypeError` from inside the conversion. `InvalidMISPInputError` is already exported top-level, so callers have a stable type to catch; the file-based entry functions report it in their result dict as they report any failure.

## Tests

Three tests in the existing STIX 1 input-contract class, each measured failing before its fix: an events collection handed to the attributes parser, and — handed to the events parser — the restSearch attributes shape, and attributes under a `response` list.

Suite is 2007 green.
