### PR TITLE
[critical] fix(stix2 import): reset indicator references between bundles

### DIFF
--- a/misp_stix_converter/stix2misp/stix2_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix2_to_misp.py
@@ -74,7 +74,7 @@ _LOADED_FEATURES = (
 _SDOs = (
     '_custom_galaxy_cluster', '_grouping', '_report', '_location',
     '_marking_definition', '_relationship', '_sighting', '_observable',
-    *_LOADED_FEATURES
+    '_indicator_references', *_LOADED_FEATURES
 )
 
 # Typing

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -284,6 +284,76 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self.assertIn(second_id, self.parser.invalid_objects)
         self.assertNotIn(first_id, self.parser.invalid_objects)
 
+    def test_stix21_indicator_references_do_not_leak_between_bundles(self):
+        # `_set_indicator_references` returned early, without resetting
+        # `_indicator_references`, whenever a bundle held no indicator to
+        # correlate - and `_reset_bundle_state` never cleared it either. A
+        # bundle carrying only observables then inherited the previous
+        # bundle's indicator mapping on a reused parser.
+        from misp_stix_converter.tools import load_stix2_content
+        identity = {
+            'type': 'identity',
+            'spec_version': '2.1',
+            'id': 'identity--55f6ea5e-2c60-40e5-964f-47a8950d210f',
+            'created': '2020-10-25T16:22:00.000Z',
+            'modified': '2020-10-25T16:22:00.000Z',
+            'name': 'CIRCL',
+            'identity_class': 'organization'
+        }
+        with_indicator = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--28b47d33-6a17-4de2-8f4b-d3d1091f7bda',
+                'objects': [
+                    identity,
+                    {
+                        'type': 'indicator',
+                        'spec_version': '2.1',
+                        'id': (
+                            'indicator--10440d97-42bb-4b17-'
+                            'a439-9dd5e17dd93e'
+                        ),
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'pattern': "[ipv4-addr:value = '194.78.89.250']",
+                        'pattern_type': 'stix',
+                        'valid_from': '2020-10-25T16:22:00.000Z'
+                    },
+                    {
+                        'type': 'ipv4-addr',
+                        'spec_version': '2.1',
+                        'id': (
+                            'ipv4-addr--b6f1a83b-6d92-40dc-'
+                            '83b3-e575a04a5c29'
+                        ),
+                        'value': '194.78.89.250'
+                    }
+                ]
+            }
+        )
+        observable_only = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--6a99f66a-8d92-4653-a481-b7cbeef97e95',
+                'objects': [
+                    identity,
+                    {
+                        'type': 'ipv4-addr',
+                        'spec_version': '2.1',
+                        'id': (
+                            'ipv4-addr--f6d18c96-6d1e-4c7c-'
+                            '9c56-27c9a6f4c2a1'
+                        ),
+                        'value': '8.8.8.8'
+                    }
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(with_indicator)
+        self.assertTrue(self.parser.indicator_references)
+        self.parser.load_stix_bundle(observable_only)
+        self.assertEqual(self.parser.indicator_references, {})
+
     def test_stix21_parser_inherits_the_invalid_objects_from_the_loader(self):
         # `load_stix2_file` populated its own `invalid_objects` dict, but
         # `load_stix_bundle` created another one when the argument was


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Stale `_indicator_references` leak between bundles, mislabelling a later bundle's observables.

- **Problem** — `_set_indicator_references` returns early without touching `_indicator_references` for bundles whose SDO score is 0, 1, 2, 4 or 6, and `_reset_bundle_state` in `stix2_to_misp.py` never cleared that dict, so when one parser instance is reused across bundles the mapping from an earlier document survives. A later observable-only bundle is then matched against indicators it never contained, emitting wrong `to_ids` and indicator linkage with no error.
- **Fix** — Adds `_indicator_references` to the shared `_SDOs` tuple so it is cleared at the start of every `load_stix_bundle` call.
- **Effect** — Both the external and internal STIX 2 parsers now start each bundle with clean indicator state.
<!-- /bluf -->

## Problem

`external_stix2_to_misp.py::_set_indicator_references` (around line 324-325) returns early — without touching `_indicator_references` — whenever the bundle's SDO score is 0, 1, 2, 4, or 6 (i.e. the bundle holds no indicators worth correlating against observables). `_reset_bundle_state` in `stix2_to_misp.py` never cleared `_indicator_references` either.

Concretely: parse a bundle that has an indicator plus a matching observable (this populates `_indicator_references`), then reuse the same parser instance to parse a second, unrelated bundle that has only an observable and no indicator. The early-return path in `_set_indicator_references` leaves the stale `_indicator_references` dict from the first bundle in place, so the second bundle's observable gets matched against an indicator mapping that belongs to a completely different document — producing wrong `to_ids` / indicator linkage on output.

## Fix

Add `_indicator_references` to the shared `_SDOs` tuple in `misp_stix_converter/stix2misp/stix2_to_misp.py` (line 77), so `_reset_bundle_state` deletes it at the start of every `load_stix_bundle` call, before either parser has a chance to populate or skip it. This is the same state-leak class the existing "forget a galaxy cluster before parsing the next document" fix addressed for `_custom_galaxy_cluster` — `_indicator_references` was simply missing from that same cleanup tuple. Both the external and internal STIX 2 parsers share this base class and both benefit from the fix.

## Testing

Ran the full gate: `2029 passed, 1488 warnings, 52 subtests passed in 210.81s (0:03:30)`.

Added `tests/test_external_stix21_import.py::TestExternalSTIX21Import::test_stix21_indicator_references_do_not_leak_between_bundles`: it parses a bundle with an indicator + matching observable on a parser instance (populating `_indicator_references`), then parses a second bundle with only an observable (hitting the early-return path), and asserts `parser.indicator_references == {}` on the second parse.

Verified fail-without-fix: copying the fixed base file aside, reverting the source change via `git checkout --`, rerunning the new test (it failed, showing the stale dict leaking through), then restoring the fix and confirming it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

