### PR TITLE
[high] fix(misp2stix): guard unset custom var on pe extension parse error

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix2.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix2.py
@@ -3343,6 +3343,7 @@ class MISPtoSTIX2Parser(MISPtoSTIXParser, metaclass=ABCMeta):
         file_args, observable = self._parse_file_observable_object(
             file_object
         )
+        custom = False
         try:
             extension_args, custom = self._parse_pe_extensions_observable(
                 pe_object['misp_object'], section_uuids

--- a/tests/test_stix20_export.py
+++ b/tests/test_stix20_export.py
@@ -6,12 +6,15 @@ from misp_stix_converter import (
     InvalidMISPInputError, MISPtoSTIX20Mapping, MISPtoSTIX20Parser,
     misp_collection_to_stix2, misp_to_stix2)
 from pymisp import MISPAttribute, MISPEvent
+from unittest.mock import patch
 from .test_events import *
 from .update_documentation import (
     AttributesDocumentationUpdater, GalaxiesDocumentationUpdater,
     ObjectsDocumentationUpdater)
 from ._test_stix import TestSTIX20
 from ._test_stix_export import TestCollectionSTIX2Export, TestSTIX2Export, TestSTIX20Export
+
+_parser_module = 'misp_stix_converter.misp2stix.misp_to_stix2'
 
 
 class TestSTIX20GenericExport(TestSTIX20Export, TestSTIX20):
@@ -4118,6 +4121,35 @@ class TestSTIX20JSONObjectsExport(TestSTIX20ObjectsExport):
     def test_event_with_file_and_pe_observable_objects(self):
         event = get_event_with_file_and_pe_objects()
         self._test_event_with_file_and_pe_observable_objects(event['Event'])
+
+    def test_event_with_file_and_pe_observable_object_pe_parsing_error(self):
+        # If parsing the pe extension raises, the file object must still be
+        # produced as a plain file observable instead of crashing with an
+        # UnboundLocalError on the unset `custom` fallback variable.
+        event = get_event_with_file_and_pe_objects()
+        self._remove_object_ids_flags(event['Event'])
+        # Drop the only non-mapped file attribute so `file_args` has no
+        # `allow_custom` key yet, forcing evaluation of the `custom`
+        # fallback set by `_parse_pe_extensions_observable`.
+        file_object = event['Event']['Object'][0]
+        file_object['Attribute'] = [
+            attribute for attribute in file_object['Attribute']
+            if attribute['object_relation'] != 'entropy'
+        ]
+        with patch(
+            f'{_parser_module}.MISPtoSTIX2Parser'
+            '._parse_pe_extensions_observable',
+            side_effect=Exception('pe parsing error')
+        ):
+            self.parser.parse_misp_event(event['Event'])
+        observed_data = next(
+            stix_object for stix_object in self.parser.stix_objects
+            if stix_object.type == 'observed-data'
+            and stix_object.objects['0'].type == 'file'
+        )
+        file_object = observed_data.objects['0']
+        self.assertEqual(file_object.type, 'file')
+        self.assertNotIn('extensions', file_object)
 
     def test_event_with_file_indicator_object(self):
         event = get_event_with_file_object_with_artifact()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An unset `custom` flag turns a pe-extension parse error into the silent loss of the file object.

- **Problem** — In `_resolve_file_to_parse` in `misp_to_stix2.py` the `custom` flag is bound only inside the `try` that wraps `_parse_pe_extensions_observable`, so when that call fails the later check `if 'allow_custom' not in file_args and custom` raises `UnboundLocalError`; the outer per-object handler then swallows it and drops the whole file plus pe pair, emitting no file observable at all.
- **Fix** — Initialises `custom = False` before the `try`.
- **Effect** — A pe-extension parsing failure now degrades to the intended plain file observable instead of silently losing the object from the export.
<!-- /bluf -->

## Problem

In `_resolve_file_to_parse` (`misp_stix_converter/misp2stix/misp_to_stix2.py`, around line 3343), the `custom` flag is only bound inside the `try` block that wraps `_parse_pe_extensions_observable`:

```python
file_args, observable = self._parse_file_observable_object(file_object)
try:
    extension_args, custom = self._parse_pe_extensions_observable(
        pe_object['misp_object'], section_uuids
    )
    ...
except Exception as exception:
    self._add_error(...)
```

If `_parse_pe_extensions_observable` raises, the `except` branch logs the error but leaves `custom` unset. Further down, the code checks `if 'allow_custom' not in file_args and custom:` to decide whether to fall back to a plain file observable. When `file_args` has no `allow_custom` key (i.e. the file object has no unmapped/custom attributes of its own), that check evaluates `custom` and raises `UnboundLocalError` instead of degrading gracefully.

That secondary `UnboundLocalError` is then caught by the outer per-object error handler, which silently drops the entire file+pe pair — no file observable is emitted at all — instead of the intended fallback of emitting the plain file object without the pe extension.

## Fix

Initialize `custom = False` before the `try` block, so that when `_parse_pe_extensions_observable` fails, the existing fallback logic can genuinely evaluate `custom` as `False` and emit the plain file observable, matching the behavior the `except` branch already appears to intend for a pe-extension parsing failure.

## Testing

Ran the existing test gate: `2029 passed, 1488 warnings, 52 subtests passed in 314.73s (0:05:14)`.

Added a regression test, `tests/test_stix20_export.py::TestSTIX20JSONObjectsExport.test_event_with_file_and_pe_observable_object_pe_parsing_error`, which patches `_parse_pe_extensions_observable` to raise, using a file+pe fixture stripped of its one custom (unmapped) attribute so `file_args` lacks `allow_custom` and the `custom` fallback path is actually exercised. Verified this test fails with `StopIteration` (no file observed-data emitted at all — the outer handler swallowed the `UnboundLocalError` and dropped the whole file+pe pair) when the fix is reverted, and passes with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
