### PR TITLE
[critical] fix(stix1): build passive-dns object for DNSRecord with domain+IP

### DIFF
--- a/misp_stix_converter/stix2misp/stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/stix1_to_misp.py
@@ -214,9 +214,9 @@ class STIX1toMISPParser(STIXtoMISPParser, metaclass=ABCMeta):
         if properties.domain_name:
             relation.append(["domain", str(properties.domain_name.value), ""])
         if properties.ip_address:
-            relation.append(["ip-dst", str(properties.ip_address.value), ""])
+            relation.append(["ip-dst", str(properties.ip_address.address_value.value), ""])
         if relation:
-            if len(relation) == '2':
+            if len(relation) == 2:
                 domain = relation[0][1]
                 ip = relation[1][1]
                 attributes = [["text", domain, "rrname"], ["text", ip, "rdata"]]

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -3,6 +3,7 @@
 
 from cybox.core import Object, Observable, Observables, RelatedObject
 from cybox.objects.address_object import Address
+from cybox.objects.dns_record_object import DNSRecord
 from cybox.objects.domain_name_object import DomainName
 from cybox.objects.file_object import File
 from cybox.objects.uri_object import URI
@@ -42,6 +43,7 @@ _ACTOR_UUID = '5e6f7a8b-9c0d-4e1f-8a2b-3c4d5e6f7a8b'
 _DOMAIN_UUID = '2d3e4f5a-6b7c-4d8e-9f0a-1b2c3d4e5f6a'
 _IP_UUID = '3e4f5a6b-7c8d-4e9f-8a0b-1c2d3e4f5a6b'
 _URL_UUID = '4f5a6b7c-8d9e-4f0a-8b1c-2d3e4f5a6b7c'
+_DNS_RECORD_UUID = '5a6b7c8d-9e0f-4a1b-8c2d-3e4f5a6b7c8d'
 
 
 class TestSTIX1Import(TestSTIX):
@@ -120,6 +122,20 @@ class TestSTIX1Import(TestSTIX):
         related_object.relationship = 'Resolved_To'
         uri_object.related_objects.append(related_object)
         return cls._indicator(uri_object, _URL_UUID)
+
+    @classmethod
+    def _dns_record_indicator(cls, domain, ip):
+        """A DNSRecord Indicator carrying both a domain name and an IP address,
+        which the parser is meant to fold into a single `passive-dns` object."""
+        dns_record = DNSRecord()
+        dns_record.domain_name = domain
+        address = Address()
+        address.address_value = ip
+        address.category = Address.CAT_IPV4
+        dns_record.ip_address = address
+        dns_record_object = Object(dns_record)
+        dns_record_object.id_ = f'MISP:DNSRecord-{_DNS_RECORD_UUID}'
+        return cls._indicator(dns_record_object, _DNS_RECORD_UUID)
 
     @staticmethod
     def _threat_actor(title):
@@ -261,6 +277,28 @@ class TestSTIX1Import(TestSTIX):
         self.assertEqual(
             parser.references[_OBSERVABLE_UUID],
             [{'idref': _RELATED_UUID, 'relationship': 'contains'}]
+        )
+
+    def test_external_dns_record_with_domain_and_ip_converts_to_passive_dns(self):
+        """A DNSRecord carrying both a domain name and an IP address has to
+        become one `passive-dns` object, not have its IP half silently
+        dropped."""
+        stix_package = STIXPackage()
+        stix_package.add_indicator(
+            self._dns_record_indicator('circl.lu', '198.51.100.4')
+        )
+        parser = self._parse_external_package(stix_package)
+        misp_objects = parser.misp_event.objects
+        self.assertEqual(len(misp_objects), 1)
+        misp_object = misp_objects[0]
+        self.assertEqual(misp_object.name, 'passive-dns')
+        attributes = {
+            attribute.object_relation: attribute.value
+            for attribute in misp_object.attributes
+        }
+        self.assertEqual(
+            attributes,
+            {'rrname': 'circl.lu', 'rdata': '198.51.100.4', 'rrtype': 'A'}
         )
 
     ############################################################################


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An int-to-string comparison makes the DNSRecord passive-dns branch dead code, silently discarding the IP.

- **Problem** — In `stix1_to_misp.py`, `_handle_dns` tests `if len(relation) == '2'`, comparing an int against a string, so the branch that folds a DNSRecord's domain and IP into one `passive-dns` object never runs and never raises; every such record keeps only the domain. The branch would also have failed anyway, reading `properties.ip_address.value` when the cybox Address object exposes the string at `.address_value.value`.
- **Fix** — Compares against the integer `2` and reads the value the way `_handle_address` already does.
- **Effect** — STIX 1 passive DNS records now import as a complete `passive-dns` object with both attributes.
<!-- /bluf -->

## Problem

In `misp_stix_converter/stix2misp/stix1_to_misp.py`, `_handle_dns` is meant to fold a STIX1 DNSRecord carrying both a `domain_name` and an `ip_address` into a single `passive-dns` MISP object, but the branch that does this was doubly dead:

- At line 220 (original), `if len(relation) == '2':` compares an int (`len(...)`) to the string `'2'`. This comparison is always `False`, so the branch never runs. A DNSRecord with both a domain and an IP silently falls through to `return relation[0]`, keeping only the domain attribute and dropping the IP entirely.
- Even if reached, the branch would have crashed: at line 217, `properties.ip_address.value` is read directly, but `properties.ip_address` is a cybox `Address` object, which does not expose a `.value` attribute — the string lives at `.address_value.value`, the same way the sibling `_handle_address` method already reads it.

Concrete trigger: any STIX1 package with an Observable/Indicator wrapping a `DNSRecord` object that sets both `domain_name` and `ip_address` (a passive DNS record) hits this path during import.

## Fix

- Compare `len(relation)` to the integer `2` instead of the string `'2'`, so the fold-into-`passive-dns` branch actually executes when both fields are present.
- Read the IP through `properties.ip_address.address_value.value`, matching how `_handle_address` already extracts the value from a cybox `Address` object.

## Testing

Ran the repo's test gate: 2029 passed, 1488 warnings, 52 subtests passed in 203.18s (0:03:23).

Added `tests/test_stix1_import.py::TestSTIX1Import::test_external_dns_record_with_domain_and_ip_converts_to_passive_dns`, which builds a DNSRecord Indicator with both a domain name and an IP address, parses it, and asserts the resulting MISP object is a single `passive-dns` object with the correct `rrname`/`rdata`/`rrtype` attributes. Verified this test fails with an AttributeError against the unfixed source (via checkout-and-revert) and passes against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
