### PR TITLE
[high] fix(stix2misp): guard optional external_references on Vulnerability

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_vulnerability_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_vulnerability_converter.py
@@ -121,35 +121,45 @@ class InternalSTIX2VulnerabilityConverter(
     def _parse_vulnerability_object(
             self, vulnerability: _VULNERABILITY_TYPING):
         misp_object = self._create_misp_object('vulnerability', vulnerability)
-        for reference in vulnerability.external_references:
-            if reference['source_name'] in ('cve', 'vulnerability'):
-                external_id = reference['external_id']
-                vuln_mapping = self._mapping.vulnerability_attribute()
-                misp_object.add_attribute(
-                    **vuln_mapping, value=external_id,
-                    uuid=self.main_parser._create_v5_uuid(
-                        f"{vulnerability.id} - {vuln_mapping['object_relation']}"
-                        f" - {external_id}"
-                    )
-                )
-                if external_id != vulnerability.name:
-                    summary_mapping = self._mapping.summary_attribute()
+        for reference in getattr(vulnerability, 'external_references', []):
+            try:
+                if reference.get('source_name') in ('cve', 'vulnerability'):
+                    external_id = reference.get('external_id')
+                    if not external_id:
+                        continue
+                    vuln_mapping = self._mapping.vulnerability_attribute()
                     misp_object.add_attribute(
-                        **summary_mapping, value=vulnerability.name,
+                        **vuln_mapping, value=external_id,
                         uuid=self.main_parser._create_v5_uuid(
-                            f"{vulnerability.id}"
-                            f" - {summary_mapping['object_relation']}"
-                            f" - {vulnerability.name}"
+                            f"{vulnerability.id} - {vuln_mapping['object_relation']}"
+                            f" - {external_id}"
                         )
                     )
-            elif reference['source_name'] == 'url':
-                ref_mapping = self._mapping.references_attribute()
-                misp_object.add_attribute(
-                    **ref_mapping, value=reference['url'],
-                    uuid=self.main_parser._create_v5_uuid(
-                        f"{vulnerability.id} - {ref_mapping['object_relation']}"
-                        f" - {reference['url']}"
+                    if external_id != vulnerability.name:
+                        summary_mapping = self._mapping.summary_attribute()
+                        misp_object.add_attribute(
+                            **summary_mapping, value=vulnerability.name,
+                            uuid=self.main_parser._create_v5_uuid(
+                                f"{vulnerability.id}"
+                                f" - {summary_mapping['object_relation']}"
+                                f" - {vulnerability.name}"
+                            )
+                        )
+                elif reference.get('source_name') == 'url':
+                    ref_mapping = self._mapping.references_attribute()
+                    misp_object.add_attribute(
+                        **ref_mapping, value=reference['url'],
+                        uuid=self.main_parser._create_v5_uuid(
+                            f"{vulnerability.id} - {ref_mapping['object_relation']}"
+                            f" - {reference['url']}"
+                        )
                     )
+            except Exception as exception:
+                _traceback = self.main_parser._parse_traceback(exception)
+                self.main_parser._add_error(
+                    'Error while parsing an external reference of the'
+                    f' Vulnerability object with id {vulnerability.id}:'
+                    f' {_traceback}'
                 )
         for attribute in self._generic_parser(vulnerability):
             misp_object.add_attribute(**attribute)

--- a/tests/test_internal_stix21_bundles.py
+++ b/tests/test_internal_stix21_bundles.py
@@ -9525,6 +9525,20 @@ _VULNERABILITY_OBJECT = {
     "x_misp_cvss_score": "6.8",
     "x_misp_published": "2017-10-13T07:29:00Z"
 }
+_VULNERABILITY_OBJECT_WITHOUT_EXTERNAL_REFERENCES = {
+    "type": "vulnerability",
+    "spec_version": "2.1",
+    "id": "vulnerability--5e579975-e9cc-46c6-a6ad-1611a964451b",
+    "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+    "created": "2020-10-25T16:22:00.000Z",
+    "modified": "2020-10-25T16:22:00.000Z",
+    "name": "CVE-2017-11774",
+    "description": "Microsoft Outlook allow an attacker to execute arbitrary commands",
+    "labels": ['misp:name="vulnerability"', 'misp:meta-category="vulnerability"'],
+    "x_misp_created": "2017-10-13T07:29:00Z",
+    "x_misp_cvss_score": "6.8",
+    "x_misp_published": "2017-10-13T07:29:00Z"
+}
 _X509_FINGERPRINT_INDICATOR_ATTRIBUTES = [
     {
         "type": "indicator",
@@ -11105,6 +11119,12 @@ class TestInternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_vulnerability_object(cls):
         return cls.__assemble_bundle(_VULNERABILITY_OBJECT)
+
+    @classmethod
+    def get_bundle_with_vulnerability_object_without_external_references(cls):
+        return cls.__assemble_bundle(
+            _VULNERABILITY_OBJECT_WITHOUT_EXTERNAL_REFERENCES
+        )
 
     @classmethod
     def get_bundle_with_x509_indicator_object(cls):

--- a/tests/test_internal_stix21_import.py
+++ b/tests/test_internal_stix21_import.py
@@ -4537,6 +4537,26 @@ class TestInternalSTIX21Import(TestInternalSTIX2Import, TestSTIX21, TestSTIX21Im
             vulnerability = vulnerability
         )
 
+    def test_stix21_bundle_with_vulnerability_object_without_external_references(self):
+        bundle = (
+            TestInternalSTIX21Bundles
+            .get_bundle_with_vulnerability_object_without_external_references()
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(self.parser.errors, {})
+        event = self.parser.misp_event
+        _, grouping, vulnerability = bundle.objects
+        misp_object = self._check_misp_event_features_from_grouping(event, grouping)[0]
+        self.assertEqual(misp_object.uuid, vulnerability.id.split('--')[1])
+        self.assertEqual(misp_object.name, vulnerability.type)
+        object_relations = {
+            attribute.object_relation for attribute in misp_object.attributes
+        }
+        self.assertNotIn('id', object_relations)
+        self.assertNotIn('summary', object_relations)
+        self.assertNotIn('references', object_relations)
+
     def test_stix21_bundle_with_x509_indicator_object(self):
         bundle = TestInternalSTIX21Bundles.get_bundle_with_x509_indicator_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** Vulnerability objects with absent or partial `external_references` were discarded whole on import.

- **Problem** — `InternalSTIX2VulnerabilityConverter._parse_vulnerability_object` iterates `vulnerability.external_references` directly and subscripts `reference['external_id']`, but both are optional in STIX 2.1, so a Vulnerability SDO without references raises `AttributeError` and one missing `external_id` raises `KeyError`. Either is swallowed by `parse()`'s catch-all.
- **Fix** — Guards with `getattr`/`.get`, skips references lacking an `external_id`, and wraps each reference in its own `try`/`except` that logs through `_add_error`.
- **Effect** — Vulnerability objects import even when their references are absent or partial.
<!-- /bluf -->

## Problem

`InternalSTIX2VulnerabilityConverter._parse_vulnerability_object` (in `misp_stix_converter/stix2misp/converters/stix2_vulnerability_converter.py`) iterated `vulnerability.external_references` directly, but `external_references` is an optional property in STIX 2.1 — a Vulnerability SDO is not required to carry it. When a bundle contains a Vulnerability object with no `external_references` at all, accessing the missing attribute raises `AttributeError`. The generic `except Exception` in `parse()` catches that and drops the *entire* Vulnerability object instead of just skipping the missing references.

The same block also subscripted `reference['external_id']` instead of using `.get()`, so a `cve`/`vulnerability` reference present without an `external_id` key would raise `KeyError` and likewise abort the whole object rather than just that one reference.

## Fix

Guard the loop with `getattr(vulnerability, 'external_references', [])`, matching the `hasattr`/`getattr` idiom already used by sibling converters and by `_create_cluster` in this same file. Read `source_name`/`external_id` via `.get()` and skip a reference when it has no `external_id`. The per-reference body is now wrapped in its own `try`/`except` so a single malformed reference logs an error via `self.main_parser._add_error(...)` and is skipped, instead of raising out of the loop and dropping the whole Vulnerability object.

## Testing

Ran the test gate: 2029 passed, 1488 warnings, 52 subtests passed in 158.65s (0:02:38).

Added a regression test, `tests/test_internal_stix21_import.py::TestInternalSTIX21Import::test_stix21_bundle_with_vulnerability_object_without_external_references`, backed by a new bundle fixture (`_VULNERABILITY_OBJECT_WITHOUT_EXTERNAL_REFERENCES` / `get_bundle_with_vulnerability_object_without_external_references` in `tests/test_internal_stix21_bundles.py`) that imports a Vulnerability object with no `external_references` at all and asserts the object still converts without error.

Verified fail-without/pass-with: reverted only the source file (`git checkout --`) while keeping the new test, confirming it failed with `AssertionError: self.parser.errors != {}` (the whole object was dropped), then restored the fix from a saved copy and confirmed the test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

