### PR TITLE
[high] fix(stix2misp): fix indicator_ref lookup for email-message body

### DIFF
--- a/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
+++ b/misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py
@@ -1210,6 +1210,7 @@ class ExternalSTIX2ObservedDataConverter(
                 )
                 continue
             email_message = observable['observable']
+            email_observable = observable
             misp_object = self._parse_generic_observable_object_ref(
                 email_message, observed_data, 'email', False
             )
@@ -1257,7 +1258,7 @@ class ExternalSTIX2ObservedDataConverter(
                         misp_object.add_attribute(
                             'email-body', multipart.body,
                             **self._observables._handle_object_id(
-                                observable.get(object_ref),
+                                email_observable.get('indicator_ref'),
                                 'email-message', multipart.body,
                                 f'{object_ref} - body_multipart - '
                                 f'{index} - email-body'

--- a/tests/test_external_stix21_bundles.py
+++ b/tests/test_external_stix21_bundles.py
@@ -943,6 +943,20 @@ _EMAIL_MESSAGE_OBJECTS = [
         "valid_from": "2024-10-25T16:22:00Z"
     }
 ]
+_EMAIL_MESSAGE_BODY_INDICATOR = {
+    "type": "indicator",
+    "spec_version": "2.1",
+    "id": "indicator--0d1e2f3a-4b5c-4d6e-8f7a-1b2c3d4e5f60",
+    "created_by_ref": "identity--a0c22599-9e58-4da4-96ac-7051603fa951",
+    "created": "2024-10-25T16:22:00.000Z",
+    "modified": "2024-10-25T16:22:00.000Z",
+    "name": "Suspicious email body pattern",
+    "description": "Email body matching known phishing campaign content.",
+    "pattern": "[email-message:body_multipart[0].body = 'Cats are funny!']",
+    "pattern_type": "stix",
+    "pattern_version": "2.1",
+    "valid_from": "2024-10-25T16:22:00Z"
+}
 _FILE_OBJECTS = [
     {
         "type": "observed-data",
@@ -3409,6 +3423,12 @@ class TestExternalSTIX21Bundles(TestSTIX2Bundles):
     @classmethod
     def get_bundle_with_email_message_observables_and_indicator(cls):
         return cls.__assemble_bundle(*_EMAIL_MESSAGE_OBJECTS[1:])
+
+    @classmethod
+    def get_bundle_with_email_message_objects_and_body_indicator(cls):
+        return cls.__assemble_bundle(
+            *_EMAIL_MESSAGE_OBJECTS[:-1], _EMAIL_MESSAGE_BODY_INDICATOR
+        )
 
     @classmethod
     def get_bundle_with_file_objects_and_indicator(cls):

--- a/tests/test_external_stix21_import.py
+++ b/tests/test_external_stix21_import.py
@@ -4395,6 +4395,26 @@ class TestExternalSTIX21Import(TestExternalSTIX2Import, TestSTIX21, TestSTIX21Im
         self._check_email_artifact_object(artifact_object, observed_data, artifact)
         self._check_email_file_object(file_object, observed_data, _file)
 
+    def test_stix21_bundle_with_email_message_objects_and_body_indicator(self):
+        # Regression test: an indicator whose pattern only matches the
+        # email-message body_multipart value must flag the resulting
+        # `email-body` attribute as `to_ids` with an indicator comment,
+        # instead of always being dropped to `to_ids = False`.
+        bundle = TestExternalSTIX21Bundles.get_bundle_with_email_message_objects_and_body_indicator()
+        self.parser.load_stix_bundle(bundle)
+        self.parser.parse_stix_bundle()
+        event = self.parser.misp_event
+        _, grouping, observed_data, message, *_, indicator = bundle.objects
+        misp_objects = self._check_misp_event_features_from_grouping(event, grouping)
+        email_object = misp_objects[0]
+        self.assertEqual(email_object.name, 'email')
+        body = email_object.attributes[-1]
+        self.assertEqual(body.type, 'email-body')
+        self.assertEqual(body.object_relation, 'email-body')
+        self.assertEqual(body.value, message.body_multipart[0].body)
+        self.assertTrue(body.to_ids)
+        self.assertEqual(body.comment, f'Indicator ID: {indicator.id}')
+
     def test_stix21_bundle_with_email_message_observables_and_indicator(self):
         bundle = TestExternalSTIX21Bundles.get_bundle_with_email_message_observables_and_indicator()
         self.parser.load_stix_bundle(bundle)


### PR DESCRIPTION
<!-- bluf -->
**BLUF —** email-body attributes always imported with `to_ids=False` because of a wrong indicator lookup.

- **Problem** — In `_parse_email_message_observable_object_refs()` in `stix2_observed_data_converter.py`, the email-body attribute looked up its indicator with `observable.get(object_ref)` rather than the `indicator_ref` key its `from_ref`/`to_refs` siblings use, and `observable` had already been reassigned to the last address observable processed.
- **Fix** — Captures the message's own observable as `email_observable` before that reassignment and reads `indicator_ref` from it.
- **Effect** — An email-body matching an Indicator pattern imports with `to_ids=True` and its Indicator ID comment instead of always `to_ids=False`.
<!-- /bluf -->

## Problem

In `_parse_email_message_observable_object_refs()` (`misp_stix_converter/stix2misp/converters/stix2_observed_data_converter.py`, around line 1261), the `email-body` attribute built from an email-message's `body_multipart` value looked up its matching indicator with `observable.get(object_ref)`. `object_ref` is a STIX id string, not the `indicator_ref` key that the bookkeeping dict actually stores under — the sibling `from_ref`/`to_refs`/`cc_refs`/`bcc_refs` lookups a few lines above correctly read `indicator_ref`. This lookup was therefore always `None`, so every `email-body` attribute was emitted with `to_ids=False` and no indicator comment, even when an Indicator's pattern matched the body content.

A second bug compounded it: by the time the `body_multipart` block runs, the local `observable` variable has already been reassigned to the last `from`/`to`/`cc`/`bcc` address observable processed, not the email-message's own observable. So even fixing only the key would still read the wrong object's `indicator_ref` whenever the message has any address references.

Concrete trigger: a STIX 2.1 bundle containing an `email-message` observed-data object plus an `indicator` whose pattern matches only `email-message:body_multipart[0].body` (e.g. `"Cats are funny!"`). Importing it into MISP should mark the resulting `email-body` attribute as `to_ids=True` with an `Indicator ID: ...` comment, but it never did.

## Fix

Capture the email-message's own observable dict as `email_observable` right after it is fetched, before it gets overwritten by address-ref processing, and read `indicator_ref` from that (`email_observable.get('indicator_ref')`) at the `body_multipart` site instead of `observable.get(object_ref)`. This matches how the from/to/cc/bcc lookups a few lines above already read `indicator_ref` from their own observable dicts.

## Testing

Ran the full test gate: `2029 passed, 1494 warnings, 52 subtests passed in 516.26s (0:08:36)`.

Added a regression test, `tests/test_external_stix21_import.py::TestExternalSTIX21Import::test_stix21_bundle_with_email_message_objects_and_body_indicator`, using new fixtures in `tests/test_external_stix21_bundles.py` (`_EMAIL_MESSAGE_BODY_INDICATOR`, `get_bundle_with_email_message_objects_and_body_indicator`) that assert the `email-body` attribute comes back with `to_ids=True` and the expected `Indicator ID: ...` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
