### PR TITLE
[high] fix: skip unmapped hash types instead of yielding None

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observable_converter.py
@@ -530,9 +530,10 @@ class ExternalSTIX2ObservableConverter(
             )
         if hasattr(observable, 'hashes'):
             for hash_type, value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    indicator_ref, observable.type, hash_type, value, object_id
-                )
+                if (attribute := self._handle_hash_attribute(
+                        indicator_ref, observable.type, hash_type, value,
+                        object_id)) is not None:
+                    yield attribute
         for field, mapping in self._mapping.artifact_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes_with_data(
@@ -639,9 +640,10 @@ class ExternalSTIX2ObservableConverter(
             object_id = observable.id
         if hasattr(observable, 'hashes'):
             for hash_type, value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    indicator_ref, observable.type, hash_type, value, object_id
-                )
+                if (attribute := self._handle_hash_attribute(
+                        indicator_ref, observable.type, hash_type, value,
+                        object_id)) is not None:
+                    yield attribute
         for field, mapping in self._mapping.file_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes_with_data(
@@ -784,9 +786,10 @@ class ExternalSTIX2ObservableConverter(
                 )
         if hasattr(section, 'hashes'):
             for hash_type, hash_value in section.hashes.items():
-                yield self._handle_hash_attribute(
-                    indicator_ref, 'file', hash_type, hash_value, reference
-                )
+                if (attribute := self._handle_hash_attribute(
+                        indicator_ref, 'file', hash_type, hash_value,
+                        reference)) is not None:
+                    yield attribute
 
     def _parse_process_observable(
             self, observable: _PROCESS_TYPING, object_id: Optional[str] = None,
@@ -894,10 +897,10 @@ class ExternalSTIX2ObservableConverter(
             object_id = observable.id
         if hasattr(observable, 'hashes'):
             for hash_type, hash_value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    indicator_ref, observable.type, hash_type, hash_value,
-                    object_id, 'x509'
-                )
+                if (attribute := self._handle_hash_attribute(
+                        indicator_ref, observable.type, hash_type,
+                        hash_value, object_id, 'x509')) is not None:
+                    yield attribute
         for field, mapping in self._mapping.x509_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes(
@@ -1206,7 +1209,9 @@ class InternalSTIX2ObservableConverter(
             self, observable: _FILE_TYPING, object_id: str) -> Iterator[dict]:
         if hasattr(observable, 'hashes'):
             for hash_type, value in observable.hashes.items():
-                yield self._handle_hash_attribute(hash_type, value, object_id)
+                if (attribute := self._handle_hash_attribute(
+                        hash_type, value, object_id)) is not None:
+                    yield attribute
         for field, mapping in self._mapping.file_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes_with_data(
@@ -1246,9 +1251,9 @@ class InternalSTIX2ObservableConverter(
             )
         if hasattr(observable, 'hashes'):
             for hash_type, hash_value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    hash_type, hash_value, object_id
-                )
+                if (attribute := self._handle_hash_attribute(
+                        hash_type, hash_value, object_id)) is not None:
+                    yield attribute
         for field, mapping in self._mapping.artifact_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes(
@@ -1259,9 +1264,10 @@ class InternalSTIX2ObservableConverter(
             self, observable: _FILE_TYPING, object_id: str) -> Iterator[dict]:
         if hasattr(observable, 'hashes'):
             for hash_type, value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    hash_type, value, object_id, mapping='hashlookup'
-                )
+                if (attribute := self._handle_hash_attribute(
+                        hash_type, value, object_id,
+                        mapping='hashlookup')) is not None:
+                    yield attribute
         for field, mapping in self._mapping.hashlookup_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes(
@@ -1328,7 +1334,9 @@ class InternalSTIX2ObservableConverter(
                               object_id: str) -> Iterator[dict]:
         if hasattr(observable, 'hashes'):
             for hash_type, value in observable.hashes.items():
-                yield self._handle_hash_attribute(hash_type, value, object_id)
+                if (attribute := self._handle_hash_attribute(
+                        hash_type, value, object_id)) is not None:
+                    yield attribute
         for field, mapping in self._mapping.lnk_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes(
@@ -1567,9 +1575,10 @@ class InternalSTIX2ObservableConverter(
                                object_id: str) -> Iterator[dict]:
         if hasattr(observable, 'hashes'):
             for hash_type, hash_value in observable.hashes.items():
-                yield self._handle_hash_attribute(
-                    hash_type, hash_value, object_id, 'x509'
-                )
+                if (attribute := self._handle_hash_attribute(
+                        hash_type, hash_value, object_id,
+                        'x509')) is not None:
+                    yield attribute
         for field, mapping in self._mapping.x509_object_mapping().items():
             if hasattr(observable, field):
                 yield from self._handle_object_attributes(

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -3166,6 +3166,50 @@ _FILE_OBSERVABLE_OBJECT = [
         "target_ref": "observed-data--5e384ae7-672c-4250-9cda-3b4da964451a"
     }
 ]
+_FILE_WITH_UNMAPPED_HASH_OBSERVABLE_OBJECT = [
+    {
+        "type": "observed-data",
+        "id": "observed-data--90ffca09-cbe0-4c94-a4e8-1f0a870add6f",
+        "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+        "created": "2020-10-25T16:22:00.000Z",
+        "modified": "2020-10-25T16:22:00.000Z",
+        "first_observed": "2020-10-25T16:22:00Z",
+        "last_observed": "2020-10-25T16:22:00Z",
+        "number_observed": 1,
+        "objects": {
+            "0": {
+                "type": "file",
+                "hashes": {
+                    "MD5": "8764605c6f388c89096b534d33565802",
+                    "CRC32": "deadbeef"
+                },
+                "name": "oui"
+            }
+        },
+        "labels": ['misp:name="file"', 'misp:meta-category="file"']
+    },
+    {
+        "type": "indicator",
+        "id": "indicator--90ffca09-cbe0-4c94-a4e8-1f0a870add6f",
+        "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+        "created": "2020-10-25T16:22:00.000Z",
+        "modified": "2020-10-25T16:22:00.000Z",
+        "valid_from": "2020-10-25T16:22:00Z",
+        "kill_chain_phases": [
+            {"kill_chain_name": "misp-category", "phase_name": "file"}
+        ],
+        "labels": ['misp:name="file"', 'misp:meta-category="file"']
+    },
+    {
+        "type": "relationship",
+        "id": "relationship--41074d15-6a68-4e97-8879-1c8007749913",
+        "created": "2020-10-25T16:22:00.000Z",
+        "modified": "2020-10-25T16:22:00.000Z",
+        "relationship_type": "based-on",
+        "source_ref": "indicator--90ffca09-cbe0-4c94-a4e8-1f0a870add6f",
+        "target_ref": "observed-data--90ffca09-cbe0-4c94-a4e8-1f0a870add6f"
+    }
+]
 _FILENAME_INDICATOR_ATTRIBUTE = {
     "type": "indicator",
     "id": "indicator--91ae0a21-c7ae-4c7f-b84b-b84a7ce53d1f",
@@ -8751,6 +8795,18 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
             "file:content_ref.x_misp_filename = 'oui'",
             "file:content_ref.hashes.MD5 = '8764605c6f388c89096b534d33565802'",
             "file:content_ref.mime_type = 'application/zip')"
+        ]
+        indicator['pattern'] = f"[{' AND '.join(pattern)}]"
+        return cls.__assemble_bundle(observed_data, indicator, relationship)
+
+    @classmethod
+    def get_bundle_with_file_with_unmapped_hash_observable_object(cls):
+        observed_data, indicator, relationship = deepcopy(
+            _FILE_WITH_UNMAPPED_HASH_OBSERVABLE_OBJECT
+        )
+        pattern = [
+            "file:hashes.MD5 = '8764605c6f388c89096b534d33565802'",
+            "file:name = 'oui'"
         ]
         indicator['pattern'] = f"[{' AND '.join(pattern)}]"
         return cls.__assemble_bundle(observed_data, indicator, relationship)

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -3015,6 +3015,37 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
             observed_data=[observed_data, indicator, relationship]
         )
 
+    def test_stix20_bundle_with_file_with_unmapped_hash_observable_object(self):
+        bundle = (
+            TestInternalSTIX20Bundles
+            .get_bundle_with_file_with_unmapped_hash_observable_object()
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, report, observed_data, indicator, relationship = bundle.objects
+        misp_object = self._check_misp_event_features(event, report)[0]
+        observable = self._check_observed_data_object(
+            misp_object, observed_data
+        )['0']
+        attribute_types = {
+            attribute.object_relation: attribute.value
+            for attribute in misp_object.attributes
+        }
+        # Only the mapped MD5 and filename fields become attributes; the
+        # unmapped 'CRC32' hash is skipped instead of yielding `None` into
+        # the attribute stream (which used to raise a TypeError).
+        self.assertEqual(len(misp_object.attributes), 2)
+        self.assertEqual(attribute_types['md5'], observable.hashes['MD5'])
+        self.assertEqual(attribute_types['filename'], observable.name)
+        self.assertIn(self.parser.identifier, self.parser.errors)
+        self.assertTrue(
+            any(
+                'CRC32' in error
+                for error in self.parser.errors[self.parser.identifier]
+            )
+        )
+
     def test_stix20_bundle_with_artifact_payload_indicator_object(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_artifact_payload_indicator_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Unmapped hash algorithms yield `None` into the attribute stream, aborting the whole object conversion.

- **Problem** — `_handle_hash_attribute` in `stix2_observable_converter.py` returns `None` for a hash algorithm with no MISP mapping, but all nine call sites yield that `None` straight into the attribute stream, so `add_attribute(**None)` raises `TypeError`. A File, Artifact or x509 observable carrying an unmapped algorithm such as `CRC32` is enough to trigger it.
- **Fix** — Each yield is guarded with the walrus-bind pattern already used in the file, emitting only non-`None` attributes while `_hash_type_error` still records the mapping gap.
- **Effect** — Objects with mixed mapped and unmapped hashes now import their mapped attributes instead of aborting.
<!-- /bluf -->

## Problem
`_handle_hash_attribute` (used by both the internal and external STIX2 observable converters in `misp_stix_converter/stix2misp/converters/stix2_observable_converter.py`) returns `None` when a hash algorithm has no mapping to a MISP attribute type. All nine call sites yielded that return value straight into the attribute stream instead of filtering it out. When a File (or Artifact/x509) observable carried an unmapped hash type — for example `CRC32` — this led downstream code to call `add_attribute(**None)`, raising `TypeError: argument of type 'NoneType' is not a mapping` and aborting the conversion of the whole object.

## Fix
Each `yield self._handle_hash_attribute(...)` call site is now guarded with the walrus-assignment pattern already used elsewhere in this file: the result is bound to `attribute` and only yielded when it is not `None`. `_handle_hash_attribute` already records the unmapped algorithm through `_hash_type_error`, so the mapping gap stays visible in the parser's errors — the fix only stops the `None` from propagating into `add_attribute`. The mapped hashes (and any other object fields) still convert normally.

## Testing
Ran the project's test gate; result: 2029 passed, 1494 warnings, 52 subtests passed in 75.28s (0:01:15).

Added a regression test, `tests/test_internal_stix20_import.py::TestInternalSTIX20Import.test_stix20_bundle_with_file_with_unmapped_hash_observable_object`, which builds a minimal File observable with one mapped hash (MD5) and one unmapped hash (CRC32). Without the fix this previously raised `TypeError` deep inside object conversion; with the fix the resulting MISP object is built from just the mapped MD5/filename attributes, and the unmapped CRC32 hash is recorded as a parser error instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

