### PR TITLE
[high] fix(stix2misp): fix AttributeError on email body_multipart artifact part

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
@@ -1186,7 +1186,7 @@ class InternalSTIX2ObservableConverter(
             yield attribute
         else:
             content = {
-                'value': value.split('=').strip("'"),
+                'value': value.split('=', 1)[-1].strip("'"),
                 'data': observable.payload_bin
             }
             mapping = f'{feature}_attribute'

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -2357,6 +2357,36 @@ _EMAIL_ATTACHMENT_OBSERVABLE_ATTRIBUTE = [
         "target_ref": "observed-data--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f"
     }
 ]
+_EMAIL_OBJECT_WITH_ARTIFACT_ATTACHMENT_OBSERVABLE_OBJECT = [
+    {
+        "type": "observed-data",
+        "id": "observed-data--5e396622-2a54-4c8d-b61d-159da964451b",
+        "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+        "created": "2020-10-25T16:22:00.000Z",
+        "modified": "2020-10-25T16:22:00.000Z",
+        "first_observed": "2020-10-25T16:22:00Z",
+        "last_observed": "2020-10-25T16:22:00Z",
+        "number_observed": 1,
+        "objects": {
+            "0": {
+                "type": "email-message",
+                "is_multipart": True,
+                "subject": "Email test subject",
+                "body_multipart": [
+                    {
+                        "body_raw_ref": "1",
+                        "content_disposition": "attachment; filename='email_attachment.test'"
+                    }
+                ]
+            },
+            "1": {
+                "type": "artifact",
+                "payload_bin": "ZWNobyAiREFOR0VST1VTIE1BTFdBUkUiIAoK"
+            }
+        },
+        "labels": ['misp:name="email"', 'misp:meta-category="network"']
+    }
+]
 _EMAIL_BODY_INDICATOR_ATTRIBUTE = {
     "type": "indicator",
     "id": "indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
@@ -8014,6 +8044,12 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_email_attachment_observable_attribute(cls):
         return cls.__assemble_bundle(deepcopy(_EMAIL_ATTACHMENT_OBSERVABLE_ATTRIBUTE[0]))
+
+    @classmethod
+    def get_bundle_with_email_object_with_artifact_attachment_observable_object(cls):
+        return cls.__assemble_bundle(
+            *deepcopy(_EMAIL_OBJECT_WITH_ARTIFACT_ATTACHMENT_OBSERVABLE_OBJECT)
+        )
 
     @classmethod
     def get_bundle_with_email_attribute(cls):

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -582,6 +582,30 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
         )
         self.assertFalse(attribute.to_ids)
 
+    def test_stix20_bundle_with_email_object_with_artifact_attachment_observable_object(self):
+        # Regression test: an email-message body_multipart part whose
+        # body_raw_ref is an `artifact` (not a `file`) used to raise
+        # AttributeError, because the content value was built with
+        # `value.split('=').strip("'")` -- .strip() called on the list
+        # returned by split(), instead of on the split-out string.
+        bundle = TestInternalSTIX20Bundles.get_bundle_with_email_object_with_artifact_attachment_observable_object()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, observed_data = bundle.objects
+        misp_object = self._check_misp_event_features(event, report)[0]
+        message, artifact_object = observed_data.objects.values()
+        self.assertEqual(misp_object.name, 'email')
+        attachment = misp_object.attributes[-1]
+        self.assertEqual(attachment.type, 'email-attachment')
+        self.assertEqual(
+            attachment.value,
+            message.body_multipart[0]['content_disposition'].split('=', 1)[-1].strip("'")
+        )
+        self.assertEqual(
+            self._get_data_value(attachment.data), artifact_object.payload_bin
+        )
+
     def test_stix20_bundle_with_email_attribute(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_email_attribute()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Email `body_multipart` parts referencing an artifact always raise `AttributeError`, dropping the email.

- **Problem** — `_parse_email_body_observable` in `stix2_observable_converter.py` builds an attachment value with `value.split('=').strip("'")`, calling a string method on a list, so the line always raises `AttributeError`. The branch is reached whenever an email-message `body_multipart` part references a non-file observable such as an artifact, and because the error is caught upstream the whole email object is dropped from the import without a visible error.
- **Fix** — Changes it to `value.split('=', 1)[-1].strip("'")`, matching the sibling file branch and degrading gracefully when no `=` is present.
- **Effect** — Emails with artifact body parts now import their attachment attributes.
<!-- /bluf -->

## Problem

In `misp_stix_converter/stix2misp/converters/stix2_observable_converter.py`, `_parse_email_body_observable` (around line 1189) builds an email-attachment attribute's value with:

```python
'value': value.split('=').strip("'"),
```

`str.split('=')` returns a `list`, so calling `.strip("'")` on it always raises `AttributeError`. This branch is reached whenever an email-message's `body_multipart` entry references a body part that is not a `file` observable — for example an `artifact` observable used as the message body. Because the `AttributeError` is caught upstream and the failing object is silently dropped, the email object is simply lost from the import rather than surfacing an error.

## Fix

Split with `maxsplit=1` and strip the right-hand side instead:

```python
'value': value.split('=', 1)[-1].strip("'"),
```

This matches the pattern used by the sibling `file` branch just above it in the same function, and correctly falls back to stripping the whole string when no `=` is present (instead of raising).

A regression test was added in `tests/test_internal_stix20_import.py` (`test_stix20_bundle_with_email_object_with_artifact_attachment_observable_object`) and a matching bundle fixture in `tests/test_internal_stix20_bundles.py`. The test constructs an email object with an `artifact`-typed `body_multipart` part and asserts the resulting email-attachment attribute's `value`/`data` are correct. It was verified to fail with an `IndexError` (a consequence of the underlying `AttributeError` being caught and the object being dropped) when the original buggy line is restored, and to pass with the fix.

## Testing

Full test gate: `2029 passed, 1494 warnings, 52 subtests passed in 249.54s (0:04:09)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

