### PR TITLE
[high] fix(stix2misp): guard missing external_id on attack-pattern refs

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_attack_pattern_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_attack_pattern_converter.py
@@ -153,6 +153,8 @@ class InternalSTIX2AttackPatternConverter(InternalSTIX2Converter):
         if hasattr(attack_pattern, 'external_references'):
             for reference in attack_pattern.external_references:
                 attribute = self._parse_attack_pattern_reference(reference)
+                if attribute is None:
+                    continue
                 misp_object.add_attribute(
                     **attribute,
                     uuid=self.main_parser._create_v5_uuid(
@@ -163,13 +165,15 @@ class InternalSTIX2AttackPatternConverter(InternalSTIX2Converter):
         self.main_parser._add_misp_object(misp_object, attack_pattern)
 
     def _parse_attack_pattern_reference(
-            self, reference: _EXTERNAL_REFERENCE_TYPING) -> dict:
+            self, reference: _EXTERNAL_REFERENCE_TYPING) -> Optional[dict]:
         if reference.source_name == 'url':
             return {
                 'value': reference.url,
                 **self._mapping.references_attribute()
             }
-        external_id = reference.external_id
+        external_id = getattr(reference, 'external_id', None)
+        if external_id is None:
+            return None
         return {
             'value': external_id.split('-')[1]
             if external_id.startswith('CAPEC-') else external_id,

--- a/tests/test_internal_stix20_bundles.py
+++ b/tests/test_internal_stix20_bundles.py
@@ -834,6 +834,26 @@ _ATTACK_PATTERN_OBJECT = {
     "x_misp_related_weakness": ["CWE-118", "CWE-120"],
     "x_misp_solutions": "Carefully review the service\\'s implementation before making it available to users."
 }
+_ATTACK_PATTERN_OBJECT_WITH_INCOMPLETE_REFERENCE = {
+    "type": "attack-pattern",
+    "id": "attack-pattern--7205da54-70de-4fa7-9b34-e14e63fe6787",
+    "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+    "created": "2020-10-25T16:22:00.000Z",
+    "modified": "2020-10-25T16:22:00.000Z",
+    "name": "Buffer Overflow in Local Command-Line Utilities",
+    "description": "This attack targets command-line utilities available in a number of shells. An attacker can leverage a vulnerability found in a command-line utility to escalate privilege to root.",
+    "kill_chain_phases": [
+        {"kill_chain_name": "misp-category", "phase_name": "vulnerability"}
+    ],
+    "labels": ['misp:name="attack-pattern"', 'misp:meta-category="vulnerability"'],
+    "external_references": [
+        {"source_name": "capec", "external_id": "CAPEC-9"},
+        {"source_name": "other", "description": "A reference without an external_id or url."}
+    ],
+    "x_misp_prerequisites": "The target hosst exposes a command-line utility to the user. The command-line utility exposed by the target host has a buffer overflow vulnerability that can be exploited.",
+    "x_misp_related_weakness": ["CWE-118", "CWE-120"],
+    "x_misp_solutions": "Carefully review the service\\'s implementation before making it available to users."
+}
 _ATTRIBUTE_WITH_EMBEDDED_GALAXY = [
     _ATTACK_PATTERN_GALAXY,
     {
@@ -8650,6 +8670,10 @@ class TestInternalSTIX20Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_attack_pattern_object(cls):
         return cls.__assemble_bundle(_ATTACK_PATTERN_OBJECT)
+
+    @classmethod
+    def get_bundle_with_attack_pattern_object_with_incomplete_reference(cls):
+        return cls.__assemble_bundle(_ATTACK_PATTERN_OBJECT_WITH_INCOMPLETE_REFERENCE)
 
     @classmethod
     def get_bundle_with_course_of_action_object(cls):

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -2687,6 +2687,19 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
             attack_pattern=attack_pattern
         )
 
+    def test_stix20_bundle_with_attack_pattern_object_with_incomplete_reference(self):
+        bundle = (
+            TestInternalSTIX20Bundles
+            .get_bundle_with_attack_pattern_object_with_incomplete_reference()
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        self.assertEqual(self.parser.errors, {})
+        event = self.parser.misp_event
+        _, report, attack_pattern = bundle.objects
+        misp_object = self._check_misp_event_features(event, report)[0]
+        self._check_attack_pattern_object(misp_object, attack_pattern)
+
     def test_stix20_bundle_with_course_of_action_object(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_course_of_action_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** One description-only external reference made the whole attack-pattern object vanish on import.

- **Problem** — In `stix2_attack_pattern_converter.py`, `_parse_attack_pattern_reference` reads `reference.external_id` unconditionally, but the STIX 2 spec allows an `ExternalReference` to carry only a description, so such a reference raises `AttributeError`; the catch-all handler in `parse()` then drops the entire attack-pattern object rather than the one bad reference.
- **Fix** — Reads the field via `getattr` and returns `None` for references with neither `url` nor `external_id`, and has the caller skip those and keep processing.
- **Effect** — Bundles mixing a valid CAPEC reference with a description-only one now import the attack-pattern intact.
<!-- /bluf -->

## Problem

In `misp_stix_converter/stix2misp/converters/stix2_attack_pattern_converter.py`, `_parse_attack_pattern_reference` (around line 173) accessed `reference.external_id` unconditionally for any external reference whose `source_name` was not `url`. Per the STIX 2 spec, an `ExternalReference` only requires one of `description`, `external_id`, or `url` to be present — so a reference carrying only a `description` (e.g. `{"source_name": "other", "description": "..."}`) has no `external_id` attribute at all, and the access raised an `AttributeError`.

That exception propagated up out of `_parse_attack_pattern_object` and was caught by the catch-all exception handler in `parse()`, which silently dropped the *entire* attack-pattern object instead of just the one malformed reference — so a STIX bundle containing an attack-pattern with one well-formed CAPEC reference and one description-only reference lost the whole object on import.

## Fix

Use `getattr(reference, 'external_id', None)` instead of a direct attribute access, and return `None` from `_parse_attack_pattern_reference` when a reference has neither a `url` nor an `external_id`. The caller (`_parse_attack_pattern_object`) now skips `None` results and continues processing the remaining references, so only the malformed reference is dropped and the rest of the object still imports correctly. This mirrors the existing `hasattr`/optional-attribute guarding pattern already used elsewhere in the same converter for other optional STIX fields.

## Testing

Ran the repo's test gate: `2029 passed, 1494 warnings, 52 subtests passed in 126.60s (0:02:06)`.

Added a regression test, `tests/test_internal_stix20_import.py::TestInternalSTIX20Import::test_stix20_bundle_with_attack_pattern_object_with_incomplete_reference`, which builds a bundle containing an attack-pattern object with both a valid CAPEC external reference and a description-only reference, and asserts the object still parses with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
