### PR TITLE
[high] fix(stix2misp): don't crash when network-socket SCO lacks socket-ext

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
@@ -1421,6 +1421,8 @@ class InternalSTIX2ObservableConverter(
                     value, object_id, protocol_mapping['object_relation']
                 )
             )
+        if not hasattr(observable, 'extensions') or 'socket-ext' not in observable.extensions:
+            return
         socket_extension = observable.extensions['socket-ext']
         mapping = self._mapping.network_socket_extension_mapping
         for field, attribute in mapping().items():

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -7983,6 +7983,47 @@ _NETWORK_SOCKET_OBSERVABLE_OBJECT = [
         "target_ref": "observed-data--5afb3223-0988-4ef1-a920-02070a00020f"
     }
 ]
+_NETWORK_SOCKET_OBSERVABLE_OBJECT_WITHOUT_EXTENSION = [
+    {
+        "type": "observed-data",
+        "spec_version": "2.1",
+        "id": "observed-data--71c74b48-1122-4b81-8f82-b6dda19f8f19",
+        "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+        "created": "2020-10-25T16:22:00.000Z",
+        "modified": "2020-10-25T16:22:00.000Z",
+        "first_observed": "2020-10-25T16:22:00Z",
+        "last_observed": "2020-10-25T16:22:00Z",
+        "number_observed": 1,
+        "object_refs": [
+            "network-traffic--71c74b48-1122-4b81-8f82-b6dda19f8f19",
+            "ipv4-addr--65195b1c-8ea9-42dd-9a20-d63f5e6ecfdb",
+            "ipv4-addr--fc98adb7-c56a-46b1-a4b9-4de9df6ab653"
+        ],
+        "labels": ['misp:name="network-socket"', 'misp:meta-category="network"']
+    },
+    {
+        "type": "network-traffic",
+        "spec_version": "2.1",
+        "id": "network-traffic--71c74b48-1122-4b81-8f82-b6dda19f8f19",
+        "src_ref": "ipv4-addr--65195b1c-8ea9-42dd-9a20-d63f5e6ecfdb",
+        "dst_ref": "ipv4-addr--fc98adb7-c56a-46b1-a4b9-4de9df6ab653",
+        "src_port": 8080,
+        "dst_port": 8080,
+        "protocols": ["tcp"]
+    },
+    {
+        "type": "ipv4-addr",
+        "spec_version": "2.1",
+        "id": "ipv4-addr--65195b1c-8ea9-42dd-9a20-d63f5e6ecfdb",
+        "value": "1.2.3.4"
+    },
+    {
+        "type": "ipv4-addr",
+        "spec_version": "2.1",
+        "id": "ipv4-addr--fc98adb7-c56a-46b1-a4b9-4de9df6ab653",
+        "value": "5.6.7.8"
+    }
+]
 _NEWS_AGENCY_OBJECT = {
     "type": "identity",
     "spec_version": "2.1",
@@ -11000,6 +11041,12 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_network_socket_observable_object(cls):
         return cls.__assemble_bundle(*_NETWORK_SOCKET_OBSERVABLE_OBJECT)
+
+    @classmethod
+    def get_bundle_with_network_socket_observable_object_without_extension(cls):
+        return cls.__assemble_bundle(
+            *_NETWORK_SOCKET_OBSERVABLE_OBJECT_WITHOUT_EXTENSION
+        )
 
     @classmethod
     def get_bundle_with_news_agency_object(cls):

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -4127,6 +4127,29 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
             ]
         )
 
+    def test_stix21_bundle_with_network_socket_observable_object_without_extension(self):
+        # A `network-traffic` SCO labelled `network-socket` but missing the
+        # `socket-ext` extension must not abort the whole bundle conversion.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_network_socket_observable_object_without_extension()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(dict(self.parser.errors), {})
+        event = self.parser.misp_event
+        _, grouping, observed_data, network_traffic, address1, address2 = bundle.objects
+        misp_object = self._check_misp_event_features_from_grouping(event, grouping)[0]
+        self._check_observed_data_object(misp_object, observed_data)
+        port_src, port_dst, ip_src, ip_dst, protocol = misp_object.attributes
+        self.assertEqual(port_src.object_relation, 'src-port')
+        self.assertEqual(port_src.value, network_traffic.src_port)
+        self.assertEqual(port_dst.object_relation, 'dst-port')
+        self.assertEqual(port_dst.value, network_traffic.dst_port)
+        self.assertEqual(ip_src.object_relation, 'ip-src')
+        self.assertEqual(ip_src.value, address1.value)
+        self.assertEqual(ip_dst.object_relation, 'ip-dst')
+        self.assertEqual(ip_dst.value, address2.value)
+        self.assertEqual(protocol.object_relation, 'protocol')
+        self.assertEqual(protocol.value, network_traffic.protocols[0].upper())
+
     def test_stix21_bundle_with_network_socket_indicator_object(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_network_socket_indicator_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A `network-socket`-labelled SCO without `socket-ext` raises `KeyError` and aborts the whole bundle.

- **Problem** — `_parse_network_socket_observable` in `stix2_observable_converter.py` unconditionally reads `observable.extensions['socket-ext']`, but the `network-socket` mapping is dispatched off the `misp:name` label, so a `network-traffic` SCO labelled `network-socket` without that extension raises a `KeyError` that `InternalSTIX2ObservedDataConverter.parse()` does not catch.
- **Fix** — Guards the lookup and returns early with the generic protocol, port and address attributes already produced, skipping only the `socket-ext`-only fields.
- **Effect** — Such bundles now import successfully instead of failing entirely.
<!-- /bluf -->

## Problem
`InternalSTIX2ObservableConverter._parse_network_socket_observable` in `misp_stix_converter/stix2misp/converters/stix2_observable_converter.py` unconditionally reads `observable.extensions['socket-ext']`. The `network-socket` MISP object mapping is dispatched based on the `misp:name="network-socket"` label, not on the presence of the `socket-ext` extension. A `network-traffic` STIX Cyber Observable labelled `network-socket` but lacking the `socket-ext` extension raises a `KeyError` at that line. `InternalSTIX2ObservedDataConverter.parse()` only catches `UnknownObservableMappingError`, so this `KeyError` propagates and aborts conversion of the entire bundle rather than just that one object.

## Fix
Guard the `socket-ext` lookup: if the observable has no `extensions` attribute, or `socket-ext` is not present in it, return early after emitting the generic protocol-derived attributes (ports, addresses, protocol) that were already produced earlier in the method. This mirrors how other extension-dependent branches in the same converter treat optional STIX extensions as absent-safe rather than required. The address-family/socket-type/blocking/listening attributes, which only exist inside `socket-ext`, are simply skipped when the extension is missing — no attributes are fabricated.

## Testing
Ran the full test gate: 2029 passed, 1488 warnings, 52 subtests passed in 206.77s (0:03:26).

Added a regression test (`test_stix21_bundle_with_network_socket_observable_object_without_extension` in `tests/test_internal_stix21_import.py`, with the accompanying bundle fixture in `tests/test_internal_stix21_bundles.py`) covering a `network-traffic` SCO labelled `misp:name="network-socket"` without a `socket-ext` extension, asserting the bundle parses with no errors and produces the expected port/address/protocol attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

