### PR TITLE
[high] fix(stix2misp): tolerate malformed email Content-Disposition headers

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
@@ -3299,7 +3299,7 @@ class InternalSTIX2ObservedDataConverter(
                 misp_object.add_attribute(**attribute)
             if hasattr(observable, 'body_multipart'):
                 for body_part in observable.body_multipart:
-                    relation, value = body_part.content_disposition.split(';')
+                    relation, _, value = body_part.content_disposition.partition(';')
                     feature = (
                         'email_attachment' if relation == 'attachment'
                         else 'attachment'

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -10800,6 +10800,14 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
         return cls.__assemble_bundle(*_EMAIL_OBSERVABLE_OBJECT)
 
     @classmethod
+    def get_bundle_with_email_observable_object_malformed_content_disposition(cls):
+        stix_objects = deepcopy(_EMAIL_OBSERVABLE_OBJECT)
+        # No `;` separator and no filename param - a bare `Content-Disposition`
+        # value, which is valid per RFC 2183 but previously crashed the parser.
+        stix_objects[1]['body_multipart'][0]['content_disposition'] = 'attachment'
+        return cls.__assemble_bundle(*stix_objects)
+
+    @classmethod
     def get_bundle_with_employee_object(cls):
         return cls.__assemble_bundle(_EMPLOYEE_OBJECT)
 

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -3368,6 +3368,18 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
             misp_object=json.loads(misp_object.to_json()), indicator=indicator
         )
 
+    def test_stix21_bundle_with_email_observable_object_malformed_content_disposition(self):
+        # A `Content-Disposition` value with no `;` separator (e.g. a bare
+        # `attachment` with no filename param) must not crash the parser.
+        bundle = TestInternalSTIX21Bundles.get_bundle_with_email_observable_object_malformed_content_disposition()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        email = self._check_misp_event_features_from_grouping(
+            event, bundle.objects[1]
+        )[0]
+        self.assertEqual(email.name, 'email')
+
     def test_stix21_bundle_with_email_observable_object(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_email_observable_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** A parameterless email `Content-Disposition` aborted conversion of the whole email object.

- **Problem** — `_object_from_email_observable` in `stix2_observed_data_converter.py` unpacks each MIME part's `Content-Disposition` with `split(';')` into two names, so a bare value such as "attachment" or "inline" — valid per RFC 2183 — yields one element and raises `ValueError`.
- **Fix** — Switches to `partition(';')`, which always returns three parts and leaves an empty parameter when no semicolon is present, keeping the existing comparison against `'attachment'` unchanged.
- **Effect** — Emails with parameterless dispositions now convert instead of being lost.
<!-- /bluf -->

## Problem

`InternalSTIX2ObservedDataConverter._object_from_email_observable()` in `misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py` (around line 3302) parses each MIME part's `Content-Disposition` header with:

```python
relation, value = body_part.content_disposition.split(';')
```

This assumes the header always contains a `;`-separated filename parameter (e.g. `attachment; filename="foo.txt"`). A bare disposition value with no parameter at all — e.g. just `"attachment"` or `"inline"`, which is valid per RFC 2183 — makes `str.split(';')` return a single-element list. Unpacking that into two names raises `ValueError: not enough values to unpack`, which aborts conversion of the entire email object (and, depending on context, the whole bundle).

## Fix

Replace `.split(';')` with `.partition(';')`, which always returns a 3-tuple `(relation, sep, value)` regardless of whether a `;` is present — a bare disposition simply yields an empty `value`. This mirrors the same `partition`-over-`split` pattern already used for optional-separator parsing elsewhere in the converters (e.g. `stix2converter.py`'s label parsing), so no downstream logic needed to change: `relation` is still compared against `'attachment'` exactly as before.

## Testing

Ran the project's test gate: `2029 passed, 1494 warnings, 52 subtests passed in 108.98s (0:01:48)`.

Added a regression test, `tests/test_internal_stix21_import.py::TestInternalSTIX21Import::test_stix21_bundle_with_email_observable_object_malformed_content_disposition`, backed by a new fixture `TestInternalSTIX21Bundles.get_bundle_with_email_observable_object_malformed_content_disposition()` in `tests/test_internal_stix21_bundles.py` that sets one `body_multipart` entry's `content_disposition` to a bare `"attachment"` (no `;` or filename parameter) and asserts the email object now parses successfully instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

