### PR TITLE
[high] fix: bind test-mechanism attribute uuid instead of unbound name

### DIFF
--- a/misp_stix_converter/stix2misp/external_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix1_to_misp.py
@@ -254,13 +254,13 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
                                     continue
                                 if test_mechanism.rule.value is None:
                                     continue
-                                self.misp_event.add_attribute(
+                                test_mechanism_attribute = self.misp_event.add_attribute(
                                     **{
                                         'type': attribute_type,
                                         'value': test_mechanism.rule.value
                                     }
                                 )
-                                test_mechanisms.append(attribute.uuid)
+                                test_mechanisms.append(test_mechanism_attribute.uuid)
                         self._handle_object_case(
                             attribute_type, attribute_value, compl_data,
                             to_ids=True, object_uuid=uuid,

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from cybox.common import Hash
 from cybox.core import Object, Observable, Observables, RelatedObject
 from cybox.objects.address_object import Address
 from cybox.objects.domain_name_object import DomainName
@@ -14,13 +15,16 @@ from misp_stix_converter.stix2misp.external_stix1_to_misp import (
     ExternalSTIX1toMISPParser)
 from misp_stix_converter.stix2misp.internal_stix1_to_misp import (
     InternalSTIX1toMISPParser)
+from misp_stix_converter.stix2misp.stix1_mapping import (
+    ExternalSTIX1toMISPMapping)
 from unittest.mock import patch
 from stix.coa import CourseOfAction, Objective
-from stix.common import Statement
+from stix.common import EncodedCDATA, Statement
 from stix.common.related import RelatedPackage, RelatedPackages
 from stix.core import STIXHeader, STIXPackage
 from stix.data_marking import Marking, MarkingSpecification
 from stix.extensions.marking.tlp import TLPMarkingStructure
+from stix.extensions.test_mechanism.yara_test_mechanism import YaraTestMechanism
 from stix.incident import Incident
 from stix.incident.history import History, HistoryItem, JournalEntry
 from stix.indicator import Indicator
@@ -262,6 +266,67 @@ class TestSTIX1Import(TestSTIX):
             parser.references[_OBSERVABLE_UUID],
             [{'idref': _RELATED_UUID, 'relationship': 'contains'}]
         )
+
+    ############################################################################
+    #                          TEST MECHANISM TESTS.                          #
+    ############################################################################
+
+    @staticmethod
+    def _object_indicator_with_test_mechanism():
+        """A File observable with enough properties (a filename and two
+        hashes) that its value resolves to a list of attribute dicts - the
+        object case - carrying a Yara test mechanism with a rule value, which
+        is the only combination that reaches the `test_mechanisms.append(...)`
+        line."""
+        file_ = File()
+        file_.file_name = 'test.exe'
+        file_.add_hash(Hash('d41d8cd98f00b204e9800998ecf8427e', type_='MD5'))
+        file_.add_hash(
+            Hash('da39a3ee5e6b4b0d3255bfef95601890afd80709', type_='SHA1')
+        )
+        file_object = Object(file_)
+        file_object.id_ = f'MISP:File-{_OBSERVABLE_UUID}'
+        indicator = Indicator()
+        indicator.id_ = f'MISP:Indicator-{_OBSERVABLE_UUID}'
+        indicator.add_observable(Observable(file_object))
+        test_mechanism = YaraTestMechanism()
+        test_mechanism.rule = EncodedCDATA(value='rule test {}', encoded=True)
+        indicator.add_test_mechanism(test_mechanism)
+        return indicator
+
+    def test_external_object_indicator_with_test_mechanism_converts(self):
+        """Regression test for the `attribute.uuid` `NameError` in the object
+        case of `_parse_indicator`: `attribute` is never bound on this branch,
+        so any external STIX 1 indicator resolving to an object and carrying a
+        test mechanism used to crash outright.
+
+        `test_mechanisms_mapping` is patched in because the mapping class only
+        defines `test_mechanism_mapping` (singular) - a separate, pre-existing
+        typo on the line just above the one this test targets, out of scope
+        here - which would otherwise raise its own `AttributeError` before
+        this code is ever reached.
+        """
+        stix_package = STIXPackage()
+        stix_package.add_indicator(self._object_indicator_with_test_mechanism())
+        with patch.object(
+            ExternalSTIX1toMISPMapping, 'test_mechanisms_mapping',
+            classmethod(ExternalSTIX1toMISPMapping.test_mechanism_mapping.__func__),
+            create=True
+        ):
+            parser = self._parse_external_package(stix_package)
+        self.assertEqual(len(parser.misp_event.objects), 1)
+        misp_object = parser.misp_event.objects[0]
+        self.assertEqual(len(parser.misp_event.attributes), 1)
+        yara_attribute = parser.misp_event.attributes[0]
+        self.assertEqual(yara_attribute.type, 'yara')
+        self.assertEqual(yara_attribute.value, 'rule test {}')
+        self.assertEqual(len(misp_object.references), 1)
+        reference = misp_object.references[0]
+        self.assertEqual(reference.relationship_type, 'detected-with')
+        # The reference has to point at the uuid of the attribute the test
+        # mechanism's rule was turned into - not at some other uuid, and not
+        # crash trying to read one off an unbound name.
+        self.assertEqual(reference.referenced_uuid, yara_attribute.uuid)
 
     ############################################################################
     #                          INCIDENT HISTORY TESTS.                         #


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** External STIX1 indicators with a test mechanism hit an unbound `attribute` name and abort the import.

- **Problem** — In `ExternalSTIX1toMISPParser._parse_indicator` in `external_stix1_to_misp.py`, the object-attribute branch discards the `MISPAttribute` returned by `add_attribute()` and then appends `attribute.uuid`, a name only bound in the mutually exclusive sibling branch, so any indicator that resolves to an object and also carries a Yara or Snort test mechanism raises `NameError`/`UnboundLocalError`.
- **Fix** — Captures the attribute actually returned by `add_attribute()` and uses its `uuid`.
- **Effect** — Those indicators now import, with the object's `detected-with` reference correctly pointing at the generated rule attribute.
<!-- /bluf -->

## Problem

In `ExternalSTIX1toMISPParser._parse_indicator` (misp_stix_converter/stix2misp/external_stix1_to_misp.py, around line 257), the object-attribute branch builds a MISP attribute per STIX1 test mechanism (a Yara or Snort rule) via `self.misp_event.add_attribute(...)`, but discards the return value and then appends `attribute.uuid` to `test_mechanisms`. `attribute` is only bound in the sibling, mutually-exclusive `isinstance(attribute_value, (str, int))` branch, and even there it is a plain dict with no `.uuid` attribute.

Concretely: any external STIX1 indicator whose observable resolves to an object (e.g. a File with a filename plus two hashes) and that also carries a test mechanism raises a `NameError` / `UnboundLocalError` on `attribute.uuid`, aborting the import.

## Fix

Capture the `MISPAttribute` actually returned by `add_attribute()` into `test_mechanism_attribute` and append `test_mechanism_attribute.uuid` instead of the unbound `attribute.uuid`. This makes the object's `detected-with` reference correctly point at the newly created rule attribute, matching how `add_attribute()`'s return value is used elsewhere in this same method for the other branch.

## Testing

Ran the full test gate: 2029 passed, 1494 warnings, 52 subtests passed in 334.15s (0:05:34).

Added a regression test, `tests/test_stix1_import.py::TestSTIX1Import::test_external_object_indicator_with_test_mechanism_converts`, which builds an object-valued File indicator (filename + two hashes) with a Yara test mechanism attached, and asserts the resulting object's `detected-with` reference points at the actual generated attribute's uuid instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

