### PR TITLE
[high] fix(stix1): stop mis-splitting regkey|value on incidental underscore

### DIFF
--- a/misp_stix_converter/misp2stix/misp_to_stix1.py
+++ b/misp_stix_converter/misp2stix/misp_to_stix1.py
@@ -441,18 +441,22 @@ class MISPtoSTIX1Parser(MISPtoSTIXParser, metaclass=ABCMeta):
         self._handle_attribute(attribute, observable)
 
     def _parse_regkey_value_attribute(self, attribute: dict):
-        for separator in self.composite_separators:
-            if separator in attribute['value']:
-                regkey, value = attribute['value'].split(separator)
-                registry_key = self._create_registry_key_object(regkey)
-                registry_value = RegistryValue()
-                registry_value.data = value.strip()
-                registry_value.data.condition = "Equals"
-                registry_key.values = RegistryValues(registry_value)
-                observable = self._create_observable(
-                    registry_key, attribute['uuid'], 'WindowsRegistryKey')
-                self._handle_attribute(attribute, observable)
-                break
+        # The `regkey|value` type is only ever spelled with a `|` separator,
+        # so that is the only separator we should honour here. Scanning the
+        # legacy `composite_separators` (which also includes `_`) is wrong:
+        # a value with no `|` but containing an incidental `_` (e.g. a key
+        # name like `HKLM\Software\My_App`) would be silently mis-split on
+        # that `_` instead of taking the warning path below.
+        if '|' in attribute['value']:
+            regkey, value = attribute['value'].split('|')
+            registry_key = self._create_registry_key_object(regkey)
+            registry_value = RegistryValue()
+            registry_value.data = value.strip()
+            registry_value.data.condition = "Equals"
+            registry_key.values = RegistryValues(registry_value)
+            observable = self._create_observable(
+                registry_key, attribute['uuid'], 'WindowsRegistryKey')
+            self._handle_attribute(attribute, observable)
         else:
             self._composite_attribute_value_warning(attribute['type'], attribute['value'])
             registry_key = self._create_registry_key_object(attribute['value'])

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5431,6 +5431,22 @@ def get_event_with_regkey_value_attribute():
     return event
 
 
+def get_event_with_regkey_value_attribute_no_separator():
+    event = deepcopy(_BASE_EVENT)
+    event['Event']['Attribute'] = [
+        {
+            "uuid": "91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
+            "type": "regkey|value",
+            "category": "Persistence mechanism",
+            "value": "HKLM\Software\My_App",
+            "to_ids": True,
+            "timestamp": "1603642920",
+            "comment": "Regkey | value test attribute without a `|` separator"
+        }
+    ]
+    return event
+
+
 def get_event_with_sightings():
     event = deepcopy(_BASE_EVENT)
     event['Event']['Attribute'] = deepcopy(_TEST_SIGHTINGS)

--- a/tests/test_stix1_export.py
+++ b/tests/test_stix1_export.py
@@ -1693,6 +1693,13 @@ class TestStix1Export(TestSTIX):
         self.assertEqual(properties.key.value, regkey)
         self.assertEqual(properties.values[0].data.value, value)
 
+    def _test_event_with_regkey_value_attribute_no_separator(self, event):
+        # No `|` separator in the value: the key must not be silently
+        # mis-split on an incidental `_` in the registry key name.
+        properties, attribute = self._run_indicator_tests(event, 'WindowsRegistryKey')
+        self.assertEqual(properties.key.value, attribute['value'])
+        self.assertFalse(properties.values)
+
     def _test_event_with_size_in_bytes_attribute(self, event):
         properties, attribute = self._run_observable_tests(event, 'File')
         self.assertEqual(properties.size_in_bytes.value, int(attribute['value']))
@@ -2583,6 +2590,10 @@ class TestSTIX11JSONExport(TestSTIX11Export):
     def test_event_with_regkey_value_attribute(self):
         event = get_event_with_regkey_value_attribute()
         self._test_event_with_regkey_value_attribute(event['Event'])
+
+    def test_event_with_regkey_value_attribute_no_separator(self):
+        event = get_event_with_regkey_value_attribute_no_separator()
+        self._test_event_with_regkey_value_attribute_no_separator(event['Event'])
 
     def test_event_with_size_in_bytes_attribute(self):
         event = get_event_with_size_in_bytes_attribute()


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** `regkey|value` splits on an incidental underscore, exporting silently wrong registry keys.

- **Problem** — `_parse_regkey_value_attribute` in `misp_to_stix1.py` loops over composite separators and splits on whichever appears first, so a `regkey|value` with no pipe but an incidental underscore, such as `HKLM\Software\My_App`, was silently split into a plausible but wrong key/value pair instead of taking the existing warning path.
- **Fix** — Hardcodes the pipe, the only separator this composite type uses, and falls back to `_composite_attribute_value_warning` otherwise.
- **Effect** — STIX1 exports stop emitting silently wrong registry keys.
- **Cost** — Deliberate behaviour change: legacy underscore-only values now take the warning path rather than being guessed at.
<!-- /bluf -->

## Problem

`_parse_regkey_value_attribute()` in `misp_stix_converter/misp2stix/misp_to_stix1.py` (around line 444) looped over `composite_separators` (`|` then `_`) and split on whichever appeared first in the attribute value. The `regkey|value` type is only ever spelled with a `|`, so a value that has no `|` but happens to contain an unrelated `_` — e.g. a registry key named `HKLM\Software\My_App` — was silently mis-split on that `_` into a plausible-looking but wrong key/value pair (`HKLM\Software\My` / `App`) instead of taking the existing warning path for malformed composite values.

## Fix

The separator is now hardcoded to `|`, the only separator this composite type's name actually spells. If `|` is absent from the value, the code falls back to the pre-existing warning path (`_composite_attribute_value_warning`), which builds a key-only `WindowsRegistryKey` object with no `RegistryValue` attached — the same behaviour already used for other malformed composite values in this function.

This intentionally changes behaviour for a genuinely underscore-separated legacy value with no `|`: it now takes the warning path instead of being guessed at, which is the correct outcome since `regkey|value` was never meant to be split on `_`.

Note: the same `composite_separators` loop pattern still exists in sibling functions in this file (domain|ip, hash composite, hostname|port, ip|port, malware-sample) and in `misp_to_stix2.py`'s `regkey|value` handling. Those are out of scope for this fix and may warrant separate follow-up.

## Testing

Ran the full test gate: `2029 passed, 1492 warnings, 52 subtests passed in 368.15s (0:06:08)`.

Added a regression test, `tests/test_stix1_export.py::TestSTIX11JSONExport::test_event_with_regkey_value_attribute_no_separator`, backed by a new `_test_event_with_regkey_value_attribute_no_separator` helper in `tests/test_stix1_export.py` and a `get_event_with_regkey_value_attribute_no_separator()` fixture in `tests/test_events.py` (value `HKLM\Software\My_App`, no `|`). Verified this test fails against the unmodified source (key truncated to `HKLM\Software\My`) and passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
