### PR TITLE
[medium] fix(misp2stix): use aware UTC now() for event_timestamp fallback

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -405,7 +405,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
         try:
             return self.__event_timestamp
         except AttributeError:
-            event_timestamp = datetime.now()
+            event_timestamp = datetime.now(UTC)
             self.__event_timestamp = event_timestamp
             return event_timestamp
 

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -31,6 +31,12 @@ class TestSTIX20InputContract(TestSTIX20GenericExport):
         with self.assertRaises(InvalidMISPInputError):
             self.parser.parse_json_content({'foo': 'bar'})
 
+    def test_event_timestamp_fallback_is_timezone_aware(self):
+        # No event timestamp is available, so `event_timestamp` falls back
+        # to the current time, which must be timezone-aware like every
+        # other timestamp produced by the parser.
+        self.assertIsNotNone(self.parser.event_timestamp.tzinfo)
+
     def test_single_bare_attribute_converts(self):
         self.parser.parse_json_content(get_indicator_attribute())
         self.assertIsNotNone(self.parser.bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** The `event_timestamp` fallback emits a naive value, mixing naive and aware times in one bundle.

- **Problem** — `MISPtoSTIX2Parser.event_timestamp` in `misp_to_stix2.py` falls back to a naive `datetime.now()` when no event timestamp is available, while its sibling `_handle_event_timestamp` already uses `datetime.now(UTC)`. Bundles built via `parse_misp_attribute(s)`, `parse_misp_object(s)` or galaxy conversion can therefore mix naive local-time `created`/`modified` values with aware ones.
- **Fix** — A one-line change uses `datetime.now(UTC)` for the fallback.
- **Effect** — Every timestamp the parser emits is now timezone-aware and consistent.
<!-- /bluf -->

## Problem

`MISPtoSTIX2Parser.event_timestamp` (misp_stix_converter/misp2stix/misp_to_stix2.py, line 408) falls back to naive `datetime.now()` when no event timestamp is available, while its sibling `_handle_event_timestamp` uses `datetime.now(UTC)`. This fallback is reached via `parse_misp_attribute(s)` / `parse_misp_object(s)` and galaxy conversion when the input carries no event timestamp. The result is a naive, local-time `created`/`modified` value mixed with timezone-aware ones in the same STIX bundle, which is inconsistent with the rest of the converter's timestamp handling and can surface as comparison/serialization mismatches downstream.

## Fix

Use `datetime.now(UTC)` for the fallback, matching the existing sibling pattern (`_handle_event_timestamp`) so every timestamp produced by the parser is timezone-aware. This is a one-line change with no behavioral impact beyond making the fallback timestamp aware instead of naive.

## Testing

Ran the repo's test gate: 2029 passed, 1489 warnings, 52 subtests passed in 438.59s (0:07:18).

Added a regression test, `tests/test_stix20_export.py::TestSTIX20InputContract::test_event_timestamp_fallback_is_timezone_aware`, asserting the fallback `event_timestamp` carries `tzinfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
