### PR TITLE
[high] fix(stix1-import): correct typo'd timestamp method call

### DIFF
--- a/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/internal_stix1_to_misp.py
@@ -346,7 +346,7 @@ class InternalSTIX1toMISPParser(STIX1toMISPParser):
             self._sanitise_object_uuid(misp_object, item.id_)
             if to_ids:
                 observables = item.observable.observable_composition.observables
-                misp_object.timestamp = self._get_imestamp_from_date(item.timestamp)
+                misp_object.timestamp = self._timestamp_from_date(item.timestamp)
             else:
                 observables = item.observable_composition.observables
             args = (misp_object, observables, to_ids)

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from cybox.core import Object, Observable, Observables, RelatedObject
+from cybox.core import (
+    Object, Observable, ObservableComposition, Observables, RelatedObject)
 from cybox.objects.address_object import Address
 from cybox.objects.domain_name_object import DomainName
 from cybox.objects.file_object import File
@@ -17,7 +18,7 @@ from misp_stix_converter.stix2misp.internal_stix1_to_misp import (
 from unittest.mock import patch
 from stix.coa import CourseOfAction, Objective
 from stix.common import Statement
-from stix.common.related import RelatedPackage, RelatedPackages
+from stix.common.related import RelatedIndicator, RelatedPackage, RelatedPackages
 from stix.core import STIXHeader, STIXPackage
 from stix.data_marking import Marking, MarkingSpecification
 from stix.extensions.marking.tlp import TLPMarkingStructure
@@ -243,6 +244,53 @@ class TestSTIX1Import(TestSTIX):
                 for attribute in misp_objects[0].attributes
             },
             self._course_of_action_attributes()
+        )
+
+    ############################################################################
+    #                     OBSERVABLE COMPOSITION INDICATOR TESTS.              #
+    ############################################################################
+
+    def test_internal_indicator_with_observable_composition_converts(self):
+        """A `to_ids` Indicator whose Observable is an Observable_Composition
+        (rather than a single Object) used to hit a typo'd method name -
+        `_get_imestamp_from_date` instead of `_timestamp_from_date` - and
+        raise an `AttributeError` while stamping the resulting MISP object.
+        This pins that path so it stays reachable."""
+        first_object = Object(File())
+        first_object.id_ = f'MISP:File-{_OBSERVABLE_UUID}'
+        first_object.properties.file_name = 'a.txt'
+        second_object = Object(File())
+        second_object.id_ = f'MISP:File-{_RELATED_UUID}'
+        second_object.properties.md5 = 'd41d8cd98f00b204e9800998ecf8427e'
+        composition = Observable()
+        composition.id_ = f'MISP:ObservableComposition-{_OBSERVABLE_UUID}'
+        composition.observable_composition = ObservableComposition(
+            observables=[Observable(first_object), Observable(second_object)]
+        )
+        indicator = Indicator()
+        indicator.id_ = f'MISP:Indicator-{_OBSERVABLE_UUID}'
+        indicator.timestamp = datetime(2020, 10, 25, 16, 22)
+        indicator.observable = composition
+        incident = Incident()
+        incident.title = 'Incident with a composed file Indicator'
+        incident.add_related_indicator(
+            RelatedIndicator(indicator, relationship='file')
+        )
+        parser = self._parse_internal_package(self._internal_package(incident))
+        misp_objects = [
+            misp_object for misp_object in parser.misp_event.objects
+            if misp_object.name == 'file'
+        ]
+        self.assertEqual(len(misp_objects), 1)
+        self.assertEqual(
+            {
+                attribute.object_relation: attribute.value
+                for attribute in misp_objects[0].attributes
+            },
+            {
+                'filename': 'a.txt',
+                'md5': 'd41d8cd98f00b204e9800998ecf8427e'
+            }
         )
 
     ############################################################################


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A typo'd method name crashes every STIX 1 import that uses an `Observable_Composition`.

- **Problem** — `_fill_misp_object` in `internal_stix1_to_misp.py` calls `self._get_imestamp_from_date`, a typo of the real method `_timestamp_from_date` used correctly nine other places in the same file, so it raises a guaranteed `AttributeError` whenever a `to_ids` STIX1 Indicator's Observable is an `Observable_Composition`, aborting the entire package parse.
- **Fix** — Corrects the method name and adds a regression test that builds such a composed indicator.
- **Effect** — STIX1 packages using observable compositions now import instead of crashing.
<!-- /bluf -->

## Problem
In `misp_stix_converter/stix2misp/internal_stix1_to_misp.py`, `_fill_misp_object` (around line 349) called `self._get_imestamp_from_date(item.timestamp)` — a typo of the actual method `_timestamp_from_date`, which is defined once and used correctly in nine other places in the same file. Since `_get_imestamp_from_date` does not exist, this raised a guaranteed `AttributeError` whenever a `to_ids` STIX1 Indicator's Observable was an `Observable_Composition` (for example a `file` object built by composing several related STIX objects), aborting the whole package parse.

## Fix
Replaces the typo'd call with `self._timestamp_from_date(item.timestamp)`, matching the method's actual name and the pattern already used everywhere else it is called in this file. No behavioral change beyond removing the crash — the intent (stamping the MISP object's timestamp from the STIX item's timestamp) was already correct, only the method name was wrong.

## Testing
Ran the repository's test gate: 2029 passed, 1489 warnings, 52 subtests passed in 344.06s (0:05:44).

Added a regression test, `tests/test_stix1_import.py::TestSTIX1Import::test_internal_indicator_with_observable_composition_converts`, which builds a `to_ids` Indicator whose Observable is an `Observable_Composition` of two `file`-related objects and asserts it converts into a single `file` MISP object instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

