### PR TITLE
[high] fix(stix2misp): guard unquoted contact_information in Employee objects

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_identity_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_identity_converter.py
@@ -328,16 +328,28 @@ class InternalSTIX2IdentityConverter(
         for attribute in self._generic_parser(identity, 'employee'):
             misp_object.add_attribute(**attribute)
         if hasattr(identity, 'contact_information'):
-            object_relation, value = identity.contact_information.split(': ')
-            misp_object.add_attribute(
-                **{
-                    'type': 'target-email', 'value': value,
-                    'object_relation': object_relation,
-                    'uuid': self.main_parser._create_v5_uuid(
-                        f'{identity.id} - {object_relation} - {value}'
-                    )
-                }
-            )
+            try:
+                object_relation, value = identity.contact_information.split(
+                    ': ', 1
+                )
+            except ValueError:
+                misp_object.add_attribute(
+                    **{
+                        'type': 'text', 'object_relation':
+                        'contact_information',
+                        'value': identity.contact_information
+                    }
+                )
+            else:
+                misp_object.add_attribute(
+                    **{
+                        'type': 'target-email', 'value': value,
+                        'object_relation': object_relation,
+                        'uuid': self.main_parser._create_v5_uuid(
+                            f'{identity.id} - {object_relation} - {value}'
+                        )
+                    }
+                )
         self.main_parser._add_misp_object(misp_object, identity)
     
     def _parse_identity_object_attributes(

--- a/tests/test_internal_stix20_import.py
+++ b/tests/test_internal_stix20_import.py
@@ -2923,6 +2923,74 @@ class TestInternalSTIX20Import(TestInternalSTIX2Import, TestSTIX20, TestSTIX20Im
             misp_object=json.loads(misp_object.to_json()), identity=identity
         )
 
+    def test_stix20_bundle_with_employee_object_bare_contact_information(self):
+        # A `contact_information` value with no `object_relation: value`
+        # separator used to blow up the unguarded split in
+        # `_parse_employee_object`, discarding the whole Employee object
+        # before `_add_misp_object` ever ran (issue #98). The sibling
+        # `_parse_identity_object_attributes` already tolerates this shape
+        # by falling back to storing the raw string.
+        from misp_stix_converter.tools import load_stix2_content
+        identity_id = 'identity--a0c22599-9e58-4da4-96ac-7051603fa951'
+        employee_id = 'identity--3f5a9e6c-1b2d-4c3e-8f9a-0b1c2d3e4f5a'
+        report_id = 'report--6b1e2f3a-4c5d-4e6f-8a9b-0c1d2e3f4a5b'
+        bundle = load_stix2_content(
+            {
+                'type': 'bundle',
+                'id': 'bundle--f5e2c3d4-1a2b-4c3d-8e9f-0a1b2c3d4e5f',
+                'spec_version': '2.0',
+                'objects': [
+                    {
+                        'type': 'identity', 'id': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'CIRCL', 'identity_class': 'organization'
+                    },
+                    {
+                        'type': 'report', 'id': report_id,
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'MISP-STIX-Converter test event',
+                        'published': '2020-10-25T16:22:00Z',
+                        'labels': [
+                            'Threat-Report',
+                            'misp:tool="MISP-STIX-Converter"'
+                        ],
+                        'object_refs': [employee_id]
+                    },
+                    {
+                        'type': 'identity', 'id': employee_id,
+                        'created_by_ref': identity_id,
+                        'created': '2020-10-25T16:22:00.000Z',
+                        'modified': '2020-10-25T16:22:00.000Z',
+                        'name': 'John Doe', 'identity_class': 'individual',
+                        'contact_information': 'jdoe@example.com',
+                        'x_misp_employee_type': 'Human Resources',
+                        'labels': [
+                            'misp:name="employee"',
+                            'misp:meta-category="misc"'
+                        ]
+                    }
+                ]
+            }
+        )
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        self.assertEqual(self.parser.errors, {})
+        self.assertEqual(len(event.objects), 1)
+        misp_object = event.objects[0]
+        self.assertEqual(misp_object.name, 'employee')
+        full_name, employee_type, contact_information = misp_object.attributes
+        self.assertEqual(full_name.value, 'John Doe')
+        self.assertEqual(employee_type.value, 'Human Resources')
+        self.assertEqual(contact_information.type, 'text')
+        self.assertEqual(
+            contact_information.object_relation, 'contact_information'
+        )
+        self.assertEqual(contact_information.value, 'jdoe@example.com')
+
     def test_stix20_bundle_with_file_and_pe_indicator_object(self):
         bundle = TestInternalSTIX20Bundles.get_bundle_with_file_and_pe_indicator_object()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** An Employee whose `contact_information` is a bare string was dropped from the conversion entirely.

- **Problem** — `InternalSTIX2IdentityConverter._parse_employee_object()` in `stix2_identity_converter.py` splits `identity.contact_information` on `': '` with no guard, unlike the sibling `_parse_identity_object_attributes()` which catches `ValueError`. A bare string such as a plain email address raised before `_add_misp_object()` ran.
- **Fix** — Splits with `maxsplit=1` and falls back to a `text`/`contact_information` attribute.
- **Effect** — Those Employee objects are imported instead of silently disappearing.
<!-- /bluf -->

## Problem

`InternalSTIX2IdentityConverter._parse_employee_object()` in `misp_stix_converter/converters/stix2_identity_converter.py` splits `identity.contact_information` on `': '` with no guard around it. The sibling method `_parse_identity_object_attributes()` (line 357) performs the same split but wraps it in a `try/except ValueError`.

When an Employee identity object's `contact_information` field is a bare string with no `relation: value` prefix (for example a plain email address), the unguarded split raises `ValueError` before `_add_misp_object()` runs, so the whole Employee object is silently discarded from the conversion.

## Fix

Mirror the tolerance already used in `_parse_identity_object_attributes()`: split with `maxsplit=1` and, when no separator is present, fall back to storing the raw string as a `text`/`contact_information` attribute instead of raising.

## Testing

Ran the repo's test gate: `2029 passed, 1494 warnings, 52 subtests passed in 284.25s (0:04:44)`.

Added a regression test, `tests/test_internal_stix20_import.py::TestInternalSTIX20Import::test_stix20_bundle_with_employee_object_bare_contact_information`, which builds a minimal internal STIX 2.0 bundle with an Employee identity carrying a bare `contact_information` string and asserts the Employee object still comes through with the fallback attribute. Confirmed it fails against the pre-fix code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
