### PR TITLE
[high] fix(stix2misp): guard dangling observable refs in domain/network parsing

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observable_objects_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observable_objects_converter.py
@@ -324,6 +324,11 @@ class STIX2ObservableObjectConverter(
                     )
                     continue
                 resolved_ip = self.main_parser._fetch_observable(reference)
+                if resolved_ip is None:
+                    self._missing_observable_object_error(
+                        domain_name.id, reference
+                    )
+                    continue
                 ip_address = resolved_ip['observable']
                 misp_object.add_attribute(
                     **self._parse_ip_observable(
@@ -335,7 +340,14 @@ class STIX2ObservableObjectConverter(
                 resolved_ip['misp_object'] = misp_object
                 if hasattr(ip_address, 'resolves_to_refs'):
                     for referenced_mac in ip_address.resolves_to_refs:
-                        resolved_mac = self.main_parser._fetch_observable(referenced_mac)
+                        resolved_mac = self.main_parser._fetch_observable(
+                            referenced_mac
+                        )
+                        if resolved_mac is None:
+                            self._missing_observable_object_error(
+                                ip_address.id, referenced_mac
+                            )
+                            continue
                         mac_address = resolved_mac['observable']
                         indicator_ref = resolved_mac.get('indicator_ref')
                         misp_attribute = self.main_parser._add_misp_attribute(
@@ -636,9 +648,13 @@ class STIX2ObservableObjectConverter(
         observable['misp_object'] = misp_object
         for asset, field in self.network_assets.items():
             if hasattr(network_traffic, f'{asset}_ref'):
-                referenced = self.main_parser._fetch_observable(
-                    getattr(network_traffic, f'{asset}_ref')
-                )
+                asset_ref = getattr(network_traffic, f'{asset}_ref')
+                referenced = self.main_parser._fetch_observable(asset_ref)
+                if referenced is None:
+                    self._missing_observable_object_error(
+                        network_traffic.id, asset_ref
+                    )
+                    continue
                 referenced_observable = referenced['observable']
                 attributes = self._parse_network_traffic_reference_observable(
                     asset, referenced_observable,

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -3206,6 +3206,25 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(*_DOMAIN_IP_OBJECTS[-5:-1])
 
     @classmethod
+    def get_bundle_with_domain_ip_dangling_resolution(cls):
+        # A domain-name is referenced by the Grouping on its own - not
+        # wrapped by an Observed Data - so it is converted by
+        # `STIX2ObservableObjectConverter._parse_domain_observable_object`
+        # as unparsed content. It resolves to an ip-addr the bundle never
+        # carries: the reference is dangling and must not raise while it is
+        # dereferenced.
+        domain_name = {
+            "type": "domain-name",
+            "spec_version": "2.1",
+            "id": "domain-name--0e6d0e0e-5f2b-4b3a-9f0b-6a2f2f9b5c1e",
+            "value": "dangling.example.com",
+            "resolves_to_refs": [
+                "ipv4-addr--00000000-0000-4000-8000-000000000000"
+            ]
+        }
+        return cls.__assemble_bundle(domain_name)
+
+    @classmethod
     def get_bundle_with_email_address_attributes(cls):
         return cls.__assemble_bundle(*_EMAIL_ADDRESS_ATTRIBUTES[:-1])
 

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -2523,6 +2523,30 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
             misp_object=domain_ip_object, observed_data=[od2, domain1, ipv4, ipv6]
         )
 
+    def test_stix21_bundle_with_domain_ip_dangling_resolution(self):
+        # A standalone domain-name resolves to an ip-addr the bundle never
+        # carries. `_parse_domain_observable_object` used to dereference
+        # `_fetch_observable(...)['observable']` with no `None` check,
+        # raising a `TypeError` caught only by the generic unparsed-content
+        # handler, which dropped the domain-ip object entirely and reported
+        # a traceback instead of the specific dangling reference.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_ip_dangling_resolution()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        _, grouping, domain_name = bundle.objects
+        misp_objects = self._check_misp_event_features_from_grouping(
+            self.parser.misp_event, grouping
+        )
+        self.assertEqual(len(misp_objects), 1)
+        domain_object = misp_objects[0]
+        self.assertEqual(domain_object.name, 'domain-ip')
+        self.assertEqual(len(domain_object.attributes), 1)
+        self.assertEqual(domain_object.attributes[0].value, domain_name.value)
+        self.assertIn(
+            f'Missing Observable object with id {domain_name.resolves_to_refs[0]}',
+            '\n'.join(self._reported_messages(self.parser.errors))
+        )
+
     def test_stix21_bundle_with_domain_ip_observables(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_domain_ip_observables()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Dangling observable refs in domain and network-traffic parsing discarded the whole observable.

- **Problem** — `STIX2ObservableObjectConverter` dereferences `self.main_parser._fetch_observable(reference)['observable']` at three sites — twice in `_parse_domain_observable_object` and once in `_parse_network_traffic_observable_object` — without the `None` check every sibling resolution site uses. A bundle whose `resolves_to_refs` or `src_ref`/`dst_ref` points at an object it does not carry raises an uncaught `TypeError` and a traceback.
- **Fix** — Adds the missing guard, logging a specific missing-observable error and continuing.
- **Effect** — Bundles with dangling references now convert their remaining content.
<!-- /bluf -->

## Problem

`STIX2ObservableObjectConverter` in `misp_stix_converter/stix2misp/converters/stix2_observable_objects_converter.py` has three sites that dereference `self.main_parser._fetch_observable(reference)['observable']` without checking whether `_fetch_observable` returned `None`:

- line 326, in `_parse_domain_observable_object`, resolving a domain-name's `resolves_to_refs` to an IP address
- the following IP-to-MAC resolution a few lines later, in the same method
- line 652, in `_parse_network_traffic_observable_object`, resolving a network-traffic asset reference (`src_ref`, `dst_ref`, etc.)

Every other reference-resolution site in this file guards with `if observable is None` (or `_has_observable`) before dereferencing, but these three do not. When a STIX 2.1 bundle contains a `domain-name` whose `resolves_to_refs` points to an `ipv4-addr`/`ipv6-addr` that the bundle does not actually carry (or a `network-traffic` object with a dangling `src_ref`/`dst_ref`), the unguarded `['observable']` subscript on `None` raises an uncaught `TypeError`. That exception is only caught by the generic unparsed-content handler further up the call stack, which drops the whole observable object and reports a traceback instead of a clear, specific error — silently losing data that could otherwise still be partially converted.

## Fix

Add the same `None` guard the sibling parsers already use at all three sites: when `_fetch_observable` returns `None`, call `self._missing_observable_object_error(...)` to log a "Missing Observable object" error for the specific dangling reference and `continue` to the next reference, instead of crashing. This matches the existing pattern used elsewhere in the same file (e.g. the process-object parser at lines 721, 732, 741, 750, 759).

With the fix, a domain-name with a dangling `resolves_to_refs` still produces its `domain-ip` MISP object with the domain attribute, and the missing IP reference is reported as a specific, actionable error rather than aborting the whole object.

## Testing

Ran the existing test gate: 2029 passed, 1488 warnings, 52 subtests passed in 89.34s (0:01:29).

Added a regression test, `tests/test_external_stix21_import.py::TestExternalSTIX21Import::test_stix21_bundle_with_domain_ip_dangling_resolution`, using a new bundle fixture `TestExternalSTIX21Bundles.get_bundle_with_domain_ip_dangling_resolution` in `tests/test_external_stix21_bundles.py`. It builds a bundle with a standalone `domain-name` resolving to an `ipv4-addr` the bundle never carries, and asserts the `domain-ip` MISP object is still created with the domain attribute, and that the specific "Missing Observable object" error is reported for the dangling reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
