### PR TITLE
[high] fix(stix21): guard unguarded split() in region galaxy export

### DIFF
--- a/misp_stix_converter/misp2stix/exportparser.py
+++ b/misp_stix_converter/misp2stix/exportparser.py
@@ -152,7 +152,11 @@ class MISPtoSTIXParser(AbstractParser):
                 galaxy_type = galaxy['type']
                 to_call = self._mapping.galaxy_types_mapping(galaxy_type)
                 if to_call is not None:
-                    getattr(self, to_call.format('event'))(galaxy)
+                    try:
+                        getattr(self, to_call.format('event'))(galaxy)
+                    except Exception as exception:
+                        self._event_galaxy_error(galaxy, exception)
+                        continue
                     tag_names.extend(self._quick_fetch_tag_names(galaxy))
                 else:
                     self._handle_undefined_event_galaxy(galaxy)
@@ -367,6 +371,12 @@ class MISPtoSTIXParser(AbstractParser):
         self._add_warning(
             f'Invalid MISP object template name {name!r}: the object is '
             f'converted as a {_UNKNOWN_TEMPLATE_NAME} one.', identifier
+        )
+
+    def _event_galaxy_error(self, galaxy: dict, exception: Exception):
+        tb = self._parse_traceback(exception)
+        self._add_error(
+            f"Error with the {galaxy['type']} galaxy in event:\n{tb}."
         )
 
     def _event_galaxy_not_mapped_warning(self, galaxy_type: str):

--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -1749,7 +1749,7 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
             self, cluster: MISPGalaxyCluster | dict, description: str,
             name: str, timestamp: datetime| None) -> dict:
         meta = cluster.get('meta', {})
-        region_value = cluster['value'].split(' - ')[1]
+        region_value = cluster['value'].partition(' - ')[2] or cluster['value']
         location_args = {
             'id': f"location--{cluster['uuid']}", 'type': 'location',
             'description': f"{description} | {cluster['description']}",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1248,6 +1248,22 @@ _TEST_REGION_GALAXY = {
     ]
 }
 
+_TEST_MALFORMED_REGION_GALAXY = {
+    "uuid": "d151a79a-e029-11e9-9409-f3e0cf3d93bb",
+    "name": "Regions UN M49",
+    "type": "region",
+    "description": "Regions based on UN M49",
+    "GalaxyCluster": [
+        {
+            "uuid": "f93cb275-0366-4ecc-abf0-a17928d1e188",
+            "type": "region",
+            "value": "Antarctica",
+            "description": "Antarctica",
+            "meta": {}
+        }
+    ]
+}
+
 _TEST_SECTOR_GALAXY = {
     "uuid": "e1bb134c-ae4d-11e7-8aa9-f78a37325439",
     "name": "Sector",
@@ -4657,6 +4673,14 @@ def get_event_with_location_galaxies():
     event['Event']['Galaxy'] = [
         deepcopy(_TEST_COUNTRY_GALAXY),
         deepcopy(_TEST_REGION_GALAXY)
+    ]
+    return event
+
+
+def get_event_with_malformed_region_galaxy():
+    event = deepcopy(_BASE_EVENT)
+    event['Event']['Galaxy'] = [
+        deepcopy(_TEST_MALFORMED_REGION_GALAXY)
     ]
     return event
 

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -6476,6 +6476,18 @@ class TestSTIX21JSONGalaxiesExport(TestSTIX21GalaxiesExport):
         for galaxy, location in zip(self.parser._misp_event.galaxies, self.parser.stix_objects[-2:]):
             self._populate_documentation(galaxy=galaxy, stix=location)
 
+    def test_event_with_malformed_region_galaxy(self):
+        # A custom region cluster whose value has no ' - ' separator (e.g.
+        # "Antarctica") must not raise an IndexError and abort the export.
+        event = get_event_with_malformed_region_galaxy()
+        galaxy = event['Event']['Galaxy'][0]
+        cluster = galaxy['GalaxyCluster'][0]
+        timestamp = self._datetime_from_timestamp(event['Event']['timestamp'])
+        location = self._run_galaxy_tests(event['Event'], timestamp)
+        self.assertEqual(location.type, 'location')
+        self.assertEqual(location.name, cluster['value'])
+        self.assertEqual(location.region, cluster['value'].lower())
+
     def test_event_with_malware_galaxy(self):
         event = get_event_with_malware_galaxy()
         self._test_event_with_malware_galaxy(event['Event'])


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** One malformed region galaxy cluster raises `IndexError` and aborts the whole STIX 2.1 export.

- **Problem** — `_create_region_galaxy_args` in `misp_to_stix21.py` builds a STIX location with `cluster['value'].split(' - ')[1]`, so a custom region cluster without the `' - '` separator raises `IndexError`. `_handle_event_tags_and_galaxies` in `exportparser.py` dispatches event-level galaxies with none of the try/except protection attribute- and object-level galaxy parsing already has.
- **Fix** — Switch to `partition(' - ')[2]` with a fallback to the raw value, and wrap the event-galaxy dispatch so a bad cluster is recorded via a new `_event_galaxy_error` helper and skipped.
- **Effect** — A single malformed galaxy no longer takes down a whole export.
<!-- /bluf -->

## Problem

In `misp_stix_converter/misp2stix/misp_to_stix21.py`, `_create_region_galaxy_args` builds a STIX `location` object from a region galaxy cluster using:

```python
region_value = cluster['value'].split(' - ')[1]
```

Stock MISP region clusters are named like `"Antarctica - AQ"`, so the split always has an index 1. A custom region cluster whose value has no `" - "` separator (e.g. simply `"Antarctica"`) raises `IndexError: list index out of range` at that line, aborting the entire STIX 2.1 export for the event.

Separately, `_handle_event_tags_and_galaxies` in `misp_stix_converter/misp2stix/exportparser.py` dispatches event-level galaxies without the try/except that already wraps attribute- and object-level galaxy parsing (see `_resolve_attribute` / `_resolve_object` in `misp_to_stix2.py`), so any single malformed event-level galaxy cluster propagates and aborts the whole export instead of being recorded as an error and skipped.

## Fix

- In `misp_to_stix21.py`, replace the unguarded `split(' - ')[1]` with `cluster['value'].partition(' - ')[2] or cluster['value']`, falling back to the raw value when the separator is absent. This matches the tolerant parsing style already used elsewhere in the file.
- In `exportparser.py`, wrap the event-galaxy dispatch call in `_handle_event_tags_and_galaxies` in a try/except that records the error via a new `_event_galaxy_error` helper (mirroring the existing `_attribute_error` / `_object_error` pattern) and continues with the next galaxy instead of propagating the exception.

## Testing

Full gate command passed: 2029 passed, 1489 warnings, 52 subtests passed in 350.35s (0:05:50).

Added a regression test, `tests/test_stix21_export.py::TestSTIX21JSONGalaxiesExport::test_event_with_malformed_region_galaxy`, using a new fixture (`get_event_with_malformed_region_galaxy` / `_TEST_MALFORMED_REGION_GALAXY` in `tests/test_events.py`). It constructs an event with a region galaxy cluster valued `"Antarctica"` (no `" - "` separator) and asserts the export completes, with the resulting location falling back to the raw value / lowercased region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
