### PR TITLE
[high] fix(misp2stix): link attachment-only File objects to their Artifact

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix20.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix20.py
@@ -985,7 +985,10 @@ class MISPtoSTIX20Parser(MISPtoSTIX2Parser):
                 )
         elif isinstance(attributes.get('attachment'), tuple):
             args = self._create_attachment_args(*attributes.pop('attachment'))
-            observable_object[str(index)] = Artifact(**args)
+            str_index = str(index)
+            observable_object[str_index] = Artifact(**args)
+            file_args['content_ref'] = str_index
+            file_args['_valid_refs'][str_index] = 'artifact'
         if attributes:
             file_args.update(
                 self._parse_file_args(

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -1038,8 +1038,10 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
             if len(value) == 3:
                 filename, data, uuid = value
                 args = self._create_attachment_args(filename, data)
-                args['id'] = f'artifact--{uuid}'
+                artifact_id = f'artifact--{uuid}'
+                args['id'] = artifact_id
                 objects.append(Artifact(**args))
+                file_args['content_ref'] = artifact_id
             else:
                 file_args.update(
                     {'allow_custom': True, 'x_misp_attachment': value[0]}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2392,6 +2392,32 @@ _TEST_FILE_OBJECT = {
     ]
 }
 
+_TEST_FILE_OBJECT_WITH_ATTACHMENT_ONLY = {
+    "name": "file",
+    "meta-category": "file",
+    "description": "File object describing a file with meta-information",
+    "uuid": "5e384ae7-672c-4250-9cda-3b4da964451b",
+    "timestamp": "1603642920",
+    "Attribute": [
+        {
+            "type": "filename",
+            "object_relation": "filename",
+            "value": "oui"
+        },
+        {
+            "type": "md5",
+            "object_relation": "md5",
+            "value": "8764605c6f388c89096b534d33565802"
+        },
+        {
+            "uuid": "518b4bcb-a86b-4783-9457-391d548b605c",
+            "type": "attachment",
+            "object_relation": "attachment",
+            "value": "non"
+        }
+    ]
+}
+
 _TEST_FILE_FOR_PE_OBJECT = {
     "name": "file",
     "meta-category": "file",
@@ -5955,6 +5981,16 @@ def get_event_with_file_object_with_artifact():
     with open(_TESTFILES_PATH / 'malware_sample.zip', 'rb') as f:
         file_object['Attribute'][0]['data'] = b64encode(f.read()).decode()
     file_object['Attribute'][6]['data'] = "Tm9uLW1hbGljaW91cyBmaWxlCg=="
+    event['Event']['Object'] = [file_object]
+    return event
+
+
+def get_event_with_file_object_with_attachment_only():
+    event = deepcopy(_BASE_EVENT)
+    file_object = dict(
+        _populate_object(_TEST_FILE_OBJECT_WITH_ATTACHMENT_ONLY)
+    )
+    file_object['Attribute'][2]['data'] = "Tm9uLW1hbGljaW91cyBmaWxlCg=="
     event['Event']['Object'] = [file_object]
     return event
 

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -2388,6 +2388,21 @@ class TestSTIX20ObjectsExport(TestSTIX20GenericExport):
         self.assertEqual(artifact.hashes['MD5'], md5)
         self.assertEqual(artifact.x_misp_filename, filename)
 
+    def _check_file_observable_object_attachment_only(
+            self, misp_object, observed_data):
+        _filename, _md5, _attachment = misp_object.attributes
+        _file = observed_data.objects['0']
+        self.assertEqual(_file.type, 'file')
+        self.assertEqual(_file.name, _filename.value)
+        self.assertEqual(_file.hashes['MD5'], _md5.value)
+        self.assertEqual(_file.content_ref, '1')
+        artifact = observed_data.objects['1']
+        self.assertEqual(artifact.type, 'artifact')
+        data = _attachment.data
+        if not isinstance(data, str):
+            data = b64encode(data.getvalue()).decode()
+        self.assertEqual(artifact.payload_bin, data)
+
     def _check_hashlookup_observable_object(self, misp_object, observed_data):
         (filename, filesize, known_malicious, md5, sha1, sha256, ssdeep, tlsh,
          package_name, package_version, package_release, package_arch,
@@ -3270,6 +3285,12 @@ class TestSTIX20ObjectsExport(TestSTIX20GenericExport):
     def _test_event_with_file_observable_object(self, event):
         misp_object, observed_data = self._run_observable_from_object_tests(event)
         self._check_file_observable_object(misp_object, observed_data)
+
+    def _test_event_with_file_observable_object_attachment_only(self, event):
+        misp_object, observed_data = self._run_observable_from_object_tests(event)
+        self._check_file_observable_object_attachment_only(
+            misp_object, observed_data
+        )
 
     def _test_event_with_http_request_indicator_object(self, event):
         misp_object, observed_data, pattern = self._run_indicator_from_object_tests(event)
@@ -4712,6 +4733,14 @@ class TestSTIX20MISPObjectsExport(TestSTIX20ObjectsExport):
         misp_event = MISPEvent()
         misp_event.from_dict(**event)
         self._test_event_with_file_observable_object(misp_event)
+
+    def test_event_with_file_observable_object_attachment_only(self):
+        event = get_event_with_file_object_with_attachment_only()
+        misp_event = MISPEvent()
+        misp_event.from_dict(**event)
+        self._test_event_with_file_observable_object_attachment_only(
+            misp_event
+        )
 
     def test_event_with_hashlookup_indicator_object(self):
         event = get_event_with_hashlookup_object()

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -3014,6 +3014,27 @@ class TestSTIX21ObjectsExport(TestSTIX21GenericExport):
         self.assertEqual(artifact.hashes['MD5'], md5)
         self.assertEqual(artifact.x_misp_filename, filename)
 
+    def _check_file_observable_object_attachment_only(
+            self, misp_object, observables, object_refs):
+        _filename, _md5, _attachment = misp_object['Attribute']
+        _file, artifact = observables
+        file_ref, artifact_ref = object_refs
+        self._assert_multiple_equal(
+            _file.id, file_ref, f"file--{misp_object['uuid']}"
+        )
+        self.assertEqual(_file.type, 'file')
+        self.assertEqual(_file.name, _filename['value'])
+        self.assertEqual(_file.hashes['MD5'], _md5['value'])
+        self._assert_multiple_equal(
+            _file.content_ref, artifact.id, artifact_ref,
+            f"artifact--{_attachment['uuid']}"
+        )
+        self.assertEqual(artifact.type, 'artifact')
+        data = _attachment['data']
+        if not isinstance(data, str):
+            data = b64encode(data.getvalue()).decode()
+        self.assertEqual(artifact.payload_bin, data)
+
     def _check_hashlookup_observable_object(self, misp_object, observable, object_ref):
         (filename, filesize, known_malicious, md5, sha1, sha256, ssdeep, tlsh,
          package_name, package_version, package_release, package_arch,
@@ -4121,6 +4142,12 @@ class TestSTIX21ObjectsExport(TestSTIX21GenericExport):
     def _test_event_with_file_observable_object(self, event):
         misp_object, observables, object_refs = self._run_observable_from_object_tests(event)
         self._check_file_observable_object(misp_object, observables, object_refs)
+
+    def _test_event_with_file_observable_object_attachment_only(self, event):
+        misp_object, observables, object_refs = self._run_observable_from_object_tests(event)
+        self._check_file_observable_object_attachment_only(
+            misp_object, observables, object_refs
+        )
 
     def _test_event_with_hashlookup_indicator_object(self, event):
         misp_object, observables, object_refs, pattern = self._run_indicator_from_object_tests(event)
@@ -5778,6 +5805,14 @@ class TestSTIX21MISPObjectsExport(TestSTIX21ObjectsExport):
         misp_event = MISPEvent()
         misp_event.from_dict(**event)
         self._test_event_with_file_observable_object(misp_event)
+
+    def test_event_with_file_observable_object_attachment_only(self):
+        event = get_event_with_file_object_with_attachment_only()
+        misp_event = MISPEvent()
+        misp_event.from_dict(**event)
+        self._test_event_with_file_observable_object_attachment_only(
+            misp_event
+        )
 
     def test_event_with_geolocation_object(self):
         event = get_event_with_geolocation_object()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Attachment-only file objects export an orphaned `Artifact` that nothing links back to its `File`.

- **Problem** — The attachment branch of `_parse_file_observable_object` in both `misp_to_stix20.py` and `misp_to_stix21.py` creates the `Artifact` observable but never sets `file_args['content_ref']` (nor, for 2.0, the `_valid_refs` entry), unlike the malware-sample branch just above it. Consumers cannot associate the attachment content with its file.
- **Fix** — Set `content_ref` in both exporters, registering the 2.0 valid ref and reusing the `artifact--<uuid>` id in 2.1.
- **Effect** — Attachment-only file objects now round-trip with a correct content reference.
<!-- /bluf -->

## Problem

In `_parse_file_observable_object` (both `misp_to_stix20.py` and `misp_to_stix21.py`), the `elif` branch that handles a MISP `file` object's `attachment` field creates the STIX `Artifact` observable but never links it back to the `File` object it belongs to.

- In `misp_to_stix20.py`, around line 987, the branch does `observable_object[str(index)] = Artifact(**args)` but never sets `file_args['content_ref']`, and never registers the artifact in `_valid_refs`.
- In `misp_to_stix21.py`, around line 1040, the branch appends the `Artifact` to `objects` but never sets `file_args['content_ref']`.

This is inconsistent with the `malware-sample` branch directly above each of these, which sets both `content_ref` and (for 2.0) the `_valid_refs` entry when creating its `Artifact`.

Concrete trigger: a MISP `file` object that carries only an `attachment` attribute (no `malware-sample`). Exporting it to STIX 2.0 or 2.1 produces a `File` SCO and a separate `Artifact` SCO, but the `File` has no `content_ref` pointing at the `Artifact` — so the artifact is emitted as an orphaned object with nothing referencing it, and consumers cannot associate the attachment content with the file it belongs to.

## Fix

Set `content_ref` on `file_args` to the artifact's reference in the attachment branch, mirroring what the `malware-sample` branch already does immediately above it:

- `misp_to_stix20.py`: store the artifact under `str_index`, set `file_args['content_ref'] = str_index`, and register `file_args['_valid_refs'][str_index] = 'artifact'`.
- `misp_to_stix21.py`: build the artifact's `artifact--<uuid>` id once, reuse it for `Artifact.id`, and set `file_args['content_ref']` to the same id.

## Testing

Ran the existing test gate: 2030 passed, 1489 warnings, 52 subtests passed in 214.11s (0:03:34).

Added regression coverage in `tests/test_events.py`, `tests/test_stix20_export.py`, and `tests/test_stix21_export.py` exercising a `file` object with only an `attachment` (no `malware-sample`), asserting the exported `File`'s `content_ref` points at the corresponding `Artifact`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
