### PR TITLE
[high] fix(stix2.1 export): require text before building annotation Note

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix21.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix21.py
@@ -726,6 +726,15 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
                     object_refs[object_ref] = None
         if not object_refs:
             return self._parse_custom_object(misp_object)
+        attributes = self._extract_multiple_object_attributes_with_data(
+            misp_object['Attribute'],
+            force_single=self._mapping.annotation_single_fields(),
+            with_data=self._mapping.annotation_data_fields()
+        )
+        if not attributes.get('text'):
+            # `Note.content` is required in STIX 2.1; without a `text`
+            # attribute the object cannot be represented as a `Note`.
+            return self._parse_custom_object(misp_object)
         note_id = self._parse_stix_object_id('object', 'note', misp_object)
         timestamp = self._parse_timestamp_value(misp_object)
         note_args = {
@@ -738,13 +747,7 @@ class MISPtoSTIX21Parser(MISPtoSTIX2Parser):
         )
         if markings:
             self._handle_markings(note_args, markings)
-        attributes = self._extract_multiple_object_attributes_with_data(
-            misp_object['Attribute'],
-            force_single=self._mapping.annotation_single_fields(),
-            with_data=self._mapping.annotation_data_fields()
-        )
-        if attributes.get('text'):
-            note_args['content'] = attributes.pop('text')
+        note_args['content'] = attributes.pop('text')
         if attributes:
             note_args['allow_custom'] = True
             for key, values in attributes.items():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5835,6 +5835,26 @@ def get_event_with_annotation_object():
     return event
 
 
+def get_event_with_annotation_object_without_text():
+    event = deepcopy(_BASE_EVENT)
+    domain_ip = dict(_populate_object(_TEST_DOMAIN_IP_OBJECT))
+    annotation = dict(_populate_object(_TEST_ANNOTATION_OBJECT))
+    annotation['Attribute'] = [
+        attribute for attribute in annotation['Attribute']
+        if attribute['object_relation'] != 'text'
+    ]
+    annotation['ObjectReference'] = [
+        {
+            "uuid": uuid5(_TEST_UUID, domain_ip['uuid']).__str__(),
+            "object_uuid": annotation['uuid'],
+            "referenced_uuid": domain_ip['uuid'],
+            "relationship_type": "annotates"
+        }
+    ]
+    event['Event']['Object'] = [annotation, domain_ip]
+    return event
+
+
 def get_event_with_asn_object():
     event = deepcopy(_BASE_EVENT)
     event['Event']['Object'] = [

--- a/tests/test_stix21_export.py
+++ b/tests/test_stix21_export.py
@@ -3844,6 +3844,18 @@ class TestSTIX21ObjectsExport(TestSTIX21GenericExport):
             data = b64encode(data.getvalue()).decode()
         self.assertEqual(note.x_misp_attachment['data'], data)
 
+    def _test_event_with_annotation_object_without_text(self, event):
+        self.parser.parse_misp_event(event)
+        annotation, domain_ip = self.parser._misp_event.objects
+        stix_objects = self.parser.stix_objects
+        self._check_spec_versions(stix_objects)
+        (identity, grouping, observed_data, _, _, indicator,
+         custom, *relationships) = stix_objects
+        self.assertEqual(
+            custom.id, f"x-misp-object--{annotation.uuid}"
+        )
+        self.assertFalse(any(o.type == 'note' for o in stix_objects))
+
     def _test_event_with_android_app_indicator_object(self, event):
         misp_object, observables, object_refs, pattern = self._run_indicator_from_object_tests(event)
         self._assert_multiple_equal(len(observables), len(object_refs), 1)
@@ -4972,6 +4984,10 @@ class TestSTIX21JSONObjectsExport(TestSTIX21ObjectsExport):
             stix=self.parser.stix_objects[2:], name='annotation',
             summary='**Note** with references to the annotated objects'
         )
+
+    def test_event_with_annotation_object_without_text(self):
+        event = get_event_with_annotation_object_without_text()
+        self._test_event_with_annotation_object_without_text(event['Event'])
 
     def test_event_with_android_app_indicator_object(self):
         event = get_event_with_android_app_object()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Annotation objects with references but no `text` are silently dropped from the STIX 2.1 export.

- **Problem** — `_parse_annotation_object` in `misp_to_stix21.py` picks the `Note` path as soon as the annotation has a supported reference, but only sets `note_args['content']` if a `text` attribute happens to exist. Without `text`, `stix2.Note` fails its required `content` property with `MissingPropertiesError`, which the object-level catch-all swallows, so the annotation vanishes.
- **Fix** — Read the attributes up front and fall back to `_parse_custom_object` when `text` is absent.
- **Effect** — Such annotations are now exported as custom objects instead of being silently dropped.
<!-- /bluf -->

## Problem

In `misp_to_stix21.py`, `_parse_annotation_object` (around line 726) chose the `Note` code path whenever the annotation object had at least one supported reference, then set `note_args['content']` only if a `text` attribute happened to be present on the object. `Note.content` is a required property in STIX 2.1, so when an annotation object referenced a supported object but had no `text` attribute, building the `stix2.Note` raised `MissingPropertiesError`. That exception was swallowed by the object-level catch-all, so the whole annotation was silently dropped from the export instead of being represented in any form.

## Fix

Extract the annotation's attributes up front (before deciding on a representation) and check whether `text` is present. If it is absent, fall back to `_parse_custom_object`, the same fallback already used a few lines above when there are no supported object references — so an annotation without `text` now degrades gracefully to a custom object instead of vanishing. When `text` is present, `note_args['content']` is set unconditionally from it, since the check above already guarantees it exists.

## Testing

Ran the existing gate command: 2029 passed, 1488 warnings, 52 subtests passed in 315.30s (0:05:15).

Added a regression test: `tests/test_stix21_export.py::TestSTIX21JSONObjectsExport::test_event_with_annotation_object_without_text`, using a new fixture `get_event_with_annotation_object_without_text` added in `tests/test_events.py`. The test builds an annotation object with its `text` attribute removed and asserts it is exported as a custom object (`x-misp-object--...`) rather than being dropped, and that no `note` object appears in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
