### PR TITLE
[high] fix(stix1): don't dereference absent TTP infrastructure

### DIFF
--- a/misp_stix_converter/stix2misp/external_stix1_to_misp.py
+++ b/misp_stix_converter/stix2misp/external_stix1_to_misp.py
@@ -126,8 +126,9 @@ class ExternalSTIX1toMISPParser(STIX1toMISPParser, ExternalSTIXtoMISPParser):
 
     def _parse_attributes_from_ttp(self, ttp: TTP, galaxies: set):
         attributes = []
-        if ttp.resources and getattr(ttp.resources, 'infrastructure', None).observable_characterization:
-            observables = ttp.resources.infrastructure.observable_characterization
+        infrastructure = getattr(ttp.resources, 'infrastructure', None) if ttp.resources else None
+        if infrastructure is not None and infrastructure.observable_characterization:
+            observables = infrastructure.observable_characterization
             if observables.observables:
                 for observable in observables.observables:
                     if not self._has_properties(observable):

--- a/tests/test_stix1_import.py
+++ b/tests/test_stix1_import.py
@@ -20,6 +20,7 @@ from stix.common import Statement
 from stix.common.related import RelatedPackage, RelatedPackages
 from stix.core import STIXHeader, STIXPackage
 from stix.data_marking import Marking, MarkingSpecification
+from stix.exploit_target import ExploitTarget, Vulnerability
 from stix.extensions.marking.tlp import TLPMarkingStructure
 from stix.incident import Incident
 from stix.incident.history import History, HistoryItem, JournalEntry
@@ -773,6 +774,25 @@ class TestSTIX1Import(TestSTIX):
         self.assertNotIn(
             f'misp-galaxy:ransomware="{SMUGGLING_TAG_VALUE}"', tags
         )
+
+    def test_external_ttp_resources_with_no_infrastructure_does_not_raise(self):
+        """`resources` is a container that can carry a `tools` list without an
+        `infrastructure`: with only the exploit target left to fall back on,
+        the infrastructure lookup must not dereference the absent value."""
+        ttp = TTP()
+        ttp.id_ = f'MISP:TTP-{_ACTOR_UUID}'
+        # A `resources` container present but with no `infrastructure` set.
+        ttp.resources = Resource()
+        vulnerability = Vulnerability()
+        vulnerability.cve_id = 'CVE-2020-0001'
+        exploit_target = ExploitTarget()
+        exploit_target.add_vulnerability(vulnerability)
+        ttp.add_exploit_target(exploit_target)
+        parser = ExternalSTIX1toMISPParser()
+        attributes = parser._parse_attributes_from_ttp(ttp, set())
+        self.assertEqual(len(attributes), 1)
+        self.assertEqual(attributes[0]['type'], 'vulnerability')
+        self.assertEqual(attributes[0]['value'], 'CVE-2020-0001')
 
     def test_external_tlp_marking_writes_one_taxonomy_entry(self):
         """A TLP colour is written into a taxonomy tag of the library's own: it


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A TTP whose resources carry no infrastructure aborted the entire STIX 1 package import.

- **Problem** — In `external_stix1_to_misp.py`, `_parse_attributes_from_ttp` chains `.observable_characterization` straight onto `getattr(ttp.resources, 'infrastructure', None)`, so any TTP whose resources hold no infrastructure — for example one carrying only tools plus an `exploit_target` — dereferences `None` and raises `AttributeError`.
- **Fix** — Binds the `getattr` result to a local and checks it against `None` before use, matching the bind-then-guard pattern already used for other optional STIX 1 sub-elements.
- **Effect** — Such packages fall through to their exploit-target attributes and import normally.
<!-- /bluf -->

## Problem

In `misp_stix_converter/stix2misp/external_stix1_to_misp.py`, `_parse_attributes_from_ttp` (around line 129) built the infrastructure check as:

\`\`\`python
if ttp.resources and getattr(ttp.resources, 'infrastructure', None).observable_characterization:
\`\`\`

`getattr(ttp.resources, 'infrastructure', None)` falls back to `None` whenever a TTP's `resources` container has no `infrastructure` set — for example a TTP whose `resources` only carries a `tools` list, with the actual content living in an `exploit_target` instead. The code then immediately dereferences `.observable_characterization` on that `None`, raising an `AttributeError` that aborts the whole STIX 1 package import rather than falling through to the exploit-target-derived attributes.

## Fix

Bind the `getattr` result to a local variable and check it for `None` before dereferencing it, instead of chaining the attribute access directly onto the `getattr` call:

\`\`\`python
infrastructure = getattr(ttp.resources, 'infrastructure', None) if ttp.resources else None
if infrastructure is not None and infrastructure.observable_characterization:
    observables = infrastructure.observable_characterization
\`\`\`

This mirrors the same "bind, then guard with `is not None`" pattern already used elsewhere in this parser for optional STIX 1 sub-elements, rather than relying on truthiness chained onto a possibly-`None` `getattr`.

## Testing

Ran the repo's test gate: `2029 passed, 1494 warnings, 52 subtests passed in 92.91s (0:01:32)`.

Added a regression test, `tests/test_stix1_import.py::TestSTIX1Import::test_external_ttp_resources_with_no_infrastructure_does_not_raise`, which calls `_parse_attributes_from_ttp` directly with a TTP whose `resources` has no `infrastructure` set (only an `exploit_target`), and asserts it returns the exploit-target-derived attribute instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
