### PR TITLE
[high] fix(misp2stix): remove duplicate group-list pop in unix user-account

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -2341,16 +2341,6 @@ class MISPtoSTIX1EventsParser(MISPtoSTIX1Parser):
             account_object.group_id.condition = 'Equals'
         if attributes.get('group'):
             self._set_group_list(account_object, attributes, UnixGroupList, UnixGroup, 'group_id')
-            group_list = UnixGroupList()
-            groups = attributes.pop('group')
-            try:
-                for group in groups:
-                    unix_group = UnixGroup()
-                    unix_group.group_id = group
-                    group_list.append(unix_group)
-                account_object.group_list = group_list
-            except ValueError:
-                attributes['group'] = groups
         return account_object
 
     def _create_user_account_object(self, attributes: dict) -> Union[UnixUserAccount, UserAccount, WinUser]:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6405,6 +6405,23 @@ def get_event_with_user_account_objects():
     return event
 
 
+def get_event_with_unix_user_account_object():
+    event = deepcopy(_BASE_EVENT)
+    unix_user_account = deepcopy(_TEST_USER_ACCOUNT_OBJECT)
+    for attribute in unix_user_account['Attribute']:
+        if attribute['object_relation'] == 'group':
+            attribute['value'] = '1000' if attribute['value'] == 'viktor-fan' else '1001'
+    unix_user_account['Attribute'].append(
+        {
+            "type": "text",
+            "object_relation": "account-type",
+            "value": "unix"
+        }
+    )
+    event['Event']['Object'] = [dict(_populate_object(unix_user_account))]
+    return event
+
+
 def get_event_with_vulnerability_and_weakness_objects():
     event = deepcopy(_BASE_EVENT)
     weakness = dict(_populate_object(_TEST_WEAKNESS_OBJECT))

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -2271,6 +2271,28 @@ class TestStix1Export(TestSTIX):
         windows_properties = self._check_observable_features(windows_observable.item, windows, 'WindowsUserAccount')
         self._check_windows_user_account_properties(windows_properties, windows['Attribute'])
 
+    def _test_event_with_unix_user_account_object(self, event):
+        self._remove_ids_flags(event)
+        unix = deepcopy(event['Object'][0])
+        self.parser.parse_misp_event(event)
+        incident = self.parser.stix_package.incidents[0]
+        unix_observable = incident.related_observables.observable[0]
+        self.assertEqual(unix_observable.relationship, unix['meta-category'])
+        observable_object = unix_observable.item.object_
+        self.assertEqual(
+            observable_object.id_,
+            f"{_ORGNAME_ID}:UnixUserAccount-{unix['uuid']}"
+        )
+        properties = observable_object.properties
+        self.assertEqual(properties._XSI_TYPE, 'UnixUserAccountObjectType')
+        username, user_id, display_name, password, group1, group2, group_id, home_dir, avatar, _ = unix['Attribute']
+        self.assertEqual(properties.username.value, username['value'])
+        group_list = properties.group_list
+        self.assertEqual(len(group_list), 2)
+        first_group, second_group = group_list
+        self.assertEqual(first_group.group_id.value, int(group1['value']))
+        self.assertEqual(second_group.group_id.value, int(group2['value']))
+
     def _test_event_with_vulnerability_and_weakness_related_object(self, event):
         vulnerability, weakness = deepcopy(event['Object'])
         self.parser.parse_misp_event(event)
@@ -2787,6 +2809,10 @@ class TestSTIX11JSONExport(TestSTIX11Export):
     def test_event_with_user_account_objects_observable(self):
         event = get_event_with_user_account_objects()
         self._test_event_with_user_account_objects_observable(event['Event'])
+
+    def test_event_with_unix_user_account_object(self):
+        event = get_event_with_unix_user_account_object()
+        self._test_event_with_unix_user_account_object(event['Event'])
 
     def test_event_with_vulnerability_and_weakness_related_object(self):
         event = get_event_with_vulnerability_and_weakness_objects()
@@ -3362,6 +3388,12 @@ class TestSTIX11MISPExport(TestSTIX11Export):
         misp_event.from_dict(**event)
         self._test_event_with_user_account_objects_observable(misp_event)
 
+    def test_event_with_unix_user_account_object(self):
+        event = get_event_with_unix_user_account_object()
+        misp_event = MISPEvent()
+        misp_event.from_dict(**event)
+        self._test_event_with_unix_user_account_object(misp_event)
+
     def test_event_with_vulnerability_and_weakness_related_object(self):
         event = get_event_with_vulnerability_and_weakness_objects()
         misp_event = MISPEvent()
@@ -3798,6 +3830,10 @@ class TestSTIX12JSONExport(TestSTIX12Export):
     def test_event_with_user_account_objects_observable(self):
         event = get_event_with_user_account_objects()
         self._test_event_with_user_account_objects_observable(event['Event'])
+
+    def test_event_with_unix_user_account_object(self):
+        event = get_event_with_unix_user_account_object()
+        self._test_event_with_unix_user_account_object(event['Event'])
 
     def test_event_with_vulnerability_and_weakness_related_object(self):
         event = get_event_with_vulnerability_and_weakness_objects()
@@ -4372,6 +4408,12 @@ class TestSTIX12MISPExport(TestSTIX12Export):
         misp_event = MISPEvent()
         misp_event.from_dict(**event)
         self._test_event_with_user_account_objects_observable(misp_event)
+
+    def test_event_with_unix_user_account_object(self):
+        event = get_event_with_unix_user_account_object()
+        misp_event = MISPEvent()
+        misp_event.from_dict(**event)
+        self._test_event_with_unix_user_account_object(misp_event)
 
     def test_event_with_vulnerability_and_weakness_related_object(self):
         event = get_event_with_vulnerability_and_weakness_objects()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A duplicate `group` pop makes the typed `UnixUserAccount` export path unreachable for valid input.

- **Problem** — `_create_unix_user_account_object` in `misp_to_stix1.py` calls `_set_group_list` and is then followed by a leftover duplicate block that pops `'group'` a second time. `_set_group_list` already pops that key, so any successful group assignment raises `KeyError`, which `_resolve_objects` swallows before falling back to `_parse_custom_object`.
- **Fix** — Delete the dead duplicate block, matching the sibling `_create_windows_user_account_object`.
- **Effect** — Unix user-account objects with valid group values now export as typed `UnixUserAccount` observables with a correct `group_list` instead of a generic `Custom` observable.
<!-- /bluf -->

## Problem

In `misp_stix_converter/misp2stix/misp_to_stix1.py`, `_create_unix_user_account_object()` calls `_set_group_list()` (around line 2341) to build the `group_list`, but is immediately followed by a leftover block of dead code that duplicates the same logic and pops `'group'` from `attributes` a second time. `_set_group_list()` already pops that key itself (restoring it only on its own `ValueError` fallback path), so on any successful group assignment the second `attributes.pop('group')` raises `KeyError`.

Because `_resolve_objects()` catches all exceptions and silently falls back to `_parse_custom_object`, a unix `user-account` MISP object with valid numeric `group` values never reaches the typed `UnixUserAccount` STIX object — it is quietly degraded to a generic `Custom` observable instead, with no error surfaced to the user.

## Fix

Delete the duplicated block and rely solely on `_set_group_list()` for building the `UnixGroupList`, matching the pattern already used by the sibling `_create_windows_user_account_object()`, which calls `_set_group_list()` once and nothing else.

## Testing

Ran the repository's test gate: `2032 passed, 1501 warnings, 52 subtests passed in 458.17s (0:07:38)`.

Added a regression test, `test_event_with_unix_user_account_object` (parameterized across `TestSTIX11JSONExport`, `TestSTIX11MISPExport`, `TestSTIX12JSONExport`, and `TestSTIX12MISPExport`), plus its `get_event_with_unix_user_account_object` fixture in `tests/test_events.py`. It exercises a unix `user-account` object with numeric group values and asserts the resulting observable is a typed `UnixUserAccount` (not `Custom`) with the correct `group_list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

